### PR TITLE
fix(p2p): exit on Kafka publish exhaustion instead of dropping announcements (#7)

### DIFF
--- a/cmd/p2p-client/main.go
+++ b/cmd/p2p-client/main.go
@@ -3,17 +3,34 @@ package main
 import (
 	"context"
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
 	"github.com/bsv-blockchain/merkle-service/internal/config"
 	"github.com/bsv-blockchain/merkle-service/internal/kafka"
 	"github.com/bsv-blockchain/merkle-service/internal/p2p"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
 )
 
+// exit is overridable so tests can assert on the status code without
+// terminating the test process.
+var exit = os.Exit
+
 func main() {
+	if err := run(); err != nil {
+		log.Printf("p2p-client terminating with error: %v", err)
+		exit(1)
+		return
+	}
+	exit(0)
+}
+
+func run() error {
 	// Load configuration.
 	cfg, err := config.Load()
 	if err != nil {
-		log.Fatal("failed to load config: ", err)
+		return err
 	}
 
 	logger := service.NewLogger(config.ParseLogLevel(cfg.LogLevel))
@@ -21,13 +38,13 @@ func main() {
 	// Create Kafka producers for subtree and block topics.
 	subtreeProducer, err := kafka.NewProducer(cfg.Kafka.Brokers, cfg.Kafka.SubtreeTopic, logger)
 	if err != nil {
-		log.Fatal("failed to create subtree producer: ", err)
+		return err
 	}
 	defer subtreeProducer.Close()
 
 	blockProducer, err := kafka.NewProducer(cfg.Kafka.Brokers, cfg.Kafka.BlockTopic, logger)
 	if err != nil {
-		log.Fatal("failed to create block producer: ", err)
+		return err
 	}
 	defer blockProducer.Close()
 
@@ -35,20 +52,20 @@ func main() {
 	client := p2p.NewClient(cfg.P2P, subtreeProducer, blockProducer, logger)
 
 	if err := client.Init(nil); err != nil {
-		log.Fatal("failed to init p2p client: ", err)
+		return err
 	}
 
-	ctx := context.Background()
-	if err := client.Start(ctx); err != nil {
-		log.Fatal("failed to start p2p client: ", err)
-	}
+	// Translate SIGTERM/SIGINT into a context cancel so the supervisor can
+	// shut us down cleanly. A terminal error from Run (e.g. exhausted Kafka
+	// publish retries) is propagated up so the process exits non-zero and
+	// the orchestrator (k8s/Docker/systemd) restarts the pod from a fresh
+	// P2P session.
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer cancel()
 
-	// Wait for shutdown signal.
-	var base service.BaseService
-	base.InitBase("p2p-client")
-	base.WaitForShutdown(ctx)
-
-	if err := client.Stop(); err != nil {
-		logger.Error("failed to stop p2p client", "error", err)
+	runErr := client.Run(ctx)
+	if stopErr := client.Stop(); stopErr != nil {
+		logger.Error("failed to stop p2p client", "error", stopErr)
 	}
+	return runErr
 }

--- a/cmd/p2p-client/main_test.go
+++ b/cmd/p2p-client/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"testing"
+)
+
+// TestExitHook verifies that the exit hook is overridable. Issue #7 relies on
+// the entrypoint exiting non-zero when client.Run returns a terminal error
+// (e.g. ErrPublishExhausted) so the orchestrator can restart the pod. We can't
+// exercise the full main() in-process because it needs Kafka brokers and a
+// libp2p host, but verifying the indirection point keeps that contract honest.
+func TestExitHook_IsOverridable(t *testing.T) {
+	original := exit
+	t.Cleanup(func() { exit = original })
+
+	captured := -1
+	exit = func(code int) { captured = code }
+
+	exit(1)
+	if captured != 1 {
+		t.Fatalf("expected captured exit code 1, got %d", captured)
+	}
+
+	exit(0)
+	if captured != 0 {
+		t.Fatalf("expected captured exit code 0, got %d", captured)
+	}
+}

--- a/internal/p2p/client.go
+++ b/internal/p2p/client.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -19,9 +20,23 @@ import (
 const (
 	// maxPublishRetries is the maximum number of retries for Kafka publish failures.
 	maxPublishRetries = 5
-	// baseRetryDelay is the initial delay between publish retries.
-	baseRetryDelay = 500 * time.Millisecond
+	// defaultBaseRetryDelay is the initial delay between publish retries.
+	defaultBaseRetryDelay = 500 * time.Millisecond
 )
+
+// baseRetryDelay is the initial delay between publish retries. It is a var
+// (rather than a const) so tests can shrink it; production code should not
+// reassign it.
+var baseRetryDelay = defaultBaseRetryDelay
+
+// ErrPublishExhausted is returned by the publish helper when all Kafka publish
+// retries have been exhausted. It is treated as a terminal/fatal condition by
+// the P2P client: the announcement cannot be re-observed from the network
+// (peers are unlikely to re-broadcast one-shot subtree gossip), so the process
+// exits non-zero and relies on the orchestrator (Kubernetes restartPolicy:
+// Always, Docker restart: always, systemd, etc.) to restart the pod and
+// re-establish a fresh P2P session against a recovered Kafka.
+var ErrPublishExhausted = errors.New("kafka publish retries exhausted")
 
 // Client is a P2P client service that connects to the Teranode P2P network
 // via go-teranode-p2p-client, subscribes to subtree and block topics, and publishes
@@ -38,6 +53,12 @@ type Client struct {
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 
+	// fatalErr is signalled (non-blocking, buffered=1) when a publish loop hits
+	// a terminal condition (e.g. ErrPublishExhausted). Run reads from it to
+	// propagate the failure to the caller, which is expected to exit the
+	// process so an orchestrator-managed restart can re-establish state.
+	fatalErr chan error
+
 	mu        sync.RWMutex
 	connected bool
 }
@@ -53,6 +74,7 @@ func NewClient(
 		cfg:             cfg,
 		subtreeProducer: subtreeProducer,
 		blockProducer:   blockProducer,
+		fatalErr:        make(chan error, 1),
 	}
 	c.InitBase("p2p-client")
 	if logger != nil {
@@ -129,6 +151,48 @@ func (c *Client) Start(ctx context.Context) error {
 
 	c.Logger.Info("p2p client started")
 	return nil
+}
+
+// Run starts the client (if it has not already been started) and blocks until
+// either the supplied context is cancelled or a terminal/fatal error is
+// signalled by the publish path (e.g. ErrPublishExhausted).
+//
+// On terminal error the returned error is non-nil; callers (typically a
+// process entry point) should log it and exit the process with a non-zero
+// status so the orchestrator restarts the pod. A clean context cancellation
+// returns nil.
+func (c *Client) Run(ctx context.Context) error {
+	if !c.IsStarted() {
+		if err := c.Start(ctx); err != nil {
+			return err
+		}
+	}
+
+	select {
+	case err := <-c.fatalErr:
+		c.Logger.Error("p2p client terminating due to fatal error", "error", err)
+		return err
+	case <-ctx.Done():
+		return nil
+	}
+}
+
+// signalFatal records a terminal error and cancels the client's internal
+// context so processing goroutines unwind. Only the first terminal error is
+// reported to Run; subsequent calls are best-effort no-ops.
+func (c *Client) signalFatal(err error) {
+	if err == nil {
+		return
+	}
+	select {
+	case c.fatalErr <- err:
+	default:
+		// A fatal error has already been reported; drop the duplicate but
+		// still ensure the context is cancelled.
+	}
+	if c.cancel != nil {
+		c.cancel()
+	}
 }
 
 // Stop gracefully shuts down the P2P client, closing the message bus and
@@ -213,7 +277,10 @@ func (c *Client) processSubtreeMessages(ctx context.Context, ch <-chan teranode.
 				c.Logger.Info("subtree message channel closed")
 				return
 			}
-			c.handleSubtreeMessage(msg)
+			if err := c.handleSubtreeMessage(ctx, msg); err != nil {
+				c.signalFatal(err)
+				return
+			}
 		case <-ctx.Done():
 			c.Logger.Info("subtree message loop exiting: context cancelled")
 			return
@@ -234,7 +301,10 @@ func (c *Client) processBlockMessages(ctx context.Context, ch <-chan teranode.Bl
 				c.Logger.Info("block message channel closed")
 				return
 			}
-			c.handleBlockMessage(msg)
+			if err := c.handleBlockMessage(ctx, msg); err != nil {
+				c.signalFatal(err)
+				return
+			}
 		case <-ctx.Done():
 			c.Logger.Info("block message loop exiting: context cancelled")
 			return
@@ -243,7 +313,11 @@ func (c *Client) processBlockMessages(ctx context.Context, ch <-chan teranode.Bl
 }
 
 // handleSubtreeMessage maps a teranode SubtreeMessage to a Kafka SubtreeMessage and publishes it.
-func (c *Client) handleSubtreeMessage(msg teranode.SubtreeMessage) {
+//
+// Returns a non-nil error only for terminal/fatal conditions (currently
+// ErrPublishExhausted). Encoding errors and transient publish errors are
+// logged and swallowed so the loop can continue on subsequent messages.
+func (c *Client) handleSubtreeMessage(ctx context.Context, msg teranode.SubtreeMessage) error {
 	c.Logger.Debug("received subtree announcement",
 		"hash", msg.Hash,
 		"dataHubUrl", msg.DataHubURL,
@@ -262,14 +336,18 @@ func (c *Client) handleSubtreeMessage(msg teranode.SubtreeMessage) {
 			"hash", msg.Hash,
 			"error", err,
 		)
-		return
+		return nil
 	}
 
-	c.publishWithRetry(c.subtreeProducer, msg.Hash, encoded, "subtree")
+	return c.publishWithRetry(ctx, c.subtreeProducer, msg.Hash, encoded, "subtree")
 }
 
 // handleBlockMessage maps a teranode BlockMessage to a Kafka BlockMessage and publishes it.
-func (c *Client) handleBlockMessage(msg teranode.BlockMessage) {
+//
+// Returns a non-nil error only for terminal/fatal conditions (currently
+// ErrPublishExhausted). Encoding errors and transient publish errors are
+// logged and swallowed so the loop can continue on subsequent messages.
+func (c *Client) handleBlockMessage(ctx context.Context, msg teranode.BlockMessage) error {
 	c.Logger.Debug("received block announcement",
 		"hash", msg.Hash,
 		"height", msg.Height,
@@ -292,20 +370,32 @@ func (c *Client) handleBlockMessage(msg teranode.BlockMessage) {
 			"hash", msg.Hash,
 			"error", err,
 		)
-		return
+		return nil
 	}
 
-	c.publishWithRetry(c.blockProducer, msg.Hash, encoded, "block")
+	return c.publishWithRetry(ctx, c.blockProducer, msg.Hash, encoded, "block")
 }
 
-// publishWithRetry attempts to publish a message to Kafka with exponential backoff retries.
-func (c *Client) publishWithRetry(producer *kafka.Producer, key string, value []byte, msgType string) {
+// publishWithRetry attempts to publish a message to Kafka with exponential
+// backoff retries.
+//
+// Returns ErrPublishExhausted (wrapped) if all attempts fail. Callers are
+// expected to treat this as a terminal/fatal condition: the announcement
+// cannot be reconstructed from the network (peers are unlikely to re-broadcast
+// one-shot subtree gossip and there is no on-disk outbox), so silently
+// continuing would cause permanent loss of network observations the longer a
+// Kafka outage lasts. Instead, the client signals shutdown to its supervisor
+// (see Client.Run) which exits non-zero so the process orchestrator can
+// restart the pod from a fresh, durable P2P session.
+//
+// A nil return means the message was successfully published.
+func (c *Client) publishWithRetry(ctx context.Context, producer *kafka.Producer, key string, value []byte, msgType string) error {
 	delay := baseRetryDelay
 
 	for attempt := 1; attempt <= maxPublishRetries; attempt++ {
 		err := producer.Publish(key, value)
 		if err == nil {
-			return
+			return nil
 		}
 
 		c.Logger.Error("kafka publish failed",
@@ -317,17 +407,24 @@ func (c *Client) publishWithRetry(producer *kafka.Producer, key string, value []
 		)
 
 		if attempt == maxPublishRetries {
-			c.Logger.Error("kafka publish exhausted all retries, message dropped",
+			c.Logger.Error("kafka publish exhausted all retries, signalling fatal shutdown",
 				"type", msgType,
 				"key", key,
 				"valueLen", len(value),
 			)
-			return
+			return fmt.Errorf("%w: type=%s key=%s: %v", ErrPublishExhausted, msgType, key, err)
 		}
 
-		time.Sleep(delay)
+		select {
+		case <-ctx.Done():
+			// Treat shutdown during retry as non-fatal; the supervising
+			// process is already tearing things down.
+			return nil
+		case <-time.After(delay):
+		}
 		delay = time.Duration(math.Min(float64(delay)*2, float64(10*time.Second)))
 	}
+	return nil
 }
 
 // setConnected updates the connected state in a thread-safe manner.

--- a/internal/p2p/client_test.go
+++ b/internal/p2p/client_test.go
@@ -1,10 +1,13 @@
 package p2p
 
 import (
+	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/IBM/sarama"
 	teranode "github.com/bsv-blockchain/teranode/services/p2p"
@@ -96,7 +99,9 @@ func TestHandleSubtreeMessage_ValidMessage(t *testing.T) {
 		ClientName: "teranode-v1",
 	}
 
-	client.handleSubtreeMessage(msg)
+	if err := client.handleSubtreeMessage(context.Background(), msg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	published := mockProducer.getMessages()
 	if len(published) != 1 {
@@ -140,7 +145,9 @@ func TestHandleSubtreeMessage_EmptyHash(t *testing.T) {
 		DataHubURL: "https://datahub.example.com/subtree/empty",
 	}
 
-	client.handleSubtreeMessage(msg)
+	if err := client.handleSubtreeMessage(context.Background(), msg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	// Should still publish (empty hash is valid from the P2P layer perspective).
 	published := mockProducer.getMessages()
@@ -164,7 +171,9 @@ func TestHandleBlockMessage_ValidMessage(t *testing.T) {
 		ClientName: "teranode-v1",
 	}
 
-	client.handleBlockMessage(msg)
+	if err := client.handleBlockMessage(context.Background(), msg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	published := mockProducer.getMessages()
 	if len(published) != 1 {
@@ -214,7 +223,9 @@ func TestHandleBlockMessage_ZeroHeight(t *testing.T) {
 		Height: 0,
 	}
 
-	client.handleBlockMessage(msg)
+	if err := client.handleBlockMessage(context.Background(), msg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	published := mockProducer.getMessages()
 	if len(published) != 1 {
@@ -367,7 +378,9 @@ func TestHandleSubtreeMessage_MultipleMessages(t *testing.T) {
 			Hash:       hash,
 			DataHubURL: "https://datahub.example.com/subtree/" + hash,
 		}
-		client.handleSubtreeMessage(msg)
+		if err := client.handleSubtreeMessage(context.Background(), msg); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 	}
 
 	published := mockProducer.getMessages()
@@ -395,11 +408,199 @@ func TestHandleBlockMessage_MultipleMessages(t *testing.T) {
 			Hash:   hash,
 			Height: uint32(i + 100),
 		}
-		client.handleBlockMessage(msg)
+		if err := client.handleBlockMessage(context.Background(), msg); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 	}
 
 	published := mockProducer.getMessages()
 	if len(published) != 2 {
 		t.Fatalf("expected 2 published messages, got %d", len(published))
 	}
+}
+
+// --- Publish-exhaustion / fatal-propagation tests (issue #7) ---
+
+// withFastRetries swaps the package-level baseRetryDelay to something tiny so
+// publish-failure paths complete quickly under -race. The original value is
+// restored when the test ends.
+func withFastRetries(t *testing.T) {
+	t.Helper()
+	prev := baseRetryDelay
+	baseRetryDelay = time.Millisecond
+	t.Cleanup(func() { baseRetryDelay = prev })
+}
+
+// TestPublishWithRetry_ExhaustionReturnsTerminalError verifies F-033: when the
+// Kafka producer returns an error on every attempt, publishWithRetry must
+// return ErrPublishExhausted instead of silently dropping the announcement.
+func TestPublishWithRetry_ExhaustionReturnsTerminalError(t *testing.T) {
+	withFastRetries(t)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	mockProducer := &mockSyncProducer{failErr: errors.New("simulated kafka outage")}
+	producer := kafka.NewTestProducer(mockProducer, "subtree", logger)
+
+	client := NewClient(config.P2PConfig{}, producer, producer, logger)
+
+	err := client.publishWithRetry(context.Background(), producer, "hash-x", []byte("payload"), "subtree")
+	if err == nil {
+		t.Fatal("expected an error after exhausting retries, got nil")
+	}
+	if !errors.Is(err, ErrPublishExhausted) {
+		t.Fatalf("expected ErrPublishExhausted, got %v", err)
+	}
+}
+
+// TestPublishWithRetry_SucceedsBeforeExhaustion verifies that a transient
+// failure followed by success still returns nil (no terminal error) and
+// continues processing.
+func TestPublishWithRetry_SucceedsBeforeExhaustion(t *testing.T) {
+	withFastRetries(t)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Producer that fails the first two attempts, then succeeds.
+	flaky := &flakyProducer{failuresRemaining: 2}
+	producer := kafka.NewTestProducer(flaky, "subtree", logger)
+	client := NewClient(config.P2PConfig{}, producer, producer, logger)
+
+	err := client.publishWithRetry(context.Background(), producer, "hash-y", []byte("payload"), "subtree")
+	if err != nil {
+		t.Fatalf("expected nil error after eventual success, got %v", err)
+	}
+	if flaky.attempts != 3 {
+		t.Errorf("expected 3 attempts (2 failures + success), got %d", flaky.attempts)
+	}
+}
+
+// TestHandleSubtreeMessage_PropagatesTerminalError verifies that the message
+// handler bubbles ErrPublishExhausted up so the run-loop can shut down.
+func TestHandleSubtreeMessage_PropagatesTerminalError(t *testing.T) {
+	withFastRetries(t)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	mockProducer := &mockSyncProducer{failErr: errors.New("kafka down")}
+	producer := kafka.NewTestProducer(mockProducer, "subtree", logger)
+
+	client := NewClient(config.P2PConfig{}, producer, producer, logger)
+
+	err := client.handleSubtreeMessage(context.Background(), teranode.SubtreeMessage{Hash: "h"})
+	if !errors.Is(err, ErrPublishExhausted) {
+		t.Fatalf("expected ErrPublishExhausted, got %v", err)
+	}
+}
+
+// TestHandleBlockMessage_PropagatesTerminalError verifies the block handler
+// bubbles ErrPublishExhausted up.
+func TestHandleBlockMessage_PropagatesTerminalError(t *testing.T) {
+	withFastRetries(t)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	mockProducer := &mockSyncProducer{failErr: errors.New("kafka down")}
+	producer := kafka.NewTestProducer(mockProducer, "block", logger)
+
+	client := NewClient(config.P2PConfig{}, producer, producer, logger)
+
+	err := client.handleBlockMessage(context.Background(), teranode.BlockMessage{Hash: "b", Height: 1})
+	if !errors.Is(err, ErrPublishExhausted) {
+		t.Fatalf("expected ErrPublishExhausted, got %v", err)
+	}
+}
+
+// TestSignalFatal_PropagatesToRun verifies that a fatal error signalled from
+// any publish path bubbles up out of Run so the entrypoint can exit non-zero.
+func TestSignalFatal_PropagatesToRun(t *testing.T) {
+	client, _, _ := newTestClient(t)
+
+	// Pretend Start has run (so Run does not try to spin up a real libp2p host).
+	client.SetStarted(true)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// Also wire a cancel function so signalFatal's cancel call is a no-op-safe.
+	client.cancel = cancel
+
+	go func() {
+		// Simulate a publish loop hitting exhaustion.
+		client.signalFatal(ErrPublishExhausted)
+	}()
+
+	err := client.Run(ctx)
+	if !errors.Is(err, ErrPublishExhausted) {
+		t.Fatalf("expected Run to return ErrPublishExhausted, got %v", err)
+	}
+}
+
+// TestRun_ContextCancellationReturnsNil verifies that a clean shutdown via
+// context cancellation returns a nil error (i.e., the entry point exits 0).
+func TestRun_ContextCancellationReturnsNil(t *testing.T) {
+	client, _, _ := newTestClient(t)
+	client.SetStarted(true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client.cancel = cancel
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	if err := client.Run(ctx); err != nil {
+		t.Fatalf("expected nil on clean shutdown, got %v", err)
+	}
+}
+
+// TestPublishWithRetry_ContextCancelledDuringBackoffIsNotFatal verifies that
+// shutting down mid-retry does not produce a spurious fatal error.
+func TestPublishWithRetry_ContextCancelledDuringBackoffIsNotFatal(t *testing.T) {
+	// Use the default retry delay so we have time to cancel mid-backoff.
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	mockProducer := &mockSyncProducer{failErr: errors.New("kafka down")}
+	producer := kafka.NewTestProducer(mockProducer, "subtree", logger)
+	client := NewClient(config.P2PConfig{}, producer, producer, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	err := client.publishWithRetry(ctx, producer, "hash-z", []byte("payload"), "subtree")
+	if err != nil {
+		t.Fatalf("expected nil on context cancellation, got %v", err)
+	}
+}
+
+// flakyProducer fails the first failuresRemaining SendMessage calls, then succeeds.
+type flakyProducer struct {
+	mu                sync.Mutex
+	failuresRemaining int
+	attempts          int
+}
+
+func (f *flakyProducer) SendMessage(_ *sarama.ProducerMessage) (int32, int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.attempts++
+	if f.failuresRemaining > 0 {
+		f.failuresRemaining--
+		return 0, 0, errors.New("transient kafka failure")
+	}
+	return 0, int64(f.attempts), nil
+}
+
+func (f *flakyProducer) SendMessages(_ []*sarama.ProducerMessage) error { return nil }
+func (f *flakyProducer) Close() error                                    { return nil }
+func (f *flakyProducer) IsTransactional() bool                           { return false }
+func (f *flakyProducer) TxnStatus() sarama.ProducerTxnStatusFlag {
+	return sarama.ProducerTxnFlagReady
+}
+func (f *flakyProducer) BeginTxn() error  { return nil }
+func (f *flakyProducer) CommitTxn() error { return nil }
+func (f *flakyProducer) AbortTxn() error  { return nil }
+func (f *flakyProducer) AddOffsetsToTxn(_ map[string][]*sarama.PartitionOffsetMetadata, _ string) error {
+	return nil
+}
+func (f *flakyProducer) AddMessageToTxn(_ *sarama.ConsumerMessage, _ string, _ *string) error {
+	return nil
 }


### PR DESCRIPTION
## Summary
- The P2P client no longer silently drops block/subtree announcements after `maxPublishRetries` exhausted Kafka publishes. Exhaustion now bubbles up as a terminal error and the `p2p-client` binary exits non-zero so the orchestrator restarts the pod from a fresh, durable P2P session.
- `internal/p2p/client.go`: introduced `ErrPublishExhausted`, made `publishWithRetry` return it on exhaustion (and respect ctx cancellation during backoff), threaded the error up through `handleSubtreeMessage` / `handleBlockMessage` and the `processSubtreeMessages` / `processBlockMessages` loops, added a `Run(ctx)` entry point that blocks until either ctx is cancelled (returns nil) or a fatal error is signalled (returns the error), and a `signalFatal` helper.
- `cmd/p2p-client/main.go`: refactored to a `run()` function with an overridable `exit` hook; SIGTERM/SIGINT translates to context cancel; a non-nil terminal error now causes a non-zero exit.
- Tests added in `internal/p2p/client_test.go` covering: exhaustion returns `ErrPublishExhausted`, transient failures still recover, both message handlers propagate the terminal error, `Run` returns the error from `signalFatal`, `Run` returns nil on context cancel, and ctx-cancellation during retry backoff is non-fatal. Added `cmd/p2p-client/main_test.go` for the exit hook indirection.

Closes #7

## Operational note
This relies on a process supervisor (Kubernetes `restartPolicy: Always`, Docker `restart: always`, systemd, etc.). The existing `deploy/k8s/p2p-client.yaml` is a `Deployment` (pods default to `restartPolicy: Always`), so this works out of the box. If `p2p-client` is ever run without a supervisor, the loss surface narrows but is replaced with a stalled pod. Verify the deployment manifest before rolling out.

Approach considered: persisting failed announcements to a local on-disk queue (Approach B) was rejected because it adds state to a stateless P2P client whose role is to observe ongoing gossip; the orchestrator-managed restart is the durability boundary, mirroring sibling PRs #76 / #77 / #78 that adopt "fail loudly so the supervisor handles it".

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/p2p/... ./cmd/p2p-client/... -race`
- [ ] Reviewer to confirm deployment supervisor is configured