### PR TITLE
fix(store/sql): serialize accumulator read+delete with append (#2)

### DIFF
--- a/internal/store/sql/callback_accumulator.go
+++ b/internal/store/sql/callback_accumulator.go
@@ -56,6 +56,24 @@ func (s *callbackAccumulator) Append(blockHash, callbackURL string, txids []stri
 
 // ReadAndDelete reads every entry for blockHash, deletes them atomically,
 // and groups them by callback URL. Safe to call once per block.
+//
+// Concurrency: under PostgreSQL's default READ COMMITTED isolation a naive
+// SELECT-then-DELETE leaves a window in which a concurrent Append may insert
+// an entries row that gets deleted by our DELETE but was never returned by
+// our SELECT — silently dropping a callback batch (F-046).
+//
+// To close that window we:
+//  1. Acquire a row lock on the parent callback_accumulator row with
+//     SELECT ... FOR UPDATE (Postgres only). Append's
+//     INSERT ... ON CONFLICT (block_hash) DO UPDATE on the same parent row
+//     blocks until our transaction commits, so no Append for this block can
+//     interleave between our read and delete.
+//  2. Use DELETE ... RETURNING on the entries rows so the read and the
+//     delete are a single statement; nothing can be inserted between them.
+//
+// On SQLite the database serializes writers globally (BEGIN IMMEDIATE
+// semantics under WAL with a single connection in tests), so a separate
+// FOR UPDATE is unnecessary; the transaction itself blocks Append.
 func (s *callbackAccumulator) ReadAndDelete(blockHash string) (map[string]*storepkg.AccumulatedCallback, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -66,9 +84,34 @@ func (s *callbackAccumulator) ReadAndDelete(blockHash string) (map[string]*store
 	}
 	defer tx.Rollback()
 
-	qSel := fmt.Sprintf(`SELECT callback_url, subtree_index, txids_json, stump_data
-        FROM callback_accumulator_entries WHERE block_hash = %s`, s.d.placeholder(1))
-	rows, err := tx.QueryContext(ctx, qSel, blockHash)
+	// On Postgres, take a row-level lock on the parent first so any
+	// concurrent Append for this block has to wait for us to commit before
+	// it can upsert the parent row (and therefore before it can insert into
+	// callback_accumulator_entries). If the parent row doesn't exist there
+	// is nothing accumulated and no entries can exist either (Append always
+	// upserts the parent before inserting an entry within the same txn).
+	if isPostgres(s.d) {
+		qLock := fmt.Sprintf("SELECT 1 FROM callback_accumulator WHERE block_hash = %s FOR UPDATE", s.d.placeholder(1))
+		var dummy int
+		err := tx.QueryRowContext(ctx, qLock, blockHash).Scan(&dummy)
+		switch {
+		case err == sql.ErrNoRows:
+			// No accumulator for this block: nothing to read or delete.
+			// Commit the (empty) txn so the deferred Rollback is a no-op.
+			if cerr := tx.Commit(); cerr != nil {
+				return nil, cerr
+			}
+			return nil, nil
+		case err != nil:
+			return nil, fmt.Errorf("lock accumulator: %w", err)
+		}
+	}
+
+	// Single-statement read+delete: DELETE ... RETURNING is supported by
+	// PostgreSQL and SQLite >= 3.35 (modernc.org/sqlite is well past that).
+	qDelEntries := fmt.Sprintf(`DELETE FROM callback_accumulator_entries WHERE block_hash = %s
+        RETURNING callback_url, subtree_index, txids_json, stump_data`, s.d.placeholder(1))
+	rows, err := tx.QueryContext(ctx, qDelEntries, blockHash)
 	if err != nil {
 		return nil, err
 	}
@@ -103,10 +146,6 @@ func (s *callbackAccumulator) ReadAndDelete(blockHash string) (map[string]*store
 	}
 	rows.Close()
 
-	qDelEntries := fmt.Sprintf("DELETE FROM callback_accumulator_entries WHERE block_hash = %s", s.d.placeholder(1))
-	if _, err := tx.ExecContext(ctx, qDelEntries, blockHash); err != nil {
-		return nil, err
-	}
 	qDelParent := fmt.Sprintf("DELETE FROM callback_accumulator WHERE block_hash = %s", s.d.placeholder(1))
 	if _, err := tx.ExecContext(ctx, qDelParent, blockHash); err != nil {
 		return nil, err

--- a/internal/store/sql/callback_accumulator_test.go
+++ b/internal/store/sql/callback_accumulator_test.go
@@ -1,0 +1,205 @@
+package sql
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestCallbackAccumulator_HappyPath asserts the basic Append → ReadAndDelete
+// round trip in isolation (sibling to the existing TestCallbackAccumulator_RoundTrip
+// in sql_test.go but exercising the single-Append path explicitly).
+func TestCallbackAccumulator_HappyPath(t *testing.T) {
+	db, d := newTestDB(t)
+	s := newCallbackAccumulator(db, d, 600)
+
+	if err := s.Append("blk", "u", []string{"tx1"}, 0, []byte{0x01}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	got, err := s.ReadAndDelete("blk")
+	if err != nil {
+		t.Fatalf("ReadAndDelete: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d URLs, want 1", len(got))
+	}
+	acc, ok := got["u"]
+	if !ok || len(acc.Entries) != 1 {
+		t.Fatalf("got %v, want one entry under \"u\"", got)
+	}
+	if acc.Entries[0].SubtreeIndex != 0 || len(acc.Entries[0].TxIDs) != 1 || acc.Entries[0].TxIDs[0] != "tx1" {
+		t.Fatalf("unexpected entry: %+v", acc.Entries[0])
+	}
+
+	// And the parent row is gone — a second read returns nil.
+	got2, err := s.ReadAndDelete("blk")
+	if err != nil {
+		t.Fatalf("ReadAndDelete (second): %v", err)
+	}
+	if got2 != nil {
+		t.Fatalf("second read should be nil, got %v", got2)
+	}
+}
+
+// TestCallbackAccumulator_ReadAndDelete_Empty asserts the early-return branch
+// (no parent row → nil, nil with no error and no orphan entries).
+func TestCallbackAccumulator_ReadAndDelete_Empty(t *testing.T) {
+	db, d := newTestDB(t)
+	s := newCallbackAccumulator(db, d, 600)
+
+	got, err := s.ReadAndDelete("never-seen")
+	if err != nil {
+		t.Fatalf("ReadAndDelete on missing block: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil result, got %v", got)
+	}
+}
+
+// TestCallbackAccumulator_NoLostEntries_F046 is the regression test for F-046:
+// concurrent Appends interleaved with ReadAndDelete must never lose entries.
+//
+// Invariant:
+//
+//	(entries returned by ReadAndDelete) ∪ (entries still in DB after) ==
+//	(all entries successfully Appended)
+//
+// The original bug was that under Postgres READ COMMITTED, an Append committing
+// between a ReadAndDelete's SELECT and its DELETE on callback_accumulator_entries
+// would have its row removed without ever being returned. SQLite serializes
+// writers globally so a single-connection harness like newTestDB cannot itself
+// reproduce the race — running this on Postgres would. The test still encodes
+// the invariant so any future regression that can leak entries (on either
+// backend) is caught, and it exercises the new lock + DELETE...RETURNING fast
+// path under -race.
+func TestCallbackAccumulator_NoLostEntries_F046(t *testing.T) {
+	db, d := newTestDB(t)
+	s := newCallbackAccumulator(db, d, 600)
+
+	const blockHash = "blk-race"
+
+	// Seed one entry so the ReadAndDelete has something to consume.
+	if err := s.Append(blockHash, "uA", []string{"tx1"}, 0, []byte{0xAA}); err != nil {
+		t.Fatalf("seed Append: %v", err)
+	}
+
+	// Track every entry we successfully append so we can compare against
+	// what ReadAndDelete returns plus what's left in the DB afterwards.
+	type want struct {
+		url      string
+		subtree  int
+		firstTxn string
+	}
+	var (
+		mu       sync.Mutex
+		appended = []want{{url: "uA", subtree: 0, firstTxn: "tx1"}}
+	)
+
+	// Spawn N concurrent Appends and one ReadAndDelete. Every Append that
+	// returns nil is a commit we must not lose.
+	const concurrentAppends = 8
+	var wg sync.WaitGroup
+
+	var rdResult map[string]*struct{} // unused; we use the real result below
+	_ = rdResult
+	var rdEntries map[string][]int // url -> subtree indices returned
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		got, err := s.ReadAndDelete(blockHash)
+		if err != nil {
+			t.Errorf("ReadAndDelete: %v", err)
+			return
+		}
+		// Capture for assertions below; map access is safe — wg.Wait fences it.
+		rdEntries = make(map[string][]int, len(got))
+		for url, acc := range got {
+			for _, e := range acc.Entries {
+				rdEntries[url] = append(rdEntries[url], e.SubtreeIndex)
+			}
+		}
+	}()
+
+	for i := 0; i < concurrentAppends; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			url := "uB"
+			tx := "txB" + itoa(i)
+			subtree := i + 1
+			if err := s.Append(blockHash, url, []string{tx}, subtree, []byte{byte(i)}); err != nil {
+				t.Errorf("concurrent Append %d: %v", i, err)
+				return
+			}
+			mu.Lock()
+			appended = append(appended, want{url: url, subtree: subtree, firstTxn: tx})
+			mu.Unlock()
+		}(i)
+	}
+
+	wg.Wait()
+
+	// What remains in the DB after the (single) ReadAndDelete?
+	leftover, err := s.ReadAndDelete(blockHash)
+	if err != nil {
+		t.Fatalf("post ReadAndDelete: %v", err)
+	}
+
+	// Build the union of (returned by first ReadAndDelete) ∪ (remaining in DB).
+	type seenKey struct {
+		url     string
+		subtree int
+	}
+	seen := map[seenKey]int{}
+	for url, indices := range rdEntries {
+		for _, st := range indices {
+			seen[seenKey{url, st}]++
+		}
+	}
+	for url, acc := range leftover {
+		for _, e := range acc.Entries {
+			seen[seenKey{url, e.SubtreeIndex}]++
+		}
+	}
+
+	// Every successfully appended entry must appear exactly once in the union.
+	if len(seen) != len(appended) {
+		t.Fatalf("union has %d entries, appended %d (lost or duplicated): seen=%v appended=%v",
+			len(seen), len(appended), seen, appended)
+	}
+	for _, w := range appended {
+		k := seenKey{w.url, w.subtree}
+		c, ok := seen[k]
+		if !ok {
+			t.Errorf("entry %+v was silently dropped (not returned and not in DB)", w)
+			continue
+		}
+		if c != 1 {
+			t.Errorf("entry %+v appeared %d times (want 1)", w, c)
+		}
+	}
+}
+
+// itoa is a tiny no-import int-to-string used by the race regression test.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}


### PR DESCRIPTION
## Summary
- Adds a parent-row `FOR UPDATE` lock (Postgres) and switches `ReadAndDelete` to a single `DELETE ... RETURNING` statement so a concurrent `Append` cannot insert into `callback_accumulator_entries` between the read and the delete in `ReadAndDelete` and be silently consumed (F-046).
- Append's `INSERT ... ON CONFLICT (block_hash) DO UPDATE` on the parent row blocks behind our lock until our transaction commits, closing the gap that existed under PostgreSQL's default READ COMMITTED isolation.
- On SQLite the writer-serialization at the database level makes the explicit `FOR UPDATE` redundant, so we skip it; the rest of the path is identical.
- Adds a regression test (`TestCallbackAccumulator_NoLostEntries_F046`) that runs concurrent Appends against a ReadAndDelete and asserts the union of (returned entries) ∪ (entries left in DB) equals the set of successfully appended entries — i.e. no entry can be silently dropped. Also adds a happy-path test and an empty-block early-return test for the new no-parent-row branch.

`DELETE ... RETURNING` is supported by both Postgres and `modernc.org/sqlite v1.49.1` (SQLite >= 3.35), so a single form works on both backends.

Note on the regression test: SQLite serializes writers globally, so the in-memory test harness cannot itself reproduce the original race — the test still encodes the post-fix invariant and exercises the new code path under `-race`. A Postgres testcontainer would be the place to demonstrate the original race; that infrastructure isn't currently present in this package.

Only `internal/store/sql/callback_accumulator.go` and its test file are touched. The Aerospike sibling (PR #74) is left alone.

Closes #2

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/store/sql/... -race`
- [ ] Reviewer sanity check on the SQL semantics on Postgres vs SQLite