### PR TITLE
fix(block): retry subtree work when STUMP callback publish fails (#4)

### DIFF
--- a/internal/block/subtree_worker.go
+++ b/internal/block/subtree_worker.go
@@ -206,6 +206,17 @@ func (s *SubtreeWorkerService) maxAttempts() int {
 	return 10
 }
 
+// handleMessage consumes a single SubtreeWorkMessage.
+//
+// Correctness contract: the work item is ack'd (return nil) and the per-block
+// subtree counter is decremented ONLY after either (a) processing succeeded
+// with no callbacks to publish, or (b) every STUMP callback has been durably
+// stored and published to Kafka. A failure during processing OR during
+// callback publishing routes the work back through handleTransientFailure,
+// which re-publishes for retry (preserving the counter) or routes to DLQ at
+// max attempts (decrementing the counter so BLOCK_PROCESSED can still fire).
+// This prevents the silent drop where a Kafka/blob-store hiccup left the
+// downstream consumer waiting for STUMPs that never arrive (F-012).
 func (s *SubtreeWorkerService) handleMessage(ctx context.Context, msg *sarama.ConsumerMessage) error {
 	workMsg, err := kafka.DecodeSubtreeWorkMessage(msg.Value)
 	if err != nil {
@@ -248,8 +259,15 @@ func (s *SubtreeWorkerService) handleMessage(ctx context.Context, msg *sarama.Co
 	}
 
 	// Publish one STUMP callback per (callbackURL, subtree) combination.
+	// A failure here (blob-store write, encode, or Kafka publish) must NOT be
+	// silently swallowed: route through the same retry/DLQ pipeline as a
+	// processing failure so the work item is either retried or terminally
+	// DLQ'd. Otherwise downstream consumers stall waiting for STUMPs that
+	// were dropped on the floor.
 	if result != nil && len(result.CallbackGroups) > 0 {
-		s.publishSubtreeCallbacks(workMsg, result)
+		if pubErr := s.publishSubtreeCallbacks(workMsg, result); pubErr != nil {
+			return s.handleTransientFailure(workMsg, pubErr)
+		}
 	}
 
 	// Successful processing — decrement the per-block counter.
@@ -335,13 +353,21 @@ func (s *SubtreeWorkerService) decrementCounterAndMaybeEmit(blockHash string) {
 // The STUMP bytes are written once to the blob store (content-addressed, so the
 // same blob is reused across every callback URL for this subtree), and each
 // Kafka message carries only the reference.
-func (s *SubtreeWorkerService) publishSubtreeCallbacks(workMsg *kafka.SubtreeWorkMessage, result *SubtreeResult) {
+//
+// Returns a non-nil error if the blob-store write fails OR if any per-URL
+// encode/publish fails. The loop continues past a single per-URL failure so
+// independent callbacks still go out (partial-success), but the first error
+// encountered is returned to the caller so handleMessage can re-drive the
+// work item through handleTransientFailure rather than silently acking and
+// decrementing the counter — see F-012.
+func (s *SubtreeWorkerService) publishSubtreeCallbacks(workMsg *kafka.SubtreeWorkMessage, result *SubtreeResult) error {
 	if s.stumpStore == nil {
 		s.Logger.Error("stump store not configured; cannot publish STUMP callbacks",
 			"blockHash", workMsg.BlockHash,
 			"subtreeIndex", workMsg.SubtreeIndex,
 		)
-		return
+		return fmt.Errorf("stump store not configured for block %s subtree %d",
+			workMsg.BlockHash, workMsg.SubtreeIndex)
 	}
 
 	stumpRef, err := s.stumpStore.Put(result.StumpData, uint64(workMsg.BlockHeight))
@@ -354,9 +380,15 @@ func (s *SubtreeWorkerService) publishSubtreeCallbacks(workMsg *kafka.SubtreeWor
 			"callbackURLs", len(result.CallbackGroups),
 			"error", err,
 		)
-		return
+		return fmt.Errorf("storing STUMP blob for block %s subtree %d: %w",
+			workMsg.BlockHash, workMsg.SubtreeIndex, err)
 	}
 
+	// Track the first error so the caller can re-drive the whole work item,
+	// while still attempting the remaining URLs (each callback target is
+	// independent — a hiccup on one shouldn't deny delivery to the others on
+	// this attempt).
+	var firstErr error
 	for callbackURL := range result.CallbackGroups {
 		msg := &kafka.CallbackTopicMessage{
 			CallbackURL:  callbackURL,
@@ -365,17 +397,24 @@ func (s *SubtreeWorkerService) publishSubtreeCallbacks(workMsg *kafka.SubtreeWor
 			SubtreeIndex: workMsg.SubtreeIndex,
 			StumpRef:     stumpRef,
 		}
-		data, err := msg.Encode()
-		if err != nil {
+		data, encErr := msg.Encode()
+		if encErr != nil {
 			s.Logger.Error("failed to encode STUMP callback message",
-				"callbackURL", callbackURL, "error", err)
+				"callbackURL", callbackURL, "error", encErr)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("encoding STUMP callback for %s: %w", callbackURL, encErr)
+			}
 			continue
 		}
-		if err := s.callbackProducer.PublishWithHashKey(callbackURL, data); err != nil {
+		if pubErr := s.callbackProducer.PublishWithHashKey(callbackURL, data); pubErr != nil {
 			s.Logger.Error("failed to publish STUMP callback",
-				"callbackURL", callbackURL, "error", err)
+				"callbackURL", callbackURL, "error", pubErr)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("publishing STUMP callback for %s: %w", callbackURL, pubErr)
+			}
 		}
 	}
+	return firstErr
 }
 
 // emitBlockProcessed publishes a BLOCK_PROCESSED message to every registered callback URL.

--- a/internal/block/subtree_worker_handle_message_test.go
+++ b/internal/block/subtree_worker_handle_message_test.go
@@ -1,0 +1,470 @@
+package block
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/IBM/sarama"
+
+	"github.com/bsv-blockchain/merkle-service/internal/config"
+	"github.com/bsv-blockchain/merkle-service/internal/datahub"
+	"github.com/bsv-blockchain/merkle-service/internal/kafka"
+	"github.com/bsv-blockchain/merkle-service/internal/store"
+)
+
+// --- Fakes ---
+//
+// Named distinctly from PR #76's helpers (failingSyncProducer / fakeSubtreeCounter)
+// because that PR is still open and we don't want either side to break the other
+// when the two land on main.
+
+// callbackFailingProducer is a sarama.SyncProducer that records every call and
+// can be configured to fail every send. Used to drive the publishSubtreeCallbacks
+// → handleTransientFailure path.
+type callbackFailingProducer struct {
+	mu       sync.Mutex
+	messages []*sarama.ProducerMessage
+	failAll  bool
+	failErr  error
+}
+
+func (f *callbackFailingProducer) SendMessage(msg *sarama.ProducerMessage) (int32, int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failAll {
+		return 0, 0, f.failErr
+	}
+	f.messages = append(f.messages, msg)
+	return 0, int64(len(f.messages)), nil
+}
+
+func (f *callbackFailingProducer) SendMessages(msgs []*sarama.ProducerMessage) error {
+	for _, m := range msgs {
+		if _, _, err := f.SendMessage(m); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *callbackFailingProducer) Close() error          { return nil }
+func (f *callbackFailingProducer) IsTransactional() bool { return false }
+func (f *callbackFailingProducer) TxnStatus() sarama.ProducerTxnStatusFlag {
+	return sarama.ProducerTxnFlagReady
+}
+func (f *callbackFailingProducer) BeginTxn() error  { return nil }
+func (f *callbackFailingProducer) CommitTxn() error { return nil }
+func (f *callbackFailingProducer) AbortTxn() error  { return nil }
+func (f *callbackFailingProducer) AddOffsetsToTxn(map[string][]*sarama.PartitionOffsetMetadata, string) error {
+	return nil
+}
+func (f *callbackFailingProducer) AddMessageToTxn(*sarama.ConsumerMessage, string, *string) error {
+	return nil
+}
+
+func (f *callbackFailingProducer) sentCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.messages)
+}
+
+// stubStumpStore is a programmable StumpStore. By default Put returns a fixed
+// ref; setting putErr causes every Put call to fail.
+type stubStumpStore struct {
+	mu      sync.Mutex
+	puts    int
+	putErr  error
+	lastRef string
+}
+
+func (s *stubStumpStore) Put(data []byte, blockHeight uint64) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.puts++
+	if s.putErr != nil {
+		return "", s.putErr
+	}
+	s.lastRef = "stump-ref-stub"
+	return s.lastRef, nil
+}
+func (s *stubStumpStore) Get(ref string) ([]byte, error) { return nil, errors.New("not implemented") }
+func (s *stubStumpStore) Delete(ref string) error        { return nil }
+
+// countingSubtreeCounter records every Decrement call so tests can assert
+// whether the counter was touched on a given handleMessage invocation.
+type countingSubtreeCounter struct {
+	mu             sync.Mutex
+	decrementCalls int
+	initCalls      int
+	values         map[string]int
+}
+
+func newCountingSubtreeCounter() *countingSubtreeCounter {
+	return &countingSubtreeCounter{values: map[string]int{}}
+}
+
+func (c *countingSubtreeCounter) Init(blockHash string, count int) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.initCalls++
+	c.values[blockHash] = count
+	return nil
+}
+
+func (c *countingSubtreeCounter) Decrement(blockHash string) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.decrementCalls++
+	c.values[blockHash]--
+	return c.values[blockHash], nil
+}
+
+func (c *countingSubtreeCounter) decrementCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.decrementCalls
+}
+
+// staticRegStore is a RegistrationStore that returns a pre-configured set of
+// callback URLs for any txid lookup. Enables ProcessBlockSubtree to produce
+// non-empty CallbackGroups without reaching for Aerospike.
+type staticRegStore struct {
+	urls []string
+}
+
+func (s *staticRegStore) Add(txid, callbackURL string) error { return nil }
+func (s *staticRegStore) Get(txid string) ([]string, error)  { return s.urls, nil }
+func (s *staticRegStore) BatchGet(txids []string) (map[string][]string, error) {
+	out := make(map[string][]string, len(txids))
+	for _, txid := range txids {
+		out[txid] = s.urls
+	}
+	return out, nil
+}
+func (s *staticRegStore) UpdateTTL(txid string, ttl time.Duration) error          { return nil }
+func (s *staticRegStore) BatchUpdateTTL(txids []string, ttl time.Duration) error { return nil }
+
+// rawSubtreeServer serves a raw 32-byte-hash subtree payload at any path. The
+// merkle-service pulls subtree binary from DataHub when its blob store doesn't
+// already have it, so this fake satisfies that path.
+func rawSubtreeServer(payload []byte) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(payload)
+	}))
+}
+
+// newWorkerForHandleMessage builds a SubtreeWorkerService wired up for tests:
+// in-memory subtree+blob+stump stores, a static registration store, fake
+// counter, and the supplied (callback, retry, dlq) sync producers.
+func newWorkerForHandleMessage(
+	t *testing.T,
+	cb sarama.SyncProducer,
+	retry sarama.SyncProducer,
+	dlq sarama.SyncProducer,
+	stumpStore store.StumpStore,
+	counter *countingSubtreeCounter,
+	maxAttempts int,
+) *SubtreeWorkerService {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	blob := store.NewMemoryBlobStore()
+	subtreeStore := store.NewSubtreeStore(blob, 1, logger)
+
+	s := &SubtreeWorkerService{
+		blockCfg: config.BlockConfig{
+			MaxAttempts:    maxAttempts,
+			PostMineTTLSec: 0,
+		},
+		regStore:       &staticRegStore{urls: []string{"http://cb.example.test/hook"}},
+		subtreeStore:   subtreeStore,
+		stumpStore:     stumpStore,
+		subtreeCounter: counter,
+	}
+	s.InitBase("subtree-worker-test")
+	s.Logger = logger
+	s.dataHubClient = datahub.NewClient(5, 0, logger)
+	s.callbackProducer = kafka.NewTestProducer(cb, "callback-test", logger)
+	s.retryProducer = kafka.NewTestProducer(retry, "subtree-work-test", logger)
+	s.dlqProducer = kafka.NewTestProducer(dlq, "subtree-work-dlq-test", logger)
+	return s
+}
+
+// makeWorkMessageBytes builds a SubtreeWorkMessage targeting the given DataHub
+// URL and returns the encoded bytes ready to feed into handleMessage.
+func makeWorkMessageBytes(t *testing.T, blockHash, subtreeHash, dataHubURL string, attempt int) []byte {
+	t.Helper()
+	msg := &kafka.SubtreeWorkMessage{
+		BlockHash:    blockHash,
+		BlockHeight:  200,
+		SubtreeHash:  subtreeHash,
+		SubtreeIndex: 0,
+		DataHubURL:   dataHubURL,
+		AttemptCount: attempt,
+	}
+	data, err := msg.Encode()
+	if err != nil {
+		t.Fatalf("encode work message: %v", err)
+	}
+	return data
+}
+
+// --- publishSubtreeCallbacks unit tests (direct invocation) ---
+
+// TestPublishSubtreeCallbacks_StumpStoreFailureReturnsError verifies that a
+// blob-store failure is no longer silently swallowed.
+func TestPublishSubtreeCallbacks_StumpStoreFailureReturnsError(t *testing.T) {
+	cbMock := &callbackFailingProducer{}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	s := &SubtreeWorkerService{
+		stumpStore: &stubStumpStore{putErr: errors.New("aerospike timeout")},
+	}
+	s.InitBase("subtree-worker-test")
+	s.Logger = logger
+	s.callbackProducer = kafka.NewTestProducer(cbMock, "callback-test", logger)
+
+	wm := &kafka.SubtreeWorkMessage{
+		BlockHash:    "blk-1",
+		BlockHeight:  10,
+		SubtreeIndex: 0,
+	}
+	res := &SubtreeResult{
+		StumpData:      []byte{0x01, 0x02},
+		CallbackGroups: map[string][]string{"http://cb.example.test/a": {"tx1"}},
+	}
+
+	err := s.publishSubtreeCallbacks(wm, res)
+	if err == nil {
+		t.Fatalf("expected error from publishSubtreeCallbacks when stump store fails")
+	}
+	if cbMock.sentCount() != 0 {
+		t.Errorf("expected zero callback messages on stump-store failure, got %d", cbMock.sentCount())
+	}
+}
+
+// TestPublishSubtreeCallbacks_KafkaPublishFailureReturnsError verifies that a
+// callback-producer failure surfaces an error to the caller.
+func TestPublishSubtreeCallbacks_KafkaPublishFailureReturnsError(t *testing.T) {
+	cbMock := &callbackFailingProducer{failAll: true, failErr: errors.New("kafka unavailable")}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	s := &SubtreeWorkerService{
+		stumpStore: &stubStumpStore{},
+	}
+	s.InitBase("subtree-worker-test")
+	s.Logger = logger
+	s.callbackProducer = kafka.NewTestProducer(cbMock, "callback-test", logger)
+
+	wm := &kafka.SubtreeWorkMessage{BlockHash: "blk-2", BlockHeight: 10}
+	res := &SubtreeResult{
+		StumpData: []byte{0x01},
+		CallbackGroups: map[string][]string{
+			"http://cb.example.test/a": {"tx1"},
+			"http://cb.example.test/b": {"tx2"},
+		},
+	}
+
+	err := s.publishSubtreeCallbacks(wm, res)
+	if err == nil {
+		t.Fatalf("expected error from publishSubtreeCallbacks when Kafka publish fails")
+	}
+}
+
+// TestPublishSubtreeCallbacks_HappyPathReturnsNil verifies the no-error path.
+func TestPublishSubtreeCallbacks_HappyPathReturnsNil(t *testing.T) {
+	cbMock := &callbackFailingProducer{}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	s := &SubtreeWorkerService{
+		stumpStore: &stubStumpStore{},
+	}
+	s.InitBase("subtree-worker-test")
+	s.Logger = logger
+	s.callbackProducer = kafka.NewTestProducer(cbMock, "callback-test", logger)
+
+	wm := &kafka.SubtreeWorkMessage{BlockHash: "blk-3", BlockHeight: 10}
+	res := &SubtreeResult{
+		StumpData: []byte{0x01},
+		CallbackGroups: map[string][]string{
+			"http://cb.example.test/a": {"tx1"},
+			"http://cb.example.test/b": {"tx2"},
+		},
+	}
+
+	if err := s.publishSubtreeCallbacks(wm, res); err != nil {
+		t.Fatalf("expected nil error on happy path, got: %v", err)
+	}
+	if got := cbMock.sentCount(); got != 2 {
+		t.Errorf("expected 2 callback messages, got %d", got)
+	}
+}
+
+// --- handleMessage decision-tree integration tests ---
+
+// TestHandleMessage_CallbackPublishFailure_RetriesAndDoesNotDecrement verifies
+// the F-012 fix: when the callback Kafka publish fails, the work item is
+// re-driven through the retry producer and the per-block subtree counter is
+// NOT decremented (otherwise BLOCK_PROCESSED would fire prematurely with a
+// missing STUMP).
+func TestHandleMessage_CallbackPublishFailure_RetriesAndDoesNotDecrement(t *testing.T) {
+	cbMock := &callbackFailingProducer{failAll: true, failErr: errors.New("kafka unavailable")}
+	retryMock := &callbackFailingProducer{}
+	dlqMock := &callbackFailingProducer{}
+
+	counter := newCountingSubtreeCounter()
+	stumpStore := &stubStumpStore{}
+
+	subtreePayload := buildRawSubtreeBytes(t, 2)
+	server := rawSubtreeServer(subtreePayload)
+	defer server.Close()
+
+	const blockHash = "block-cb-fail"
+	const subtreeHash = "subtree-cb-fail"
+
+	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, 5)
+
+	value := makeWorkMessageBytes(t, blockHash, subtreeHash, server.URL, 0)
+	err := svc.handleMessage(context.Background(), &sarama.ConsumerMessage{Value: value})
+	if err != nil {
+		t.Fatalf("handleMessage: expected nil error (retry path returns nil after re-publishing), got: %v", err)
+	}
+
+	// Counter must NOT have been decremented — otherwise BLOCK_PROCESSED could
+	// fire with a missing STUMP.
+	if got := counter.decrementCount(); got != 0 {
+		t.Errorf("expected counter Decrement NOT called on callback failure, got %d calls", got)
+	}
+
+	// Retry producer must have received the re-published work message.
+	if got := retryMock.sentCount(); got != 1 {
+		t.Errorf("expected exactly 1 retry publish, got %d", got)
+	}
+	// DLQ must NOT have been touched (we're nowhere near max attempts).
+	if got := dlqMock.sentCount(); got != 0 {
+		t.Errorf("expected zero DLQ publishes, got %d", got)
+	}
+}
+
+// TestHandleMessage_CallbackPublishFailure_AtMaxAttempts_DLQAndDecrement verifies
+// that when callback publishing fails and the work item has already reached
+// max attempts, the message is DLQ'd and the counter IS decremented (matching
+// handleTransientFailure's existing terminal-failure semantics so
+// BLOCK_PROCESSED still fires, with the missing STUMP surfaced downstream).
+func TestHandleMessage_CallbackPublishFailure_AtMaxAttempts_DLQAndDecrement(t *testing.T) {
+	cbMock := &callbackFailingProducer{failAll: true, failErr: errors.New("kafka unavailable")}
+	retryMock := &callbackFailingProducer{}
+	dlqMock := &callbackFailingProducer{}
+
+	counter := newCountingSubtreeCounter()
+	_ = counter.Init("block-dlq", 1)
+	// Reset init bookkeeping after pre-seed so test assertions only count
+	// what handleMessage drives.
+	counter.initCalls = 0
+
+	stumpStore := &stubStumpStore{}
+
+	subtreePayload := buildRawSubtreeBytes(t, 2)
+	server := rawSubtreeServer(subtreePayload)
+	defer server.Close()
+
+	const maxAttempts = 3
+	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, maxAttempts)
+
+	// AttemptCount = maxAttempts - 1 → next attempt is terminal → DLQ.
+	value := makeWorkMessageBytes(t, "block-dlq", "subtree-dlq", server.URL, maxAttempts-1)
+	err := svc.handleMessage(context.Background(), &sarama.ConsumerMessage{Value: value})
+	if err != nil {
+		t.Fatalf("handleMessage at max attempts: expected nil error after DLQ publish, got: %v", err)
+	}
+
+	if got := dlqMock.sentCount(); got != 1 {
+		t.Errorf("expected exactly 1 DLQ publish at max attempts, got %d", got)
+	}
+	if got := retryMock.sentCount(); got != 0 {
+		t.Errorf("expected zero retry publishes at max attempts, got %d", got)
+	}
+	// Terminal: BLOCK_PROCESSED must still be able to fire — counter MUST be
+	// decremented exactly once.
+	if got := counter.decrementCount(); got != 1 {
+		t.Errorf("expected counter Decrement called exactly once on DLQ, got %d", got)
+	}
+}
+
+// TestHandleMessage_HappyPath_DecrementsExactlyOnce verifies that a fully
+// successful subtree processing path decrements the counter exactly once and
+// publishes one callback per registered URL.
+func TestHandleMessage_HappyPath_DecrementsExactlyOnce(t *testing.T) {
+	cbMock := &callbackFailingProducer{}
+	retryMock := &callbackFailingProducer{}
+	dlqMock := &callbackFailingProducer{}
+
+	counter := newCountingSubtreeCounter()
+	_ = counter.Init("block-happy", 1)
+	counter.initCalls = 0
+
+	stumpStore := &stubStumpStore{}
+
+	subtreePayload := buildRawSubtreeBytes(t, 2)
+	server := rawSubtreeServer(subtreePayload)
+	defer server.Close()
+
+	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, 5)
+
+	value := makeWorkMessageBytes(t, "block-happy", "subtree-happy", server.URL, 0)
+	if err := svc.handleMessage(context.Background(), &sarama.ConsumerMessage{Value: value}); err != nil {
+		t.Fatalf("handleMessage happy path: expected nil error, got: %v", err)
+	}
+
+	if got := counter.decrementCount(); got != 1 {
+		t.Errorf("expected counter Decrement called exactly once on happy path, got %d", got)
+	}
+	if got := cbMock.sentCount(); got != 1 {
+		t.Errorf("expected 1 callback publish on happy path, got %d", got)
+	}
+	if got := retryMock.sentCount(); got != 0 {
+		t.Errorf("expected zero retry publishes on happy path, got %d", got)
+	}
+	if got := dlqMock.sentCount(); got != 0 {
+		t.Errorf("expected zero DLQ publishes on happy path, got %d", got)
+	}
+}
+
+// TestHandleMessage_StumpStoreFailure_RetriesAndDoesNotDecrement covers the
+// other half of F-012: a blob-store write failure (not Kafka) during callback
+// publishing must also re-drive via the retry pipeline.
+func TestHandleMessage_StumpStoreFailure_RetriesAndDoesNotDecrement(t *testing.T) {
+	cbMock := &callbackFailingProducer{}
+	retryMock := &callbackFailingProducer{}
+	dlqMock := &callbackFailingProducer{}
+
+	counter := newCountingSubtreeCounter()
+	stumpStore := &stubStumpStore{putErr: errors.New("blob store unreachable")}
+
+	subtreePayload := buildRawSubtreeBytes(t, 2)
+	server := rawSubtreeServer(subtreePayload)
+	defer server.Close()
+
+	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, 5)
+
+	value := makeWorkMessageBytes(t, "block-blob-fail", "subtree-blob-fail", server.URL, 0)
+	if err := svc.handleMessage(context.Background(), &sarama.ConsumerMessage{Value: value}); err != nil {
+		t.Fatalf("handleMessage stump-store failure: expected nil error (retry path), got: %v", err)
+	}
+
+	if got := counter.decrementCount(); got != 0 {
+		t.Errorf("expected counter Decrement NOT called on stump-store failure, got %d", got)
+	}
+	if got := retryMock.sentCount(); got != 1 {
+		t.Errorf("expected exactly 1 retry publish on stump-store failure, got %d", got)
+	}
+	if got := cbMock.sentCount(); got != 0 {
+		t.Errorf("expected zero callback publishes on stump-store failure, got %d", got)
+	}
+}
+


### PR DESCRIPTION
## Summary
- `publishSubtreeCallbacks` now returns `error`; `handleMessage` routes failures through `handleTransientFailure` so the work item is retried (or DLQ'd at max attempts) instead of being silently acked.
- Counter is decremented only after callbacks publish successfully (or on DLQ, matching the existing terminal-failure semantics).
- Inside `publishSubtreeCallbacks`, blob-store failure is fail-fast (no callbacks possible without a STUMP ref). Per-URL encode/publish failures use a partial-success pattern: continue iterating remaining URLs but capture the first error so the caller can re-drive — independent callbacks shouldn't deny each other this attempt's delivery, but the work item must still be retried so the failed URL is re-attempted.
- Adds `internal/block/subtree_worker_handle_message_test.go` covering: stump-store failure, Kafka publish failure, happy path, retry-vs-DLQ branch on `AttemptCount >= maxAttempts - 1`, and counter-not-decremented invariants. The file name avoids collision with PR #76's open `handle_message_test.go`. New fakes (`callbackFailingProducer`, `stubStumpStore`, `countingSubtreeCounter`, `staticRegStore`) are renamed/scoped to this file so they don't clash with PR #76's `failingSyncProducer` / `fakeSubtreeCounter` when both land.

Closes #4

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/block/... -count=1 -race`
- [x] `golangci-lint run ./internal/block/...` (no new findings; 2 pre-existing errcheck warnings in `subtree_processor_test.go` are untouched)
- [ ] Reviewer sanity check on the retry path