### PR TITLE
fix(block): only mark block processed after work is durably published (#3)

### DIFF
--- a/internal/block/handle_message_test.go
+++ b/internal/block/handle_message_test.go
@@ -1,0 +1,367 @@
+package block
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/IBM/sarama"
+
+	"github.com/bsv-blockchain/merkle-service/internal/cache"
+	"github.com/bsv-blockchain/merkle-service/internal/datahub"
+	"github.com/bsv-blockchain/merkle-service/internal/kafka"
+	"github.com/bsv-blockchain/merkle-service/internal/store"
+)
+
+// failingSyncProducer is a sarama.SyncProducer that fails on the Nth (0-indexed)
+// SendMessage call. All earlier and later calls succeed (later calls aren't
+// expected — the processor must stop on first failure).
+type failingSyncProducer struct {
+	mu       sync.Mutex
+	messages []*sarama.ProducerMessage
+	failAt   int       // 0-indexed call to fail on; -1 means never fail
+	failErr  error
+	calls    int
+}
+
+func (f *failingSyncProducer) SendMessage(msg *sarama.ProducerMessage) (int32, int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	idx := f.calls
+	f.calls++
+	if f.failAt >= 0 && idx == f.failAt {
+		return 0, 0, f.failErr
+	}
+	f.messages = append(f.messages, msg)
+	return 0, int64(len(f.messages)), nil
+}
+
+func (f *failingSyncProducer) SendMessages(msgs []*sarama.ProducerMessage) error {
+	for _, m := range msgs {
+		if _, _, err := f.SendMessage(m); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *failingSyncProducer) Close() error          { return nil }
+func (f *failingSyncProducer) IsTransactional() bool { return false }
+func (f *failingSyncProducer) TxnStatus() sarama.ProducerTxnStatusFlag {
+	return sarama.ProducerTxnFlagReady
+}
+func (f *failingSyncProducer) BeginTxn() error  { return nil }
+func (f *failingSyncProducer) CommitTxn() error { return nil }
+func (f *failingSyncProducer) AbortTxn() error  { return nil }
+func (f *failingSyncProducer) AddOffsetsToTxn(map[string][]*sarama.PartitionOffsetMetadata, string) error {
+	return nil
+}
+func (f *failingSyncProducer) AddMessageToTxn(*sarama.ConsumerMessage, string, *string) error {
+	return nil
+}
+
+// fakeSubtreeCounter is an in-memory SubtreeCounterStore for tests. It records
+// every call so tests can assert the order/count of Init invocations relative
+// to publishing.
+type fakeSubtreeCounter struct {
+	mu        sync.Mutex
+	values    map[string]int
+	initCalls int
+	failNext  bool
+}
+
+func newFakeSubtreeCounter() *fakeSubtreeCounter {
+	return &fakeSubtreeCounter{values: map[string]int{}}
+}
+
+func (f *fakeSubtreeCounter) Init(blockHash string, count int) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.initCalls++
+	if f.failNext {
+		f.failNext = false
+		return errors.New("simulated counter init failure")
+	}
+	f.values[blockHash] = count
+	return nil
+}
+
+func (f *fakeSubtreeCounter) Decrement(blockHash string) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.values[blockHash]--
+	return f.values[blockHash], nil
+}
+
+func (f *fakeSubtreeCounter) get(blockHash string) (int, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	v, ok := f.values[blockHash]
+	return v, ok
+}
+
+func (f *fakeSubtreeCounter) inits() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.initCalls
+}
+
+// newBlockMessageBytes encodes a BlockMessage for use as a sarama message value.
+func newBlockMessageBytes(t *testing.T, hash, dataHubURL string) []byte {
+	t.Helper()
+	bm := &kafka.BlockMessage{
+		Hash:       hash,
+		Height:     200,
+		DataHubURL: dataHubURL,
+	}
+	data, err := bm.Encode()
+	if err != nil {
+		t.Fatalf("encode block message: %v", err)
+	}
+	return data
+}
+
+// newDataHubServerWithSubtrees serves a binary block payload at /block/{hash}
+// containing exactly the requested number of subtree slots.
+func newDataHubServerWithSubtrees(t *testing.T, height uint32, subtreeCount int) *httptest.Server {
+	t.Helper()
+	payload := buildBlockPayload(height, subtreeCount)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/block/") && !strings.HasSuffix(r.URL.Path, "/json") {
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(payload)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+}
+
+// buildProcessorWithProducer constructs a Processor wired up with the supplied
+// sync producer and an in-memory dedup cache + counter for assertions.
+func buildProcessorWithProducer(t *testing.T, sp sarama.SyncProducer) (*Processor, *fakeSubtreeCounter, *cache.DedupCache) {
+	t.Helper()
+	logger := testLogger()
+	dedup := cache.NewDedupCache(64)
+	counter := newFakeSubtreeCounter()
+	blobStore := store.NewMemoryBlobStore()
+	subtreeStore := store.NewSubtreeStore(blobStore, 1, logger)
+
+	p := &Processor{
+		subtreeWorkProducer: kafka.NewTestProducer(sp, "subtree-work-test", logger),
+		subtreeStore:        subtreeStore,
+		subtreeCounter:      counter,
+		dedupCache:          dedup,
+		dataHubClient:       datahub.NewClient(5, 0, logger),
+	}
+	p.InitBase("block-processor-test")
+	p.Logger = logger
+	return p, counter, dedup
+}
+
+// TestHandleMessage_HappyPath_AllPublished verifies the full success path:
+// every subtree work message is published, the counter is initialised, and
+// the block is added to the dedup cache.
+func TestHandleMessage_HappyPath_AllPublished(t *testing.T) {
+	mockProducer := &failingSyncProducer{failAt: -1}
+	p, counter, dedup := buildProcessorWithProducer(t, mockProducer)
+
+	server := newDataHubServerWithSubtrees(t, 200, 3)
+	defer server.Close()
+
+	const blockHash = "block-happy"
+	msg := &sarama.ConsumerMessage{
+		Value: newBlockMessageBytes(t, blockHash, server.URL),
+	}
+
+	if err := p.handleMessage(context.Background(), msg); err != nil {
+		t.Fatalf("expected nil error on happy path, got: %v", err)
+	}
+
+	if got := len(mockProducer.messages); got != 3 {
+		t.Errorf("expected 3 published messages, got %d", got)
+	}
+	if v, ok := counter.get(blockHash); !ok || v != 3 {
+		t.Errorf("expected counter to be initialised to 3, got value=%d ok=%v", v, ok)
+	}
+	if !dedup.Contains(blockHash) {
+		t.Errorf("expected block hash to be added to dedup cache after success")
+	}
+}
+
+// TestHandleMessage_PublishFailureMidLoop_StopsAndReturnsError verifies that
+// when a publish fails partway through the fan-out:
+//   - handleMessage returns a non-nil error,
+//   - the block is NOT added to the dedup cache (so it can be retried),
+//   - publishing stops at the failing message (later messages are NOT sent).
+func TestHandleMessage_PublishFailureMidLoop_StopsAndReturnsError(t *testing.T) {
+	// Fail on the 2nd publish (index 1), so we expect exactly 1 successful
+	// send before the failure aborts the loop.
+	mockProducer := &failingSyncProducer{
+		failAt:  1,
+		failErr: errors.New("kafka unavailable"),
+	}
+	p, counter, dedup := buildProcessorWithProducer(t, mockProducer)
+
+	server := newDataHubServerWithSubtrees(t, 200, 4)
+	defer server.Close()
+
+	const blockHash = "block-publish-fail"
+	msg := &sarama.ConsumerMessage{
+		Value: newBlockMessageBytes(t, blockHash, server.URL),
+	}
+
+	err := p.handleMessage(context.Background(), msg)
+	if err == nil {
+		t.Fatalf("expected non-nil error when publish fails mid-loop")
+	}
+	if !strings.Contains(err.Error(), "publishing subtree work") {
+		t.Errorf("expected wrapped publish error, got: %v", err)
+	}
+
+	if got := len(mockProducer.messages); got != 1 {
+		t.Errorf("expected exactly 1 successful send before failure, got %d", got)
+	}
+	if mockProducer.calls != 2 {
+		t.Errorf("expected loop to stop after first failure (2 calls total), got %d", mockProducer.calls)
+	}
+	if dedup.Contains(blockHash) {
+		t.Errorf("block must NOT be in dedup cache when publish fails")
+	}
+	// Counter should have been initialised (so workers for the published
+	// message can decrement); on retry, Init is upsert and overwrites cleanly.
+	if v, ok := counter.get(blockHash); !ok || v != 4 {
+		t.Errorf("expected counter initialised to 4, got value=%d ok=%v", v, ok)
+	}
+}
+
+// TestHandleMessage_PublishFailureFirstMessage_NoMessagesLeak verifies that a
+// failure on the very first publish leaves no messages dispatched and the
+// block uncommitted to dedup.
+func TestHandleMessage_PublishFailureFirstMessage_NoMessagesLeak(t *testing.T) {
+	mockProducer := &failingSyncProducer{
+		failAt:  0,
+		failErr: errors.New("kafka unavailable"),
+	}
+	p, _, dedup := buildProcessorWithProducer(t, mockProducer)
+
+	server := newDataHubServerWithSubtrees(t, 200, 3)
+	defer server.Close()
+
+	const blockHash = "block-publish-fail-first"
+	msg := &sarama.ConsumerMessage{
+		Value: newBlockMessageBytes(t, blockHash, server.URL),
+	}
+
+	if err := p.handleMessage(context.Background(), msg); err == nil {
+		t.Fatalf("expected non-nil error when first publish fails")
+	}
+	if got := len(mockProducer.messages); got != 0 {
+		t.Errorf("expected zero successful sends, got %d", got)
+	}
+	if dedup.Contains(blockHash) {
+		t.Errorf("block must NOT be in dedup cache when fan-out fails")
+	}
+}
+
+// TestHandleMessage_RetryAfterPublishFailure_Republishes verifies that after a
+// publish failure, redelivering the same block message republishes the work
+// and (on success) marks the block in dedup. The counter is re-initialised
+// idempotently via the upsert semantics promised by the SubtreeCounterStore.
+func TestHandleMessage_RetryAfterPublishFailure_Republishes(t *testing.T) {
+	mockProducer := &failingSyncProducer{
+		failAt:  1,
+		failErr: errors.New("kafka unavailable"),
+	}
+	p, counter, dedup := buildProcessorWithProducer(t, mockProducer)
+
+	server := newDataHubServerWithSubtrees(t, 200, 3)
+	defer server.Close()
+
+	const blockHash = "block-retry"
+	msg := &sarama.ConsumerMessage{
+		Value: newBlockMessageBytes(t, blockHash, server.URL),
+	}
+
+	if err := p.handleMessage(context.Background(), msg); err == nil {
+		t.Fatalf("expected first attempt to fail")
+	}
+	if dedup.Contains(blockHash) {
+		t.Fatalf("block must not be in dedup after failed attempt")
+	}
+	firstInits := counter.inits()
+
+	// Producer is healthy on retry.
+	mockProducer.failAt = -1
+
+	if err := p.handleMessage(context.Background(), msg); err != nil {
+		t.Fatalf("expected retry to succeed, got: %v", err)
+	}
+	if !dedup.Contains(blockHash) {
+		t.Errorf("expected block in dedup after successful retry")
+	}
+	if counter.inits() <= firstInits {
+		t.Errorf("expected counter to be re-initialised on retry")
+	}
+	// Total successful sends across both attempts: 1 (before failure) + 3 (retry).
+	if mockProducer.calls < 5 || len(mockProducer.messages) != 4 {
+		t.Errorf("unexpected producer state: calls=%d successful=%d",
+			mockProducer.calls, len(mockProducer.messages))
+	}
+}
+
+// TestHandleMessage_CounterInitFailure_NoPublishNoDedup verifies that if the
+// subtree counter cannot be initialised, no messages are published and the
+// block is not marked in the dedup cache (so the block is retried).
+func TestHandleMessage_CounterInitFailure_NoPublishNoDedup(t *testing.T) {
+	mockProducer := &failingSyncProducer{failAt: -1}
+	p, counter, dedup := buildProcessorWithProducer(t, mockProducer)
+	counter.failNext = true
+
+	server := newDataHubServerWithSubtrees(t, 200, 2)
+	defer server.Close()
+
+	const blockHash = "block-counter-fail"
+	msg := &sarama.ConsumerMessage{
+		Value: newBlockMessageBytes(t, blockHash, server.URL),
+	}
+
+	err := p.handleMessage(context.Background(), msg)
+	if err == nil {
+		t.Fatalf("expected non-nil error when counter init fails")
+	}
+	if len(mockProducer.messages) != 0 {
+		t.Errorf("expected no publishes when counter init fails, got %d", len(mockProducer.messages))
+	}
+	if dedup.Contains(blockHash) {
+		t.Errorf("block must not be in dedup when counter init fails")
+	}
+}
+
+// TestHandleMessage_NoSubtrees_DedupAdded verifies that a block with zero
+// subtrees is still recorded in dedup so a redelivery is fast-skipped.
+func TestHandleMessage_NoSubtrees_DedupAdded(t *testing.T) {
+	mockProducer := &failingSyncProducer{failAt: -1}
+	p, _, dedup := buildProcessorWithProducer(t, mockProducer)
+
+	server := newDataHubServerWithSubtrees(t, 200, 0)
+	defer server.Close()
+
+	const blockHash = "block-empty"
+	msg := &sarama.ConsumerMessage{
+		Value: newBlockMessageBytes(t, blockHash, server.URL),
+	}
+
+	if err := p.handleMessage(context.Background(), msg); err != nil {
+		t.Fatalf("expected nil error for empty block, got: %v", err)
+	}
+	if !dedup.Contains(blockHash) {
+		t.Errorf("expected empty block to still be added to dedup cache")
+	}
+	if len(mockProducer.messages) != 0 {
+		t.Errorf("expected no publishes for empty block, got %d", len(mockProducer.messages))
+	}
+}

--- a/internal/block/processor.go
+++ b/internal/block/processor.go
@@ -121,6 +121,14 @@ func (p *Processor) Health() service.HealthStatus {
 	}
 }
 
+// handleMessage processes a single block announcement.
+//
+// Correctness contract: the block is added to the dedup cache (and the Kafka
+// message is ack'd by returning nil) ONLY after every subtree work message
+// for the block has been durably published to the subtree-work topic. Any
+// encode or publish failure returns a non-nil error so the consumer does not
+// mark the offset, which surfaces the failure for retry on the next session
+// and prevents silent data loss (F-011).
 func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessage) error {
 	blockMsg, err := kafka.DecodeBlockMessage(msg.Value)
 	if err != nil {
@@ -156,23 +164,26 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 	)
 
 	if len(subtreeHashes) == 0 {
+		// No subtree work to fan out, but the block has been observed and
+		// metadata fetched — record it in dedup so a redelivery is skipped.
+		if p.dedupCache != nil {
+			p.dedupCache.Add(blockMsg.Hash)
+		}
 		return nil
 	}
 
-	// Initialize the subtree counter BEFORE publishing work messages to avoid
-	// a race where workers decrement a counter that doesn't exist yet.
-	if p.subtreeCounter != nil {
-		if err := p.subtreeCounter.Init(blockMsg.Hash, len(subtreeHashes)); err != nil {
-			p.Logger.Error("failed to init subtree counter",
-				"blockHash", blockMsg.Hash,
-				"count", len(subtreeHashes),
-				"error", err,
-			)
-			return fmt.Errorf("failed to init subtree counter for block %s: %w", blockMsg.Hash, err)
-		}
+	// Pre-encode every SubtreeWorkMessage before initializing the counter or
+	// publishing anything. Encoding is deterministic; failing now means the
+	// payload is malformed and would fail again on retry, but we must not have
+	// already initialised the counter (which would leave it pointing at work
+	// that will never arrive). Returning an error keeps the offset un-acked so
+	// Kafka redelivers; persistent failure should be caught by an upstream DLQ
+	// policy on the block topic.
+	type encodedWork struct {
+		subtreeHash string
+		payload     []byte
 	}
-
-	// Publish one SubtreeWorkMessage per subtree to the subtree-work topic.
+	encoded := make([]encodedWork, 0, len(subtreeHashes))
 	for i, stHash := range subtreeHashes {
 		workMsg := &kafka.SubtreeWorkMessage{
 			BlockHash:    blockMsg.Hash,
@@ -181,33 +192,69 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 			SubtreeIndex: i,
 			DataHubURL:   blockMsg.DataHubURL,
 		}
-		data, err := workMsg.Encode()
-		if err != nil {
+		data, encErr := workMsg.Encode()
+		if encErr != nil {
 			p.Logger.Error("failed to encode subtree work message",
 				"subtreeHash", stHash,
 				"blockHash", blockMsg.Hash,
-				"error", err,
+				"subtreeIndex", i,
+				"error", encErr,
 			)
-			continue
+			return fmt.Errorf("encoding subtree work message for block %s subtree %s: %w", blockMsg.Hash, stHash, encErr)
 		}
-		if err := p.subtreeWorkProducer.PublishWithHashKey(stHash, data); err != nil {
-			p.Logger.Error("failed to publish subtree work message",
-				"subtreeHash", stHash,
+		encoded = append(encoded, encodedWork{subtreeHash: stHash, payload: data})
+	}
+
+	// Initialize the subtree counter BEFORE publishing work messages so that
+	// workers cannot decrement a missing counter. The Aerospike-backed Init
+	// uses RecordExistsAction=UPDATE (upsert), so on a redelivery this safely
+	// overwrites any stale value left by a previous partial-publish attempt.
+	if p.subtreeCounter != nil {
+		if err := p.subtreeCounter.Init(blockMsg.Hash, len(encoded)); err != nil {
+			p.Logger.Error("failed to init subtree counter",
 				"blockHash", blockMsg.Hash,
+				"count", len(encoded),
 				"error", err,
 			)
+			return fmt.Errorf("failed to init subtree counter for block %s: %w", blockMsg.Hash, err)
+		}
+	}
+
+	// Publish each pre-encoded SubtreeWorkMessage. On the first publish
+	// failure we stop and return an error so the block message is NOT ack'd
+	// and NOT added to the dedup cache. On redelivery the counter is
+	// re-initialised (overwriting whatever the previous attempt left); some
+	// subtree work may be re-published, but the SubtreeWorkMessage retry
+	// pipeline (AttemptCount + subtree-work-dlq) is already idempotent, so
+	// duplicate fan-out is safe.
+	for i, ew := range encoded {
+		if err := p.subtreeWorkProducer.PublishWithHashKey(ew.subtreeHash, ew.payload); err != nil {
+			p.Logger.Error("failed to publish subtree work message",
+				"subtreeHash", ew.subtreeHash,
+				"blockHash", blockMsg.Hash,
+				"subtreeIndex", i,
+				"published", i,
+				"total", len(encoded),
+				"error", err,
+			)
+			return fmt.Errorf("publishing subtree work for block %s subtree %s (%d/%d): %w",
+				blockMsg.Hash, ew.subtreeHash, i, len(encoded), err)
 		}
 	}
 
 	p.Logger.Info("dispatched subtree work items",
 		"blockHash", blockMsg.Hash,
-		"subtreeCount", len(subtreeHashes),
+		"subtreeCount", len(encoded),
 	)
 
-	// Update subtree store block height for DAH pruning.
+	// Update subtree store block height for DAH pruning. Only safe to do once
+	// every subtree work message for this block has been successfully
+	// published — otherwise an unpublished subtree could be pruned.
 	p.subtreeStore.SetCurrentBlockHeight(uint64(meta.Height))
 
-	// Mark block as successfully processed for dedup.
+	// Mark block as successfully processed for dedup. This must be the last
+	// step: anything that returned an error above leaves the cache untouched
+	// so the block is retried on redelivery.
 	if p.dedupCache != nil {
 		p.dedupCache.Add(blockMsg.Hash)
 	}


### PR DESCRIPTION
## Summary
- `handleMessage` now returns an error whenever any subtree work message fails to encode or publish, so the consumer leaves the offset un-acked and Kafka redelivers the block instead of silently dropping the un-fanned-out subtree work.
- Pre-encodes every `SubtreeWorkMessage` before initialising the counter, so an encode failure (which would also fail on retry) cannot leave the counter pointing at work that will never arrive.
- Moves the `dedupCache.Add` and the `subtreeStore.SetCurrentBlockHeight` calls to after the fan-out succeeds — the block is now committed to dedup only when every work message is durably published.
- Stops the publish loop on the first error rather than continuing against a likely-broken producer.

### Counter cleanup on partial-publish failure
On a publish failure mid-loop, the subtree counter has already been initialised. We deliberately do **not** delete it. Rationale:
- `SubtreeCounterStore` has no `Delete`/`Reset` method, and the Aerospike implementation uses `RecordExistsAction = UPDATE` (upsert), so on redelivery the next `Init(blockHash, len(subtreeHashes))` cleanly **overwrites** any stale value left by the previous attempt.
- Workers from the messages that did get published in the failed attempt are idempotent on retry (the existing `AttemptCount` + `subtree-work-dlq` pipeline handles duplicate work safely), so the counter eventually reaches zero through normal retry semantics.
- If neither retry occurs, the counter expires via TTL (`ttlSec` on Aerospike) — same fallback as today.

### Tests (`internal/block/handle_message_test.go`)
- Happy path: every work message published, counter set, block in dedup.
- Publish fails on the 2nd of 4 messages: returns error, exactly one send happens, loop stops, block NOT in dedup.
- Publish fails on the very first message: returns error, zero sends, block NOT in dedup.
- Retry after publish failure: a redelivered block re-publishes successfully, dedup is updated, counter `Init` runs again (idempotent overwrite).
- Counter `Init` failure: returns error, no publishes, block NOT in dedup.
- Empty block (no subtrees): still added to dedup so redelivery is fast-skipped.

Closes #3

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/block/... -count=1 -race`
- [ ] Reviewer sanity check on the counter cleanup behaviour (TTL + upsert on retry rather than explicit delete).

## Follow-up findings (not fixed here)
- `internal/kafka/consumer.go` `ConsumeClaim` does NOT re-deliver a message when the handler returns an error — it logs and falls through to the next message in the claim. Re-delivery only happens on consumer-group rebalance or process restart. The fix here is still correct (no false-success ack), but follow-up work should make the consumer either retry inline or seek the offset back so transient handler failures retry promptly. Worth filing as a separate issue.
- The `Producer.PublishWithHashKey` path does surface broker errors via `SyncProducer.SendMessage`, so this fix relies on that contract holding (`Producer.Retry.Max = 3` is set, but Sarama returns the error after the configured retries are exhausted — good).