### PR TITLE
fix(callback): only ack messages after durable outcome (#5)

### DIFF
--- a/internal/callback/delivery.go
+++ b/internal/callback/delivery.go
@@ -14,7 +14,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -31,6 +30,15 @@ type CallbackDeduper interface {
 	Exists(txid, callbackURL, statusType string) (bool, error)
 	Record(txid, callbackURL, statusType string, ttl time.Duration) error
 }
+
+// futureRetryWaitCap is the maximum amount of time handleMessage will block
+// in-process while waiting for a not-yet-due retry to mature. Anything larger
+// than this and the consumer republishes the message back to the callback
+// topic with the same NextRetryAt and returns — so a long backoff converts
+// into N short consume/sleep/republish cycles instead of pinning a partition.
+// Kept well below Sarama's default Consumer.Group.Session.Timeout (10s) so we
+// never trip a rebalance from a single in-flight wait.
+const futureRetryWaitCap = 2 * time.Second
 
 // permanentDeliveryError marks a delivery failure that cannot be cured by
 // retrying (e.g. the STUMP blob has expired or is unreachable). Wrapping an
@@ -60,94 +68,47 @@ type callbackPayload struct {
 	Stump        string   `json:"stump,omitempty"`
 }
 
-// stumpGate coordinates STUMP/BLOCK_PROCESSED delivery ordering.
-// It ensures all STUMP HTTP deliveries for a (blockHash, callbackURL) complete
-// before BLOCK_PROCESSED is delivered to that callbackURL.
-//
-// Safety: for a given callbackURL, all messages are hash-partitioned to the same
-// Kafka partition, so handleMessage sees STUMPs before BLOCK_PROCESSED. Add()
-// is called in handleMessage (sequential per partition) and Done()/Wait() are
-// called in processDelivery (concurrent workers).
-type stumpGate struct {
-	mu    sync.Mutex
-	gates map[string]*sync.WaitGroup
-}
-
-func newStumpGate() *stumpGate {
-	return &stumpGate{gates: make(map[string]*sync.WaitGroup)}
-}
-
-func stumpGateKey(blockHash, callbackURL string) string {
-	return blockHash + "|" + callbackURL
-}
-
-// Add registers a pending STUMP delivery. Called from handleMessage (sequential per partition).
-func (g *stumpGate) Add(blockHash, callbackURL string) {
-	key := stumpGateKey(blockHash, callbackURL)
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	wg, ok := g.gates[key]
-	if !ok {
-		wg = &sync.WaitGroup{}
-		g.gates[key] = wg
-	}
-	wg.Add(1)
-}
-
-// Done signals that a STUMP delivery has completed. Called from processDelivery.
-func (g *stumpGate) Done(blockHash, callbackURL string) {
-	key := stumpGateKey(blockHash, callbackURL)
-	g.mu.Lock()
-	wg, ok := g.gates[key]
-	g.mu.Unlock()
-	if ok {
-		wg.Done()
-	}
-}
-
-// Wait blocks until all registered STUMPs for the (blockHash, callbackURL) are done.
-// Called from processDelivery for BLOCK_PROCESSED messages.
-func (g *stumpGate) Wait(blockHash, callbackURL string) {
-	key := stumpGateKey(blockHash, callbackURL)
-	g.mu.Lock()
-	wg, ok := g.gates[key]
-	g.mu.Unlock()
-	if ok {
-		wg.Wait()
-		g.mu.Lock()
-		delete(g.gates, key)
-		g.mu.Unlock()
-	}
-}
-
 // DeliveryService consumes callback messages from the callback Kafka topic
-// and delivers them via HTTP POST, with linear backoff retry logic.
+// and delivers them via HTTP POST.
+//
+// Durability contract (F-021): handleMessage processes each consumed message
+// synchronously and returns nil ONLY after the message has reached a durable
+// terminal state — i.e. one of:
+//
+//   - successfully delivered + dedup recorded, OR
+//   - republished to the callback topic for a future retry (retry budget left), OR
+//   - published to the DLQ (retries exhausted or permanent failure).
+//
+// Returning a non-nil error from handleMessage skips MarkMessage in the
+// consumer-group loop, so the Kafka offset stays put and the message will be
+// re-delivered when the consumer session is re-established. This guarantees
+// that a process crash, restart, or forced shutdown after the offset is
+// (or would have been) marked cannot permanently lose a callback. The
+// previous design parked retries in time.AfterFunc timers and dispatched to
+// an in-process worker pool, both of which were lost on crash — the dedup
+// store could not save us because no upstream component republishes callback
+// messages on restart.
+//
+// STUMP/BLOCK_PROCESSED ordering: callback URL is the partition key, so all
+// messages for a given (block, callbackURL) land on the same partition and
+// are consumed sequentially. With synchronous handling, prior STUMP
+// deliveries complete before BLOCK_PROCESSED is processed without any extra
+// gating primitive — the previous in-memory stumpGate is no longer needed.
 type DeliveryService struct {
 	service.BaseService
 
-	cfg         *config.Config
-	consumer    *kafka.Consumer
-	dlqProducer *kafka.Producer
-	httpClient  *http.Client
-	dedupStore  CallbackDeduper
-	stumpStore  store.StumpStore
-	stumpGate   *stumpGate
-
-	// Worker pool for concurrent delivery.
-	workCh   chan *kafka.CallbackTopicMessage
-	workerWg sync.WaitGroup
-
-	// shuttingDown guards the retry-scheduler path: once Stop begins, in-flight
-	// time.AfterFunc callbacks must not attempt to send on workCh. Tracked with
-	// retryTimerWg so Stop can wait for pending timer callbacks to finish.
-	shuttingDown atomic.Bool
-	retryTimerWg sync.WaitGroup
+	cfg           *config.Config
+	consumer      *kafka.Consumer
+	dlqProducer   *kafka.Producer
+	retryProducer *kafka.Producer
+	httpClient    *http.Client
+	dedupStore    CallbackDeduper
+	stumpStore    store.StumpStore
 
 	messagesProcessed atomic.Int64
 	messagesRetried   atomic.Int64
 	messagesFailed    atomic.Int64
 	messagesDedupe    atomic.Int64
-	messagesParked    atomic.Int64 // retries currently parked in time.AfterFunc timers
 }
 
 // NewDeliveryService creates a new callback DeliveryService. stumpStore is
@@ -158,7 +119,6 @@ func NewDeliveryService(cfg *config.Config, dedupStore CallbackDeduper, stumpSto
 		cfg:        cfg,
 		dedupStore: dedupStore,
 		stumpStore: stumpStore,
-		stumpGate:  newStumpGate(),
 	}
 }
 
@@ -194,8 +154,6 @@ func (d *DeliveryService) Init(_ interface{}) error {
 	}
 
 	// Create producer for publishing permanently failed messages to the DLQ topic.
-	// Retries are parked in-process (see scheduleRetry) rather than republished
-	// to the callback topic, so no retry-producer is needed.
 	dlqProducer, err := kafka.NewProducer(
 		d.cfg.Kafka.Brokers,
 		d.cfg.Kafka.CallbackDLQTopic,
@@ -205,6 +163,19 @@ func (d *DeliveryService) Init(_ interface{}) error {
 		return fmt.Errorf("failed to create callback DLQ producer: %w", err)
 	}
 	d.dlqProducer = dlqProducer
+
+	// Create producer for republishing retry-eligible messages back onto the
+	// callback topic. Retries flow through Kafka rather than in-process timers
+	// so a crash between consume and re-deliver doesn't lose the message.
+	retryProducer, err := kafka.NewProducer(
+		d.cfg.Kafka.Brokers,
+		d.cfg.Kafka.CallbackTopic,
+		d.Logger,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create callback retry producer: %w", err)
+	}
+	d.retryProducer = retryProducer
 
 	// Create consumer for the callback topic.
 	consumer, err := kafka.NewConsumer(
@@ -219,20 +190,13 @@ func (d *DeliveryService) Init(_ interface{}) error {
 	}
 	d.consumer = consumer
 
-	// Initialize the work channel for the worker pool.
-	workers := d.cfg.Callback.DeliveryWorkers
-	if workers <= 0 {
-		workers = 64
-	}
-	d.workCh = make(chan *kafka.CallbackTopicMessage, workers*2)
-
 	d.Logger.Info("callback delivery service initialized",
 		"callbackTopic", d.cfg.Kafka.CallbackTopic,
 		"callbackDlqTopic", d.cfg.Kafka.CallbackDLQTopic,
 		"maxRetries", d.cfg.Callback.MaxRetries,
 		"backoffBaseSec", d.cfg.Callback.BackoffBaseSec,
 		"timeoutSec", d.cfg.Callback.TimeoutSec,
-		"deliveryWorkers", workers,
+		"futureRetryWaitCap", futureRetryWaitCap,
 		"maxConnsPerHost", maxConnsPerHost,
 		"maxIdleConnsPerHost", maxIdleConnsPerHost,
 	)
@@ -240,19 +204,9 @@ func (d *DeliveryService) Init(_ interface{}) error {
 	return nil
 }
 
-// Start begins consuming callback messages from Kafka and launches delivery workers.
+// Start begins consuming callback messages from Kafka.
 func (d *DeliveryService) Start(ctx context.Context) error {
 	d.Logger.Info("starting callback delivery service")
-
-	// Launch delivery workers.
-	workers := d.cfg.Callback.DeliveryWorkers
-	if workers <= 0 {
-		workers = 64
-	}
-	d.workerWg.Add(workers)
-	for i := 0; i < workers; i++ {
-		go d.deliveryWorker(d.Context())
-	}
 
 	// Observability: periodic INFO heartbeat so prod operators can see
 	// throughput without enabling DEBUG (successful deliveries log at DEBUG).
@@ -273,21 +227,19 @@ func (d *DeliveryService) Stop() error {
 
 	var firstErr error
 
-	// Flip the shutdown flag before closing workCh so in-flight retry timers
-	// drop their messages instead of sending to a closed channel.
-	d.shuttingDown.Store(true)
-	d.retryTimerWg.Wait()
-
-	// Close work channel to signal workers to drain and exit.
-	if d.workCh != nil {
-		close(d.workCh)
-		d.workerWg.Wait()
-	}
-
 	if d.consumer != nil {
 		if err := d.consumer.Stop(); err != nil {
 			d.Logger.Error("failed to stop consumer", "error", err)
 			firstErr = err
+		}
+	}
+
+	if d.retryProducer != nil {
+		if err := d.retryProducer.Close(); err != nil {
+			d.Logger.Error("failed to close retry producer", "error", err)
+			if firstErr == nil {
+				firstErr = err
+			}
 		}
 	}
 
@@ -328,70 +280,65 @@ func (d *DeliveryService) Health() service.HealthStatus {
 	}
 }
 
-// handleMessage decodes a Kafka message and dispatches it to the worker pool.
-func (d *DeliveryService) handleMessage(_ context.Context, msg *sarama.ConsumerMessage) error {
+// handleMessage is the durable entry-point for a single Kafka message. It
+// returns nil ONLY after the message has reached a terminal durable state
+// (delivered + dedup recorded, OR republished to retry topic, OR routed to
+// DLQ). Returning non-nil leaves the Kafka offset unmarked so the message is
+// re-consumed on the next session — which is what we want when the durable
+// side-effect itself fails.
+//
+// Same-partition serialization (callback URL is the partition key) means
+// STUMP messages for a given (block, callbackURL) are processed before
+// BLOCK_PROCESSED for the same key, without any in-process gating.
+func (d *DeliveryService) handleMessage(ctx context.Context, msg *sarama.ConsumerMessage) error {
 	cbMsg, err := kafka.DecodeCallbackTopicMessage(msg.Value)
 	if err != nil {
-		d.Logger.Error("failed to decode callback message",
+		// A poison-pill message that cannot be decoded should not block the
+		// partition forever. Log and ack so the consumer can advance — the
+		// raw bytes are still inspectable via Kafka's retention.
+		d.Logger.Error("failed to decode callback message, skipping",
 			"offset", msg.Offset,
 			"partition", msg.Partition,
 			"error", err,
 		)
-		return fmt.Errorf("failed to decode callback message: %w", err)
-	}
-
-	// Park not-yet-due retries in-process instead of looping them through Kafka.
-	// Before this change, a message with NextRetryAt in the future was
-	// immediately republished to the callback topic, which caused the consumer
-	// to spin at partition speed republishing the same retry until the delay
-	// elapsed. The Kafka offset still advances (MarkMessage runs after
-	// handleMessage returns nil) so there's no durability regression —
-	// retries were never persisted across restarts anyway, dedup prevents
-	// double-delivery on re-drive from upstream.
-	if !cbMsg.NextRetryAt.IsZero() && time.Now().Before(cbMsg.NextRetryAt) {
-		delay := time.Until(cbMsg.NextRetryAt)
-		d.Logger.Debug("parking retry in-process",
-			"callbackUrl", cbMsg.CallbackURL,
-			"txid", cbMsg.TxID,
-			"nextRetryAt", cbMsg.NextRetryAt,
-			"delay", delay,
-		)
-		d.scheduleRetry(cbMsg, delay)
 		return nil
 	}
 
-	// Register first-attempt STUMP deliveries with the gate so BLOCK_PROCESSED
-	// can wait for them. This runs sequentially per partition, guaranteeing all
-	// STUMPs for a callbackURL are registered before BLOCK_PROCESSED is dispatched.
-	if cbMsg.Type == kafka.CallbackStump && cbMsg.RetryCount == 0 {
-		d.stumpGate.Add(cbMsg.BlockHash, cbMsg.CallbackURL)
+	// Not-yet-due retry: wait briefly in-process if the remaining delay is
+	// small, otherwise republish back to the topic with the same NextRetryAt
+	// so we don't pin a partition for the full backoff window.
+	if !cbMsg.NextRetryAt.IsZero() {
+		remaining := time.Until(cbMsg.NextRetryAt)
+		if remaining > 0 {
+			if remaining <= futureRetryWaitCap {
+				select {
+				case <-time.After(remaining):
+				case <-ctx.Done():
+					// Session is going away; leave the offset uncommitted so
+					// the message is re-delivered on the next session.
+					return ctx.Err()
+				}
+			} else {
+				// Sleep the cap to slow the consume/republish cycle to no
+				// faster than once per futureRetryWaitCap, then republish.
+				select {
+				case <-time.After(futureRetryWaitCap):
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+				return d.republishForRetry(cbMsg, "future-dated retry not yet due")
+			}
+		}
 	}
 
-	// Dispatch to worker pool (blocking send provides backpressure).
-	d.workCh <- cbMsg
-	return nil
+	return d.processDelivery(ctx, cbMsg)
 }
 
-// deliveryWorker is a goroutine that processes delivery jobs from the work channel.
-func (d *DeliveryService) deliveryWorker(ctx context.Context) {
-	defer d.workerWg.Done()
-	for msg := range d.workCh {
-		d.processDelivery(ctx, msg)
-	}
-}
-
-// processDelivery handles dedup check, HTTP delivery, dedup record, and retry/DLQ logic for a single message.
-func (d *DeliveryService) processDelivery(ctx context.Context, cbMsg *kafka.CallbackTopicMessage) {
-	// Signal STUMP completion when this function exits (success, dedup skip, or failure).
-	if cbMsg.Type == kafka.CallbackStump && cbMsg.RetryCount == 0 {
-		defer d.stumpGate.Done(cbMsg.BlockHash, cbMsg.CallbackURL)
-	}
-
-	// Wait for all STUMP deliveries to complete before delivering BLOCK_PROCESSED.
-	if cbMsg.Type == kafka.CallbackBlockProcessed {
-		d.stumpGate.Wait(cbMsg.BlockHash, cbMsg.CallbackURL)
-	}
-
+// processDelivery runs the dedup check, HTTP delivery, dedup record, and
+// retry/DLQ logic for a single message inline. It returns nil only after the
+// message reaches a durable terminal state; a non-nil return means the
+// Kafka offset must NOT be marked so the message is re-consumed.
+func (d *DeliveryService) processDelivery(ctx context.Context, cbMsg *kafka.CallbackTopicMessage) error {
 	d.Logger.Debug("processing callback message",
 		"callbackUrl", cbMsg.CallbackURL,
 		"txid", cbMsg.TxID,
@@ -412,8 +359,7 @@ func (d *DeliveryService) processDelivery(ctx context.Context, cbMsg *kafka.Call
 				// to fall through to the retry path so the next attempt
 				// re-checks dedup once the store recovers.
 				d.Logger.Error("dedup check failed, scheduling retry", "error", err, "dedupKey", dedupKey, "callbackUrl", cbMsg.CallbackURL)
-				d.scheduleRetryAfterFailure(cbMsg, fmt.Errorf("dedup check: %w", err))
-				return
+				return d.scheduleRetryOrDLQ(cbMsg, fmt.Errorf("dedup check: %w", err))
 			}
 			if exists {
 				d.Logger.Debug("skipping duplicate callback delivery",
@@ -422,18 +368,17 @@ func (d *DeliveryService) processDelivery(ctx context.Context, cbMsg *kafka.Call
 					"type", cbMsg.Type,
 				)
 				d.messagesDedupe.Add(1)
-				return
+				return nil
 			}
 		}
 	}
 
 	// Attempt HTTP POST delivery.
-	err := d.deliverCallback(ctx, cbMsg)
-	if err == nil {
+	deliverErr := d.deliverCallback(ctx, cbMsg)
+	if deliverErr == nil {
 		// Record successful delivery for dedup. Delivery already succeeded —
-		// the offset will advance regardless. Raising to ERROR (vs the
-		// previous Warn) so dedup-store outages are visible in prod logs
-		// without requiring DEBUG.
+		// the offset will advance regardless. Log dedup-store outages at
+		// ERROR so they're visible in prod without DEBUG.
 		if d.dedupStore != nil {
 			dedupKey := dedupKeyForMessage(cbMsg)
 			if dedupKey != "" {
@@ -450,7 +395,7 @@ func (d *DeliveryService) processDelivery(ctx context.Context, cbMsg *kafka.Call
 			"type", cbMsg.Type,
 			"subtreeIndex", cbMsg.SubtreeIndex,
 		)
-		return
+		return nil
 	}
 
 	d.Logger.Warn("callback delivery failed",
@@ -459,12 +404,19 @@ func (d *DeliveryService) processDelivery(ctx context.Context, cbMsg *kafka.Call
 		"type", cbMsg.Type,
 		"retryCount", cbMsg.RetryCount,
 		"subtreeIndex", cbMsg.SubtreeIndex,
-		"error", err,
+		"error", deliverErr,
 	)
+	return d.scheduleRetryOrDLQ(cbMsg, deliverErr)
+}
 
-	// Permanent failures (e.g. STUMP blob expired) skip the retry schedule
-	// and go straight to the DLQ — retrying cannot recover them.
-	if isPermanentDeliveryError(err) {
+// scheduleRetryOrDLQ decides whether a failed message should be republished
+// for retry or routed to the DLQ, then performs the durable side-effect. It
+// returns nil iff the durable side-effect succeeded; otherwise the caller
+// must propagate the error up so the Kafka offset is not committed.
+func (d *DeliveryService) scheduleRetryOrDLQ(cbMsg *kafka.CallbackTopicMessage, cause error) error {
+	// Permanent failures (e.g. STUMP blob expired) skip the retry budget and
+	// go straight to the DLQ — retrying cannot recover them.
+	if isPermanentDeliveryError(cause) {
 		d.Logger.Error("callback permanently failed, publishing to DLQ",
 			"callbackUrl", cbMsg.CallbackURL,
 			"txid", cbMsg.TxID,
@@ -472,38 +424,32 @@ func (d *DeliveryService) processDelivery(ctx context.Context, cbMsg *kafka.Call
 			"retryCount", cbMsg.RetryCount,
 			"subtreeIndex", cbMsg.SubtreeIndex,
 			"reason", "permanent",
+			"cause", cause,
 		)
-		d.messagesFailed.Add(1)
-		d.publishToDLQWithRetry(cbMsg)
-		return
+		return d.publishToDLQDurably(cbMsg)
 	}
 
-	// Check if we've exhausted retries.
+	// Retry budget exhausted: route to DLQ.
 	if cbMsg.RetryCount >= d.cfg.Callback.MaxRetries {
-		d.Logger.Error("callback permanently failed, publishing to DLQ",
+		d.Logger.Error("callback retries exhausted, publishing to DLQ",
 			"callbackUrl", cbMsg.CallbackURL,
 			"txid", cbMsg.TxID,
 			"type", cbMsg.Type,
 			"retryCount", cbMsg.RetryCount,
 			"subtreeIndex", cbMsg.SubtreeIndex,
+			"cause", cause,
 		)
-		d.messagesFailed.Add(1)
-		d.publishToDLQWithRetry(cbMsg)
-		return
+		return d.publishToDLQDurably(cbMsg)
 	}
 
-	d.scheduleRetryAfterFailure(cbMsg, err)
-}
-
-// scheduleRetryAfterFailure bumps RetryCount, computes the next NextRetryAt
-// using linear backoff, and parks the message in-process until the delay
-// elapses. Shared by the HTTP-delivery-failed and dedup-check-failed paths.
-func (d *DeliveryService) scheduleRetryAfterFailure(cbMsg *kafka.CallbackTopicMessage, cause error) {
+	// Bump retry count + compute next NextRetryAt using linear backoff, then
+	// republish back to the callback topic. The republish is the durable
+	// side-effect: until it succeeds, we must not ack the source message.
 	cbMsg.RetryCount++
 	backoffSec := d.cfg.Callback.BackoffBaseSec * cbMsg.RetryCount
 	cbMsg.NextRetryAt = time.Now().Add(time.Duration(backoffSec) * time.Second)
 
-	d.Logger.Info("scheduling callback retry",
+	d.Logger.Info("scheduling callback retry via Kafka republish",
 		"callbackUrl", cbMsg.CallbackURL,
 		"txid", cbMsg.TxID,
 		"retryCount", cbMsg.RetryCount,
@@ -513,53 +459,42 @@ func (d *DeliveryService) scheduleRetryAfterFailure(cbMsg *kafka.CallbackTopicMe
 		"cause", cause,
 	)
 
-	d.messagesRetried.Add(1)
-	d.scheduleRetry(cbMsg, time.Duration(backoffSec)*time.Second)
+	return d.republishForRetry(cbMsg, "retry after delivery failure")
 }
 
-// scheduleRetry parks the message in a time.AfterFunc for the given delay,
-// then re-dispatches it to the worker pool. Respects shutdown: if Stop has
-// fired, the timer callback drops the message instead of sending on a
-// potentially-closing channel.
-func (d *DeliveryService) scheduleRetry(cbMsg *kafka.CallbackTopicMessage, delay time.Duration) {
-	if d.shuttingDown.Load() {
-		d.Logger.Warn("shutdown in progress, dropping parked retry",
+// republishForRetry encodes cbMsg and publishes it back to the callback
+// topic via the retry producer. The partition key is the callback URL so the
+// retry lands on the same partition as the original — preserving STUMP →
+// BLOCK_PROCESSED ordering for the same (block, callbackURL).
+//
+// Returning nil means the publish was acknowledged by Kafka and the source
+// message can now be safely ack'd. A non-nil return means the publish failed
+// and the caller must NOT mark the offset.
+func (d *DeliveryService) republishForRetry(cbMsg *kafka.CallbackTopicMessage, reason string) error {
+	data, err := cbMsg.Encode()
+	if err != nil {
+		return fmt.Errorf("encode callback message for retry republish (%s): %w", reason, err)
+	}
+	if err := d.retryProducer.PublishWithHashKey(cbMsg.CallbackURL, data); err != nil {
+		d.Logger.Error("retry republish failed, leaving Kafka offset uncommitted",
 			"callbackUrl", cbMsg.CallbackURL,
 			"txid", cbMsg.TxID,
 			"retryCount", cbMsg.RetryCount,
+			"reason", reason,
+			"error", err,
 		)
-		return
+		return fmt.Errorf("retry republish (%s): %w", reason, err)
 	}
-
-	d.retryTimerWg.Add(1)
-	d.messagesParked.Add(1)
-	time.AfterFunc(delay, func() {
-		defer d.retryTimerWg.Done()
-		defer d.messagesParked.Add(-1)
-		if d.shuttingDown.Load() {
-			return
-		}
-		// Non-blocking send protects us if the workCh has somehow been closed
-		// between the shuttingDown check and the send. The recover is a
-		// belt-and-braces because AfterFunc has no ctx handle of its own.
-		defer func() {
-			if r := recover(); r != nil {
-				d.Logger.Warn("retry dispatch recovered from panic, message dropped",
-					"callbackUrl", cbMsg.CallbackURL,
-					"txid", cbMsg.TxID,
-					"panic", r,
-				)
-			}
-		}()
-		d.workCh <- cbMsg
-	})
+	d.messagesRetried.Add(1)
+	return nil
 }
 
-// publishToDLQWithRetry attempts publishToDLQ up to 3 times with 500ms →
-// 1s → 2s backoff. On final failure the message is dropped but the ERROR
-// log + messagesFailed counter surface it — previously the log said
-// "failed to publish to DLQ" with no follow-up and callers assumed success.
-func (d *DeliveryService) publishToDLQWithRetry(cbMsg *kafka.CallbackTopicMessage) {
+// publishToDLQDurably publishes a permanently failed message to the DLQ topic
+// and returns nil only on success. It retries the publish a few times before
+// surfacing the failure so the Kafka offset is not committed when the DLQ
+// itself is unreachable — that way the message is reconsidered on the next
+// session instead of being silently dropped.
+func (d *DeliveryService) publishToDLQDurably(cbMsg *kafka.CallbackTopicMessage) error {
 	delays := []time.Duration{0, 500 * time.Millisecond, 1 * time.Second, 2 * time.Second}
 	var lastErr error
 	for i, delay := range delays {
@@ -576,15 +511,17 @@ func (d *DeliveryService) publishToDLQWithRetry(cbMsg *kafka.CallbackTopicMessag
 			)
 			continue
 		}
-		return
+		d.messagesFailed.Add(1)
+		return nil
 	}
-	d.Logger.Error("DLQ publish exhausted all retries, message lost",
+	d.Logger.Error("DLQ publish exhausted all retries, leaving Kafka offset uncommitted",
 		"callbackUrl", cbMsg.CallbackURL,
 		"txid", cbMsg.TxID,
 		"type", cbMsg.Type,
 		"retryCount", cbMsg.RetryCount,
 		"error", lastErr,
 	)
+	return fmt.Errorf("DLQ publish: %w", lastErr)
 }
 
 // heartbeat emits an INFO-level throughput line every 30 seconds until ctx
@@ -603,9 +540,6 @@ func (d *DeliveryService) heartbeat(ctx context.Context) {
 				"messagesRetried", d.messagesRetried.Load(),
 				"messagesFailed", d.messagesFailed.Load(),
 				"messagesDedupe", d.messagesDedupe.Load(),
-				"messagesParked", d.messagesParked.Load(),
-				"workChLen", len(d.workCh),
-				"workChCap", cap(d.workCh),
 			)
 		}
 	}

--- a/internal/callback/delivery_handle_message_test.go
+++ b/internal/callback/delivery_handle_message_test.go
@@ -1,0 +1,462 @@
+package callback
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/IBM/sarama"
+
+	"github.com/bsv-blockchain/merkle-service/internal/kafka"
+)
+
+// These tests cover the durability contract that handleMessage must obey
+// after F-021: returning nil ONLY when the message has reached a durable
+// terminal state (delivered + dedup recorded, or republished to retry topic,
+// or successfully published to the DLQ). When the durable side-effect
+// itself fails, handleMessage MUST return a non-nil error so the
+// consumer-group loop skips MarkMessage and the offset stays uncommitted —
+// the message will be re-delivered on the next session.
+
+// encodeConsumerMessage builds a sarama.ConsumerMessage carrying the
+// JSON-encoded CallbackTopicMessage, mimicking what the broker delivers.
+func encodeConsumerMessage(t *testing.T, msg *kafka.CallbackTopicMessage) *sarama.ConsumerMessage {
+	t.Helper()
+	data, err := msg.Encode()
+	if err != nil {
+		t.Fatalf("failed to encode CallbackTopicMessage: %v", err)
+	}
+	return &sarama.ConsumerMessage{Value: data}
+}
+
+// TestHandleMessage_HappyPathReturnsNilAfterDelivery covers the standard
+// "deliver, record dedup, ack" path: handleMessage returns nil only after
+// HTTP POST has succeeded, so the offset can safely advance.
+func TestHandleMessage_HappyPathReturnsNilAfterDelivery(t *testing.T) {
+	var deliveries atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deliveries.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := defaultTestConfig()
+	ds, retryMock, dlqMock := newTestDeliveryService(t, cfg, server.Client())
+
+	msg := &kafka.CallbackTopicMessage{
+		CallbackURL: server.URL + "/cb",
+		Type:        kafka.CallbackSeenOnNetwork,
+		TxID:        "tx-happy",
+	}
+
+	if err := ds.handleMessage(context.Background(), encodeConsumerMessage(t, msg)); err != nil {
+		t.Fatalf("expected nil, got error: %v", err)
+	}
+	if deliveries.Load() != 1 {
+		t.Errorf("expected 1 HTTP delivery, got %d", deliveries.Load())
+	}
+	if got := len(retryMock.getMessages()); got != 0 {
+		t.Errorf("expected 0 retry republishes for happy path, got %d", got)
+	}
+	if got := len(dlqMock.getMessages()); got != 0 {
+		t.Errorf("expected 0 DLQ publishes for happy path, got %d", got)
+	}
+	if ds.messagesProcessed.Load() != 1 {
+		t.Errorf("expected messagesProcessed=1, got %d", ds.messagesProcessed.Load())
+	}
+}
+
+// TestHandleMessage_HTTPFailureWithRetriesAvailable_RepublishesBeforeAck
+// asserts the central F-021 invariant: when delivery fails but retries are
+// available, handleMessage republishes the message to the callback topic
+// (durable retry channel) and only returns nil if the publish succeeds.
+func TestHandleMessage_HTTPFailureWithRetriesAvailable_RepublishesBeforeAck(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cfg := defaultTestConfig()
+	ds, retryMock, dlqMock := newTestDeliveryService(t, cfg, server.Client())
+
+	msg := &kafka.CallbackTopicMessage{
+		CallbackURL:  server.URL + "/cb",
+		Type:         kafka.CallbackStump,
+		BlockHash:    "blockhash",
+		SubtreeIndex: 1,
+		RetryCount:   0,
+	}
+
+	if err := ds.handleMessage(context.Background(), encodeConsumerMessage(t, msg)); err != nil {
+		t.Fatalf("expected nil after successful republish, got error: %v", err)
+	}
+
+	retryMsgs := retryMock.getMessages()
+	if len(retryMsgs) != 1 {
+		t.Fatalf("expected 1 retry republish, got %d", len(retryMsgs))
+	}
+	republished := decodePublishedCallbackMessage(t, retryMsgs[0])
+	if republished.RetryCount != 1 {
+		t.Errorf("expected republished RetryCount=1, got %d", republished.RetryCount)
+	}
+	if republished.NextRetryAt.IsZero() {
+		t.Error("expected republished NextRetryAt to be set so future consumers know to wait")
+	}
+	if got := len(dlqMock.getMessages()); got != 0 {
+		t.Errorf("expected 0 DLQ publishes when retries are still available, got %d", got)
+	}
+}
+
+// TestHandleMessage_HTTPFailureRetriesExhausted_RoutesToDLQBeforeAck asserts
+// that when retries are exhausted, handleMessage publishes to the DLQ and
+// only returns nil if the DLQ publish succeeds.
+func TestHandleMessage_HTTPFailureRetriesExhausted_RoutesToDLQBeforeAck(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cfg := defaultTestConfig()
+	cfg.Callback.MaxRetries = 3
+	ds, retryMock, dlqMock := newTestDeliveryService(t, cfg, server.Client())
+
+	msg := &kafka.CallbackTopicMessage{
+		CallbackURL: server.URL + "/cb",
+		Type:        kafka.CallbackSeenOnNetwork,
+		TxID:        "tx-exhausted",
+		RetryCount:  3,
+	}
+
+	if err := ds.handleMessage(context.Background(), encodeConsumerMessage(t, msg)); err != nil {
+		t.Fatalf("expected nil after successful DLQ publish, got error: %v", err)
+	}
+
+	if got := len(retryMock.getMessages()); got != 0 {
+		t.Errorf("expected 0 retry republishes after retries exhausted, got %d", got)
+	}
+	dlqMsgs := dlqMock.getMessages()
+	if len(dlqMsgs) != 1 {
+		t.Fatalf("expected 1 DLQ publish, got %d", len(dlqMsgs))
+	}
+	if ds.messagesFailed.Load() != 1 {
+		t.Errorf("expected messagesFailed=1, got %d", ds.messagesFailed.Load())
+	}
+}
+
+// TestHandleMessage_DLQPublishFailureReturnsError simulates Kafka being
+// unavailable for the DLQ publish on a retries-exhausted message: handler
+// must return non-nil so the consumer-group loop leaves the offset
+// uncommitted. This is what guarantees we don't silently drop messages on
+// downstream-Kafka outages — instead they're reconsidered next session.
+func TestHandleMessage_DLQPublishFailureReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cfg := defaultTestConfig()
+	cfg.Callback.MaxRetries = 3
+	ds, _, dlqMock := newTestDeliveryService(t, cfg, server.Client())
+	dlqMock.failNext = 100 // exhaust the in-call DLQ publish retry budget
+
+	msg := &kafka.CallbackTopicMessage{
+		CallbackURL: server.URL + "/cb",
+		Type:        kafka.CallbackSeenOnNetwork,
+		TxID:        "tx-dlq-fail",
+		RetryCount:  3,
+	}
+
+	err := ds.handleMessage(context.Background(), encodeConsumerMessage(t, msg))
+	if err == nil {
+		t.Fatal("expected handleMessage to return non-nil error when DLQ publish fails")
+	}
+	if ds.messagesFailed.Load() != 0 {
+		t.Errorf("expected messagesFailed=0 (DLQ never durably accepted), got %d", ds.messagesFailed.Load())
+	}
+}
+
+// TestHandleMessage_RetryRepublishFailureReturnsError simulates Kafka being
+// unavailable for the retry republish: the handler must return non-nil so
+// the offset is not committed and the message can be retried on the next
+// session. This is the primary guarantee that fixes F-021.
+func TestHandleMessage_RetryRepublishFailureReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cfg := defaultTestConfig()
+	ds, retryMock, _ := newTestDeliveryService(t, cfg, server.Client())
+	retryMock.failNext = 1 // single republish attempt that fails
+
+	msg := &kafka.CallbackTopicMessage{
+		CallbackURL: server.URL + "/cb",
+		Type:        kafka.CallbackSeenOnNetwork,
+		TxID:        "tx-republish-fail",
+	}
+
+	err := ds.handleMessage(context.Background(), encodeConsumerMessage(t, msg))
+	if err == nil {
+		t.Fatal("expected handleMessage to return non-nil error when retry republish fails")
+	}
+}
+
+// TestHandleMessage_FutureRetryShortDelaySleepsInline covers the small-delay
+// branch: when NextRetryAt is within futureRetryWaitCap, handleMessage
+// sleeps inline and then delivers, returning nil only after the delivery
+// has succeeded. No republish should happen because the inline wait
+// covered the whole delay.
+func TestHandleMessage_FutureRetryShortDelaySleepsInline(t *testing.T) {
+	var deliveries atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deliveries.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := defaultTestConfig()
+	ds, retryMock, _ := newTestDeliveryService(t, cfg, server.Client())
+
+	delay := 50 * time.Millisecond
+	msg := &kafka.CallbackTopicMessage{
+		CallbackURL: server.URL + "/cb",
+		Type:        kafka.CallbackSeenOnNetwork,
+		TxID:        "tx-future-short",
+		RetryCount:  1,
+		NextRetryAt: time.Now().Add(delay),
+	}
+
+	start := time.Now()
+	if err := ds.handleMessage(context.Background(), encodeConsumerMessage(t, msg)); err != nil {
+		t.Fatalf("expected nil, got error: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed < delay {
+		t.Errorf("handler returned before delay elapsed: %v < %v", elapsed, delay)
+	}
+	if deliveries.Load() != 1 {
+		t.Errorf("expected 1 HTTP delivery after inline wait, got %d", deliveries.Load())
+	}
+	if got := len(retryMock.getMessages()); got != 0 {
+		t.Errorf("expected 0 republishes for short-delay future retry, got %d", got)
+	}
+}
+
+// TestHandleMessage_FutureRetryLongDelayRepublishes covers the large-delay
+// branch: when NextRetryAt is further out than futureRetryWaitCap,
+// handleMessage waits the cap (to slow the consume/republish cadence) and
+// then republishes the message — preserving NextRetryAt — and returns nil
+// only if the republish succeeds.
+func TestHandleMessage_FutureRetryLongDelayRepublishes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("HTTP delivery should not happen for a long-delay future retry — message should be republished")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := defaultTestConfig()
+	ds, retryMock, _ := newTestDeliveryService(t, cfg, server.Client())
+
+	farFuture := futureRetryWaitCap * 10
+	msg := &kafka.CallbackTopicMessage{
+		CallbackURL: server.URL + "/cb",
+		Type:        kafka.CallbackSeenOnNetwork,
+		TxID:        "tx-future-long",
+		RetryCount:  1,
+		NextRetryAt: time.Now().Add(farFuture),
+	}
+
+	start := time.Now()
+	if err := ds.handleMessage(context.Background(), encodeConsumerMessage(t, msg)); err != nil {
+		t.Fatalf("expected nil after successful republish, got error: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed < futureRetryWaitCap {
+		t.Errorf("handler returned before futureRetryWaitCap elapsed: %v < %v", elapsed, futureRetryWaitCap)
+	}
+	if elapsed > 2*futureRetryWaitCap {
+		t.Errorf("handler blocked for far longer than futureRetryWaitCap: %v", elapsed)
+	}
+
+	retryMsgs := retryMock.getMessages()
+	if len(retryMsgs) != 1 {
+		t.Fatalf("expected 1 retry republish, got %d", len(retryMsgs))
+	}
+	republished := decodePublishedCallbackMessage(t, retryMsgs[0])
+	if republished.NextRetryAt.IsZero() {
+		t.Error("expected republished NextRetryAt to remain set")
+	}
+	if !republished.NextRetryAt.Equal(msg.NextRetryAt) {
+		t.Errorf("expected NextRetryAt preserved (%v), got %v", msg.NextRetryAt, republished.NextRetryAt)
+	}
+	// RetryCount must NOT be bumped on a future-dated republish — the retry
+	// budget has already been spent by the consumer that produced this
+	// scheduled retry.
+	if republished.RetryCount != 1 {
+		t.Errorf("expected republished RetryCount unchanged (1), got %d", republished.RetryCount)
+	}
+}
+
+// TestHandleMessage_PoisonPillReturnsNil asserts that a malformed message
+// (cannot be decoded) is logged and ack'd so it doesn't pin the partition
+// forever. This is unrelated to the durability contract for valid
+// messages, but worth pinning down so future refactors don't accidentally
+// turn poison pills into a stuck-consumer outage.
+func TestHandleMessage_PoisonPillReturnsNil(t *testing.T) {
+	cfg := defaultTestConfig()
+	ds, _, _ := newTestDeliveryService(t, cfg, &http.Client{Timeout: time.Second})
+
+	if err := ds.handleMessage(context.Background(), &sarama.ConsumerMessage{Value: []byte("not-json")}); err != nil {
+		t.Errorf("expected nil for poison-pill message, got: %v", err)
+	}
+}
+
+// TestHandleMessage_PermanentErrorRoutesToDLQBeforeAck asserts that a
+// permanent delivery failure (e.g. STUMP blob missing) produces a DLQ
+// publish synchronously before the handler returns nil.
+func TestHandleMessage_PermanentErrorRoutesToDLQBeforeAck(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("callback URL should never be hit for a missing-blob STUMP message")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := defaultTestConfig()
+	ds, retryMock, dlqMock, _ := newTestDeliveryServiceWithStumps(t, cfg, server.Client())
+
+	msg := &kafka.CallbackTopicMessage{
+		CallbackURL:  server.URL + "/cb",
+		Type:         kafka.CallbackStump,
+		BlockHash:    "blk-perm",
+		SubtreeIndex: 2,
+		StumpRef:     "ref-never-stored",
+	}
+
+	if err := ds.handleMessage(context.Background(), encodeConsumerMessage(t, msg)); err != nil {
+		t.Fatalf("expected nil after successful DLQ publish, got error: %v", err)
+	}
+	if got := len(retryMock.getMessages()); got != 0 {
+		t.Errorf("expected 0 retry republishes for permanent error, got %d", got)
+	}
+	if got := len(dlqMock.getMessages()); got != 1 {
+		t.Errorf("expected 1 DLQ publish for permanent error, got %d", got)
+	}
+}
+
+// TestHandleMessage_StumpOrderingViaSamePartitionSerialization asserts the
+// new (stumpGate-free) ordering guarantee: because the consumer-group loop
+// processes messages from a single partition serially, and STUMPs land on
+// the same partition as BLOCK_PROCESSED for the same callbackURL, calling
+// handleMessage in STUMP-then-BLOCK_PROCESSED order naturally delivers in
+// that order too. No in-process gate is required.
+func TestHandleMessage_StumpOrderingViaSamePartitionSerialization(t *testing.T) {
+	var mu sync.Mutex
+	var deliveries []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload callbackPayload
+		_ = json.Unmarshal(body, &payload)
+		mu.Lock()
+		deliveries = append(deliveries, payload.Type)
+		mu.Unlock()
+		// Simulate slow STUMP delivery to give a hypothetical concurrent
+		// BLOCK_PROCESSED a chance to race ahead. With sequential handler
+		// calls, there's no concurrency to exploit.
+		if payload.Type == "STUMP" {
+			time.Sleep(20 * time.Millisecond)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := defaultTestConfig()
+	ds, _, _, stumpStore := newTestDeliveryServiceWithStumps(t, cfg, server.Client())
+
+	url := server.URL + "/cb"
+	blk := "block-seq"
+	mustPut := func(b []byte) string {
+		ref, err := stumpStore.Put(b, 0)
+		if err != nil {
+			t.Fatalf("put stump: %v", err)
+		}
+		return ref
+	}
+	stumps := []*kafka.CallbackTopicMessage{
+		{CallbackURL: url, Type: kafka.CallbackStump, BlockHash: blk, SubtreeIndex: 0, StumpRef: mustPut([]byte{0x01})},
+		{CallbackURL: url, Type: kafka.CallbackStump, BlockHash: blk, SubtreeIndex: 1, StumpRef: mustPut([]byte{0x02})},
+		{CallbackURL: url, Type: kafka.CallbackStump, BlockHash: blk, SubtreeIndex: 2, StumpRef: mustPut([]byte{0x03})},
+	}
+	bp := &kafka.CallbackTopicMessage{CallbackURL: url, Type: kafka.CallbackBlockProcessed, BlockHash: blk}
+
+	// Drive the handler the way the consumer-group loop would: one message
+	// at a time, in partition order. Same callback URL → same partition,
+	// so BLOCK_PROCESSED follows the STUMPs.
+	for _, s := range stumps {
+		if err := ds.handleMessage(context.Background(), encodeConsumerMessage(t, s)); err != nil {
+			t.Fatalf("STUMP handleMessage failed: %v", err)
+		}
+	}
+	if err := ds.handleMessage(context.Background(), encodeConsumerMessage(t, bp)); err != nil {
+		t.Fatalf("BLOCK_PROCESSED handleMessage failed: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(deliveries) != 4 {
+		t.Fatalf("expected 4 deliveries, got %v", deliveries)
+	}
+	for i := 0; i < 3; i++ {
+		if deliveries[i] != "STUMP" {
+			t.Errorf("expected STUMP at position %d, got %q (full order: %v)", i, deliveries[i], deliveries)
+		}
+	}
+	if deliveries[3] != "BLOCK_PROCESSED" {
+		t.Errorf("expected BLOCK_PROCESSED last, got %q (full order: %v)", deliveries[3], deliveries)
+	}
+}
+
+// TestHandleMessage_CrashSimulationOffsetUncommitted is the unit-level
+// stand-in for the integration property that, on a real Kafka cluster, a
+// crash between consume and durable success would cause the offset to stay
+// uncommitted. We simulate the durable-side-effect failure (retry-publish
+// or DLQ-publish failing) and assert the handler returns non-nil — which
+// is what tells the consumer-group loop NOT to MarkMessage. On the next
+// session, the broker re-delivers the same record.
+func TestHandleMessage_CrashSimulationOffsetUncommitted(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cfg := defaultTestConfig()
+	ds, retryMock, _ := newTestDeliveryService(t, cfg, server.Client())
+	retryMock.failNext = 100 // simulate Kafka retry-publish unavailable
+
+	msg := &kafka.CallbackTopicMessage{
+		CallbackURL: server.URL + "/cb",
+		Type:        kafka.CallbackSeenOnNetwork,
+		TxID:        "tx-crash-sim",
+	}
+	if err := ds.handleMessage(context.Background(), encodeConsumerMessage(t, msg)); err == nil {
+		t.Fatal("expected handleMessage to return error so the consumer skips MarkMessage")
+	}
+
+	// Now simulate "next session": Kafka recovers and the same message is
+	// re-delivered. With the retry producer healthy, the handler should
+	// successfully republish and return nil — the durability contract is
+	// satisfied without losing the message.
+	retryMock.failNext = 0
+	if err := ds.handleMessage(context.Background(), encodeConsumerMessage(t, msg)); err != nil {
+		t.Fatalf("expected nil on re-delivery once retry producer recovers, got error: %v", err)
+	}
+	if got := len(retryMock.getMessages()); got != 1 {
+		t.Errorf("expected 1 successful retry republish on recovery, got %d", got)
+	}
+}

--- a/internal/callback/delivery_test.go
+++ b/internal/callback/delivery_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -25,11 +24,23 @@ import (
 type mockSyncProducer struct {
 	mu       sync.Mutex
 	messages []*sarama.ProducerMessage
+	// failNext, when > 0, makes the next N SendMessage calls fail with sendErr.
+	// Test-only knob for asserting the durability contract on publish failure.
+	failNext int
+	sendErr  error
 }
 
 func (m *mockSyncProducer) SendMessage(msg *sarama.ProducerMessage) (partition int32, offset int64, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.failNext > 0 {
+		m.failNext--
+		err := m.sendErr
+		if err == nil {
+			err = errMockSendFailure
+		}
+		return 0, 0, err
+	}
 	m.messages = append(m.messages, msg)
 	return 0, int64(len(m.messages)), nil
 }
@@ -49,9 +60,9 @@ func (m *mockSyncProducer) TxnStatus() sarama.ProducerTxnStatusFlag {
 	return sarama.ProducerTxnFlagReady
 }
 
-func (m *mockSyncProducer) BeginTxn() error   { return nil }
-func (m *mockSyncProducer) CommitTxn() error   { return nil }
-func (m *mockSyncProducer) AbortTxn() error    { return nil }
+func (m *mockSyncProducer) BeginTxn() error { return nil }
+func (m *mockSyncProducer) CommitTxn() error { return nil }
+func (m *mockSyncProducer) AbortTxn() error { return nil }
 func (m *mockSyncProducer) AddOffsetsToTxn(offsets map[string][]*sarama.PartitionOffsetMetadata, groupId string) error {
 	return nil
 }
@@ -66,6 +77,15 @@ func (m *mockSyncProducer) getMessages() []*sarama.ProducerMessage {
 	copy(result, m.messages)
 	return result
 }
+
+// errMockSendFailure is the default error returned by mockSyncProducer when
+// failNext is set and sendErr is nil — expressive enough for tests that just
+// want to assert the durability contract without crafting a custom error.
+var errMockSendFailure = mockSendError("mock send failure")
+
+type mockSendError string
+
+func (e mockSendError) Error() string { return string(e) }
 
 // decodePublishedCallbackMessage extracts the CallbackTopicMessage from a captured ProducerMessage.
 func decodePublishedCallbackMessage(t *testing.T, pm *sarama.ProducerMessage) *kafka.CallbackTopicMessage {
@@ -82,69 +102,37 @@ func decodePublishedCallbackMessage(t *testing.T, pm *sarama.ProducerMessage) *k
 }
 
 // newTestDeliveryService creates a DeliveryService wired with mock producers and a custom HTTP client.
-// The returned StumpStore is backed by an in-memory blob store — tests that
-// want to exercise STUMP delivery should Put bytes into it and reference them
-// via CallbackTopicMessage.StumpRef.
+// The returned tuple is (service, retryProducer mock, dlqProducer mock).
 func newTestDeliveryService(t *testing.T, cfg *config.Config, httpClient *http.Client) (*DeliveryService, *mockSyncProducer, *mockSyncProducer) {
 	ds, retry, dlq, _ := newTestDeliveryServiceWithStumps(t, cfg, httpClient)
 	return ds, retry, dlq
 }
 
 // newTestDeliveryServiceWithStumps returns a DeliveryService plus two
-// mockSyncProducers. The first return value is retained for backwards
-// compatibility with tests that still reference a "retry" producer mock, but
-// retries are now parked in-process rather than republished to Kafka — so
-// that mock should always observe zero messages. Tests that previously
-// asserted on retry-producer publishes have been updated to assert on
-// DeliveryService counters / message mutation instead.
+// mockSyncProducers (retry, dlq) and a StumpStore. The retry producer is the
+// one used by handleMessage to republish not-yet-delivered messages back to
+// the callback topic — it is the durable side-effect that has to succeed
+// before handleMessage returns nil.
 func newTestDeliveryServiceWithStumps(t *testing.T, cfg *config.Config, httpClient *http.Client) (*DeliveryService, *mockSyncProducer, *mockSyncProducer, store.StumpStore) {
 	t.Helper()
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	unusedRetryProducer := &mockSyncProducer{}
+	mockRetryProducer := &mockSyncProducer{}
 	mockDLQProducer := &mockSyncProducer{}
 	stumpStore := store.NewStumpStore(store.NewMemoryBlobStore(), 0, logger)
 
 	ds := &DeliveryService{
-		cfg:         cfg,
-		httpClient:  httpClient,
-		dlqProducer: kafka.NewTestProducer(mockDLQProducer, cfg.Kafka.CallbackDLQTopic, logger),
-		stumpStore:  stumpStore,
-		workCh:      make(chan *kafka.CallbackTopicMessage, 64),
-		stumpGate:   newStumpGate(),
+		cfg:           cfg,
+		httpClient:    httpClient,
+		dlqProducer:   kafka.NewTestProducer(mockDLQProducer, cfg.Kafka.CallbackDLQTopic, logger),
+		retryProducer: kafka.NewTestProducer(mockRetryProducer, cfg.Kafka.CallbackTopic, logger),
+		stumpStore:    stumpStore,
 	}
 	ds.InitBase("callback-delivery-test")
 	ds.Logger = logger
 
-	// Start workers for handleMessage dispatch.
-	workers := 4
-	ds.workerWg.Add(workers)
-	for i := 0; i < workers; i++ {
-		go ds.deliveryWorker(context.Background())
-	}
-
-	t.Cleanup(func() {
-		ds.shuttingDown.Store(true)
-		ds.retryTimerWg.Wait()
-		close(ds.workCh)
-		ds.workerWg.Wait()
-	})
-
-	return ds, unusedRetryProducer, mockDLQProducer, stumpStore
-}
-
-// waitForCondition polls until condition returns true or timeout expires.
-func waitForCondition(t *testing.T, timeout time.Duration, condition func() bool) {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if condition() {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	t.Fatal("timed out waiting for condition")
+	return ds, mockRetryProducer, mockDLQProducer, stumpStore
 }
 
 // defaultTestConfig returns a config suitable for testing.
@@ -334,7 +322,12 @@ func TestDeliverCallback_2xxStatusesSucceed(t *testing.T) {
 	}
 }
 
-func TestProcessDelivery_RetriesOnFailure(t *testing.T) {
+// TestProcessDelivery_RetriesViaKafkaRepublish asserts that an HTTP failure
+// with retries available causes the message to be republished to the
+// callback topic (the durable side-effect) before processDelivery returns
+// nil. The original behaviour parked retries in a time.AfterFunc — that's
+// what F-021 is fixing.
+func TestProcessDelivery_RetriesViaKafkaRepublish(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
@@ -351,22 +344,56 @@ func TestProcessDelivery_RetriesOnFailure(t *testing.T) {
 		RetryCount:   0,
 	}
 
-	ds.processDelivery(context.Background(), msg)
+	if err := ds.processDelivery(context.Background(), msg); err != nil {
+		t.Fatalf("processDelivery returned error: %v", err)
+	}
 
-	// Retries are parked in-process now — Kafka is not touched for a
-	// not-yet-exhausted retry. The message itself is mutated in-place with
-	// the bumped RetryCount and the scheduled NextRetryAt.
-	if got := len(retryMock.getMessages()); got != 0 {
-		t.Errorf("expected 0 Kafka retry publishes (retries are parked in-process), got %d", got)
+	retryMsgs := retryMock.getMessages()
+	if len(retryMsgs) != 1 {
+		t.Fatalf("expected 1 retry republish, got %d", len(retryMsgs))
 	}
-	if msg.RetryCount != 1 {
-		t.Errorf("expected retry count 1 on in-place msg, got %d", msg.RetryCount)
+	republished := decodePublishedCallbackMessage(t, retryMsgs[0])
+	if republished.RetryCount != 1 {
+		t.Errorf("expected republished RetryCount=1, got %d", republished.RetryCount)
 	}
-	if msg.NextRetryAt.IsZero() {
-		t.Error("expected NextRetryAt to be set on in-place msg")
+	if republished.NextRetryAt.IsZero() {
+		t.Error("expected republished NextRetryAt to be set")
 	}
 	if ds.messagesRetried.Load() != 1 {
 		t.Errorf("expected messagesRetried=1, got %d", ds.messagesRetried.Load())
+	}
+}
+
+// TestProcessDelivery_RetryRepublishFailureSurfacesError ensures that when
+// the durable side-effect (retry republish) fails, processDelivery returns a
+// non-nil error so the caller (handleMessage → consumer-group loop) leaves
+// the Kafka offset uncommitted. This is the core F-021 contract.
+func TestProcessDelivery_RetryRepublishFailureSurfacesError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cfg := defaultTestConfig()
+	ds, retryMock, _ := newTestDeliveryService(t, cfg, server.Client())
+	retryMock.failNext = 1 // first retry republish fails
+
+	msg := &kafka.CallbackTopicMessage{
+		CallbackURL:  server.URL + "/callback",
+		Type:         kafka.CallbackStump,
+		BlockHash:    "blockhash",
+		SubtreeIndex: 1,
+	}
+
+	err := ds.processDelivery(context.Background(), msg)
+	if err == nil {
+		t.Fatal("expected error from processDelivery when retry republish fails")
+	}
+	if got := len(retryMock.getMessages()); got != 0 {
+		t.Errorf("expected 0 retry messages captured (mock failed), got %d", got)
+	}
+	if ds.messagesRetried.Load() != 0 {
+		t.Errorf("expected messagesRetried=0 when republish fails, got %d", ds.messagesRetried.Load())
 	}
 }
 
@@ -388,18 +415,56 @@ func TestProcessDelivery_PublishesToDLQAfterMaxRetries(t *testing.T) {
 		RetryCount:   3, // Already at max retries.
 	}
 
-	ds.processDelivery(context.Background(), msg)
+	if err := ds.processDelivery(context.Background(), msg); err != nil {
+		t.Fatalf("processDelivery returned error: %v", err)
+	}
 
-	// No retry should happen.
 	retryMsgs := retryMock.getMessages()
 	if len(retryMsgs) != 0 {
 		t.Errorf("expected 0 retry messages after max retries, got %d", len(retryMsgs))
 	}
 
-	// Should be published to DLQ.
 	dlqMsgs := dlqMock.getMessages()
 	if len(dlqMsgs) != 1 {
 		t.Fatalf("expected 1 DLQ message, got %d", len(dlqMsgs))
+	}
+	if ds.messagesFailed.Load() != 1 {
+		t.Errorf("expected messagesFailed=1, got %d", ds.messagesFailed.Load())
+	}
+}
+
+// TestProcessDelivery_DLQPublishFailureSurfacesError asserts that when the
+// DLQ publish exhausts its in-call retries, processDelivery returns a
+// non-nil error so the offset stays put — preferring redelivery on next
+// session over silent loss.
+func TestProcessDelivery_DLQPublishFailureSurfacesError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cfg := defaultTestConfig()
+	cfg.Callback.MaxRetries = 0 // any failure goes straight to DLQ
+	ds, _, dlqMock := newTestDeliveryService(t, cfg, server.Client())
+	dlqMock.failNext = 100 // fail every DLQ attempt within the in-call retry budget
+
+	msg := &kafka.CallbackTopicMessage{
+		CallbackURL:  server.URL + "/callback",
+		Type:         kafka.CallbackStump,
+		BlockHash:    "blockhash",
+		SubtreeIndex: 1,
+	}
+
+	start := time.Now()
+	err := ds.processDelivery(context.Background(), msg)
+	if err == nil {
+		t.Fatal("expected error from processDelivery when DLQ publish fails")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("DLQ retries took too long: %v", elapsed)
+	}
+	if ds.messagesFailed.Load() != 0 {
+		t.Errorf("expected messagesFailed=0 when DLQ publish never succeeded, got %d", ds.messagesFailed.Load())
 	}
 }
 
@@ -426,7 +491,9 @@ func TestProcessDelivery_MissingStumpBlobGoesStraightToDLQ(t *testing.T) {
 		RetryCount:   0,
 	}
 
-	ds.processDelivery(context.Background(), msg)
+	if err := ds.processDelivery(context.Background(), msg); err != nil {
+		t.Fatalf("processDelivery returned error: %v", err)
+	}
 
 	if got := len(retryMock.getMessages()); got != 0 {
 		t.Errorf("expected 0 retry messages for missing blob, got %d", got)
@@ -455,7 +522,9 @@ func TestProcessDelivery_SuccessIncrementsCounter(t *testing.T) {
 		TxID:        "tx-counter",
 	}
 
-	ds.processDelivery(context.Background(), msg)
+	if err := ds.processDelivery(context.Background(), msg); err != nil {
+		t.Fatalf("processDelivery returned error: %v", err)
+	}
 
 	if ds.messagesProcessed.Load() != 1 {
 		t.Errorf("expected messagesProcessed=1, got %d", ds.messagesProcessed.Load())
@@ -481,103 +550,15 @@ func TestProcessDelivery_DedupSkipsDuplicate(t *testing.T) {
 		SubtreeIndex: 3,
 	}
 
-	ds.processDelivery(context.Background(), msg)
+	if err := ds.processDelivery(context.Background(), msg); err != nil {
+		t.Fatalf("processDelivery returned error: %v", err)
+	}
 
 	if requestCount.Load() != 0 {
 		t.Errorf("expected no HTTP requests for dedup hit, got %d", requestCount.Load())
 	}
 	if ds.messagesDedupe.Load() != 1 {
 		t.Errorf("expected messagesDedupe=1, got %d", ds.messagesDedupe.Load())
-	}
-}
-
-func TestHandleMessage_DispatchesToWorker(t *testing.T) {
-	cfg := defaultTestConfig()
-	ds, _, _ := newTestDeliveryService(t, cfg, &http.Client{Timeout: time.Second})
-
-	var delivered atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		delivered.Add(1)
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-	ds.httpClient = server.Client()
-
-	msg := &kafka.CallbackTopicMessage{
-		CallbackURL: server.URL + "/callback",
-		Type:        kafka.CallbackSeenOnNetwork,
-		TxID:        "tx-dispatch",
-	}
-	data, err := msg.Encode()
-	if err != nil {
-		t.Fatalf("encode failed: %v", err)
-	}
-
-	consumerMsg := &sarama.ConsumerMessage{
-		Value: data,
-	}
-
-	if err := ds.handleMessage(context.Background(), consumerMsg); err != nil {
-		t.Fatalf("handleMessage failed: %v", err)
-	}
-
-	waitForCondition(t, 2*time.Second, func() bool {
-		return delivered.Load() > 0
-	})
-}
-
-func TestHandleMessage_ParksRetryInProcess(t *testing.T) {
-	cfg := defaultTestConfig()
-	ds, retryMock, _ := newTestDeliveryService(t, cfg, &http.Client{Timeout: time.Second})
-
-	var delivered atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		delivered.Add(1)
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-	ds.httpClient = server.Client()
-
-	delay := 200 * time.Millisecond
-	msg := &kafka.CallbackTopicMessage{
-		CallbackURL: server.URL + "/callback",
-		Type:        kafka.CallbackSeenOnNetwork,
-		TxID:        "tx-parked",
-		RetryCount:  1,
-		NextRetryAt: time.Now().Add(delay),
-	}
-	data, err := msg.Encode()
-	if err != nil {
-		t.Fatalf("encode failed: %v", err)
-	}
-
-	start := time.Now()
-	if err := ds.handleMessage(context.Background(), &sarama.ConsumerMessage{Value: data}); err != nil {
-		t.Fatalf("handleMessage failed: %v", err)
-	}
-
-	// Immediately after handleMessage: message should be parked, nothing
-	// published to Kafka, no HTTP delivery yet.
-	if got := len(retryMock.getMessages()); got != 0 {
-		t.Errorf("expected 0 retry-producer publishes while parked, got %d", got)
-	}
-	if got := ds.messagesParked.Load(); got != 1 {
-		t.Errorf("expected messagesParked=1 while parked, got %d", got)
-	}
-	if delivered.Load() != 0 {
-		t.Errorf("expected 0 HTTP deliveries before delay elapses, got %d", delivered.Load())
-	}
-
-	// After the delay, the worker should pick the message off workCh and
-	// deliver it.
-	waitForCondition(t, 2*time.Second, func() bool {
-		return delivered.Load() > 0
-	})
-	if elapsed := time.Since(start); elapsed < delay {
-		t.Errorf("delivery fired before scheduled delay: elapsed %v < delay %v", elapsed, delay)
-	}
-	if got := len(retryMock.getMessages()); got != 0 {
-		t.Errorf("expected 0 retry-producer publishes after worker ran, got %d", got)
 	}
 }
 
@@ -738,136 +719,6 @@ func TestDeliverCallback_BlockProcessedPayload(t *testing.T) {
 	if payload.TxID != "" {
 		t.Errorf("expected empty txid, got %q", payload.TxID)
 	}
-}
-
-func TestConcurrentDelivery(t *testing.T) {
-	var deliveryCount atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		deliveryCount.Add(1)
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	cfg := defaultTestConfig()
-	ds, _, _ := newTestDeliveryService(t, cfg, server.Client())
-	ds.httpClient = server.Client()
-
-	// Dispatch multiple messages.
-	for i := 0; i < 10; i++ {
-		msg := &kafka.CallbackTopicMessage{
-			CallbackURL: server.URL + "/callback",
-			Type:        kafka.CallbackSeenOnNetwork,
-			TxID:        fmt.Sprintf("tx-%d", i),
-		}
-		ds.workCh <- msg
-	}
-
-	waitForCondition(t, 5*time.Second, func() bool {
-		return deliveryCount.Load() >= 10
-	})
-
-	if deliveryCount.Load() != 10 {
-		t.Errorf("expected 10 deliveries, got %d", deliveryCount.Load())
-	}
-}
-
-func TestBlockProcessedWaitsForStumps(t *testing.T) {
-	// Track delivery order to verify STUMPs arrive before BLOCK_PROCESSED.
-	var mu sync.Mutex
-	var deliveryOrder []string
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
-		var payload callbackPayload
-		_ = json.Unmarshal(body, &payload)
-
-		mu.Lock()
-		deliveryOrder = append(deliveryOrder, payload.Type)
-		mu.Unlock()
-
-		// Simulate slow STUMP delivery so BLOCK_PROCESSED has a chance to race ahead.
-		if payload.Type == "STUMP" {
-			time.Sleep(50 * time.Millisecond)
-		}
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	cfg := defaultTestConfig()
-	ds, _, _, stumpStore := newTestDeliveryServiceWithStumps(t, cfg, server.Client())
-
-	callbackURL := server.URL + "/callback"
-	blockHash := "block-gate-test"
-
-	mustPutStump := func(b []byte) string {
-		ref, err := stumpStore.Put(b, 0)
-		if err != nil {
-			t.Fatalf("failed to put stump: %v", err)
-		}
-		return ref
-	}
-
-	// Simulate handleMessage ordering: register STUMPs with the gate, then dispatch all.
-	stumps := []*kafka.CallbackTopicMessage{
-		{CallbackURL: callbackURL, Type: kafka.CallbackStump, BlockHash: blockHash, SubtreeIndex: 0, StumpRef: mustPutStump([]byte{0x01})},
-		{CallbackURL: callbackURL, Type: kafka.CallbackStump, BlockHash: blockHash, SubtreeIndex: 1, StumpRef: mustPutStump([]byte{0x02})},
-		{CallbackURL: callbackURL, Type: kafka.CallbackStump, BlockHash: blockHash, SubtreeIndex: 2, StumpRef: mustPutStump([]byte{0x03})},
-	}
-	bp := &kafka.CallbackTopicMessage{CallbackURL: callbackURL, Type: kafka.CallbackBlockProcessed, BlockHash: blockHash}
-
-	// Register STUMPs with the gate (simulates handleMessage sequential dispatch).
-	for _, msg := range stumps {
-		ds.stumpGate.Add(msg.BlockHash, msg.CallbackURL)
-	}
-
-	// Dispatch BLOCK_PROCESSED first to the worker pool to maximize race opportunity.
-	ds.workCh <- bp
-	for _, msg := range stumps {
-		ds.workCh <- msg
-	}
-
-	waitForCondition(t, 5*time.Second, func() bool {
-		mu.Lock()
-		defer mu.Unlock()
-		return len(deliveryOrder) == 4
-	})
-
-	mu.Lock()
-	defer mu.Unlock()
-
-	// BLOCK_PROCESSED must be last.
-	if deliveryOrder[len(deliveryOrder)-1] != "BLOCK_PROCESSED" {
-		t.Errorf("expected BLOCK_PROCESSED last, got delivery order: %v", deliveryOrder)
-	}
-	for i := 0; i < 3; i++ {
-		if deliveryOrder[i] != "STUMP" {
-			t.Errorf("expected STUMP at position %d, got %q (order: %v)", i, deliveryOrder[i], deliveryOrder)
-		}
-	}
-}
-
-func TestBlockProcessedProceedsWithoutStumps(t *testing.T) {
-	var delivered atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		delivered.Add(1)
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	cfg := defaultTestConfig()
-	ds, _, _ := newTestDeliveryService(t, cfg, server.Client())
-
-	// Dispatch BLOCK_PROCESSED with no prior STUMPs — should proceed immediately.
-	msg := &kafka.CallbackTopicMessage{
-		CallbackURL: server.URL + "/callback",
-		Type:        kafka.CallbackBlockProcessed,
-		BlockHash:   "block-no-stumps",
-	}
-	ds.workCh <- msg
-
-	waitForCondition(t, 2*time.Second, func() bool {
-		return delivered.Load() == 1
-	})
 }
 
 // mockDedupStore implements CallbackDeduper for testing.


### PR DESCRIPTION
## Summary
- `handleMessage` now returns nil only after reaching a durable terminal state (HTTP success + dedup recorded, retry republished to Kafka, or DLQ publish succeeded). Transient failures of the durable step return non-nil so the offset stays uncommitted and the message is re-delivered on the next consumer-group session.
- Approach **B** (synchronous handler + Kafka-republish for retry): retries flow through the callback topic itself instead of in-process `time.AfterFunc` timers. A `retryProducer` field was added on `DeliveryService`; the callback URL is the partition key so a republished retry lands on the same partition as the original (preserving STUMP → BLOCK_PROCESSED ordering).
- For not-yet-due retries the handler waits in-process for up to `futureRetryWaitCap` (2s) and then either delivers (small delay) or republishes the message back to the topic with `NextRetryAt` preserved (large delay). The 2s cap bounds the consume/republish cadence — Kafka isn't spammed at partition speed — and stays well below Sarama's default 10s session timeout.
- Removed the in-process worker pool (`workCh`, `deliveryWorker`, `workerWg`), the `time.AfterFunc` retry scheduler (`scheduleRetry`, `scheduleRetryAfterFailure`, `messagesParked`, `shuttingDown`, `retryTimerWg`) and the `stumpGate` primitive. STUMP-before-BLOCK_PROCESSED ordering is now provided implicitly by same-partition serialization in the consumer-group loop.
- `delivery_test.go` updated for the new contract. New `delivery_handle_message_test.go` adds direct coverage of the durability invariants: happy path, retry-republish, retries-exhausted DLQ, retry-republish failure surfaces error, DLQ-publish failure surfaces error, future-dated short and long delay, permanent-error DLQ, poison-pill ack, STUMP ordering via serialization, and a crash-simulation that exercises the "next-session re-delivery" recovery path.

Closes #5

## Design note for reviewer
The previous comment at the old `delivery.go:343-350` defended the in-memory retry on the grounds that "dedup prevents double-delivery on re-drive from upstream". That defence has a gap: once a callback topic message is consumed and acked, **nothing upstream republishes it** — `subtree-worker` and `block-processor` only republish their own work items (subtrees / blocks) on retry; they do not re-emit downstream callback messages. So an in-memory retry that's lost on crash is permanently lost. The new behaviour aligns with the standard Kafka "process before ack" pattern.

## Throughput / behaviour notes
- Per-partition throughput is now bounded by callback HTTP latency (was: unbounded inside the in-process worker pool). Operators wanting more parallelism scale the callback topic's partition count and/or run more `callback-delivery` consumer instances.
- A scheduled retry that's still far in the future causes a single consume → wait 2s → republish cycle per consumer per message. With many parked retries on the same partition this is a measurable but bounded extra Kafka write rate; acceptable in exchange for durability.
- `messagesParked` was removed from the Health-detail map (the concept no longer exists). External dashboards keying on it will need to drop the field.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/callback/... -count=1 -race`
- [x] `go test ./...` (full suite passes)
- [ ] Reviewer sanity check on the ordering with same-partition serialization (no more `stumpGate`).
- [ ] Reviewer to consider whether throughput regression vs. the in-process worker pool is acceptable, or whether partition count should be bumped in deployment configs.