### PR TITLE
fix(store): reject unsupported blob-store schemes at startup (#16)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -325,11 +325,17 @@ callback:
 # Blob Store — subtree data storage
 # ---------------------------------------------------------------------------
 blobStore:
-  # Backend URL for subtree blob storage.
-  # Supports file:// (local filesystem) and http:// (remote blob server).
+  # Backend URL for subtree blob storage. Exactly two schemes are supported:
+  #   file://<path>  — durable on-disk store rooted at <path>. The path is
+  #                    created if missing. This is the only durable backend.
+  #   memory:        — in-memory store. Tests / ephemeral single-process
+  #                    deployments only; blobs are lost on restart and are
+  #                    not visible to other replicas.
+  # Any other scheme (s3://, gs://, http://, or a typo such as flie://) is
+  # rejected at startup — there is no silent fallback to in-memory.
   # Examples:
   #   file:///var/lib/merkle-subtrees
-  #   http://blob-server:8080/subtrees
+  #   memory:
   # Env: BLOB_STORE_URL
   url: file:///mnt/nvme/merkle-subtreestore
 

--- a/internal/store/file_blob.go
+++ b/internal/store/file_blob.go
@@ -12,11 +12,35 @@ import (
 )
 
 // NewBlobStoreFromURL creates a BlobStore from a URL string.
-// Supports "file://" for local filesystem storage.
-// Falls back to in-memory store for unrecognized schemes.
+//
+// Exactly two forms are accepted:
+//
+//   - "file://<path>" — durable on-disk store rooted at <path>. The path is
+//     created if it does not exist. This is the only durable backend.
+//   - "memory:" or "memory://" — in-memory store. Suitable for tests and
+//     ephemeral single-process deployments only; blobs are lost on restart
+//     and are not visible to other replicas.
+//
+// Any other scheme (including object-store URLs such as s3://, gs://, or
+// azure://, and typos such as "flie://") returns an error so that operator
+// misconfiguration fails loudly at startup instead of silently degrading to
+// an in-memory store that loses subtree/STUMP blobs and breaks inter-replica
+// sharing. An empty URL is also rejected for the same reason — callers who
+// want an in-memory store must request it explicitly via "memory:".
 func NewBlobStoreFromURL(rawURL string) (BlobStore, error) {
-	if strings.HasPrefix(rawURL, "file://") {
-		u, err := url.Parse(rawURL)
+	trimmed := strings.TrimSpace(rawURL)
+	if trimmed == "" {
+		return nil, fmt.Errorf(`blob-store URL is empty (expected "file://<path>" or "memory:")`)
+	}
+
+	// Accept the explicit in-memory form. Both "memory:" (opaque URI) and
+	// "memory://" (authority form) are accepted for operator convenience.
+	if trimmed == "memory:" || trimmed == "memory://" {
+		return NewMemoryBlobStore(), nil
+	}
+
+	if strings.HasPrefix(trimmed, "file://") {
+		u, err := url.Parse(trimmed)
 		if err != nil {
 			return nil, fmt.Errorf("parsing blob store URL: %w", err)
 		}
@@ -26,8 +50,29 @@ func NewBlobStoreFromURL(rawURL string) (BlobStore, error) {
 		}
 		return NewFileBlobStore(dir)
 	}
-	// Default to memory store for unknown/empty URLs.
-	return NewMemoryBlobStore(), nil
+
+	// Anything else — including s3://, gs://, azure://, http://, and typos
+	// like "flie://" — is rejected. We surface the scheme but not the full
+	// URL to avoid logging credentials embedded in the userinfo component.
+	scheme := schemeOf(trimmed)
+	return nil, fmt.Errorf(`unsupported blob-store scheme %q (expected "file" or "memory")`, scheme)
+}
+
+// schemeOf returns the URL scheme for rawURL, or the raw value (truncated)
+// when the input does not look like a URL. Used purely for error messages,
+// so it never returns userinfo or path components.
+func schemeOf(rawURL string) string {
+	if i := strings.Index(rawURL, ":"); i > 0 {
+		return rawURL[:i]
+	}
+	// No scheme delimiter — the operator passed something that is not a URL
+	// at all. Echo back a short prefix so the error is actionable without
+	// risking secret leakage.
+	const maxLen = 16
+	if len(rawURL) > maxLen {
+		return rawURL[:maxLen] + "..."
+	}
+	return rawURL
 }
 
 // FileBlobStore implements BlobStore using the local filesystem.

--- a/internal/store/file_blob_test.go
+++ b/internal/store/file_blob_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"bytes"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -35,4 +36,109 @@ func TestFileBlobStore_SetCreatesParentDir(t *testing.T) {
 	if _, err := filepath.Abs(filepath.Join(dir, "stump")); err != nil {
 		t.Errorf("expected stump/ subdirectory: %v", err)
 	}
+}
+
+// TestNewBlobStoreFromURL pins the factory's scheme handling. F-040 was a
+// silent fallback to memory for any non-"file://" URL — a typo or an
+// object-store URL that the operator believed was supported would lose
+// subtree/STUMP blobs on restart with no operator-visible signal. The cases
+// below cover every documented branch and the error path that previously
+// produced the silent fallback.
+func TestNewBlobStoreFromURL(t *testing.T) {
+	t.Run("file scheme returns file-backed store", func(t *testing.T) {
+		dir := t.TempDir()
+		bs, err := NewBlobStoreFromURL("file://" + dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if bs == nil {
+			t.Fatal("nil store")
+		}
+		if _, ok := bs.(*FileBlobStore); !ok {
+			t.Errorf("expected *FileBlobStore, got %T", bs)
+		}
+	})
+
+	t.Run("memory: scheme returns in-memory store", func(t *testing.T) {
+		bs, err := NewBlobStoreFromURL("memory:")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := bs.(*MemoryBlobStore); !ok {
+			t.Errorf("expected *MemoryBlobStore, got %T", bs)
+		}
+	})
+
+	t.Run("memory:// authority form also accepted", func(t *testing.T) {
+		bs, err := NewBlobStoreFromURL("memory://")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := bs.(*MemoryBlobStore); !ok {
+			t.Errorf("expected *MemoryBlobStore, got %T", bs)
+		}
+	})
+
+	t.Run("s3 scheme rejected with helpful error", func(t *testing.T) {
+		bs, err := NewBlobStoreFromURL("s3://bucket/key")
+		if err == nil {
+			t.Fatalf("expected error, got store %T", bs)
+		}
+		if bs != nil {
+			t.Errorf("expected nil store on error, got %T", bs)
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, `"s3"`) {
+			t.Errorf("error %q should name the rejected scheme", msg)
+		}
+		if !strings.Contains(msg, "unsupported") {
+			t.Errorf("error %q should mention it is unsupported", msg)
+		}
+		// Guard against credential leakage in the diagnostic.
+		if strings.Contains(msg, "bucket") || strings.Contains(msg, "key") {
+			t.Errorf("error %q should not echo the URL path/host", msg)
+		}
+	})
+
+	t.Run("gs and azure schemes also rejected", func(t *testing.T) {
+		for _, raw := range []string{"gs://b/k", "azure://acct/c", "http://blob:8080"} {
+			if _, err := NewBlobStoreFromURL(raw); err == nil {
+				t.Errorf("expected error for %q, got nil", raw)
+			}
+		}
+	})
+
+	t.Run("typo does not silently fall back", func(t *testing.T) {
+		// Previously this would have returned a memory store with no error.
+		bs, err := NewBlobStoreFromURL("flie:///tmp/foo")
+		if err == nil {
+			t.Fatalf("expected error for typo, got store %T", bs)
+		}
+		if !strings.Contains(err.Error(), `"flie"`) {
+			t.Errorf("error %q should name the typo'd scheme", err.Error())
+		}
+	})
+
+	t.Run("empty URL is rejected (tightened semantics)", func(t *testing.T) {
+		// The factory used to return a memory store for an empty URL. We now
+		// require operators to opt in explicitly via "memory:" so a missing
+		// config field can't silently produce a non-durable store.
+		if _, err := NewBlobStoreFromURL(""); err == nil {
+			t.Error("expected error for empty URL, got nil")
+		}
+		if _, err := NewBlobStoreFromURL("   "); err == nil {
+			t.Error("expected error for whitespace-only URL, got nil")
+		}
+	})
+
+	t.Run("non-URL garbage is rejected without echoing full input", func(t *testing.T) {
+		secret := "supersecretpasswordvaluethatshouldnotleak"
+		_, err := NewBlobStoreFromURL(secret)
+		if err == nil {
+			t.Fatal("expected error for non-URL input")
+		}
+		if strings.Contains(err.Error(), "shouldnotleak") {
+			t.Errorf("error %q leaked the trailing portion of the input", err.Error())
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- The blob-store factory (`store.NewBlobStoreFromURL`) now returns an error for any URL whose scheme is not `file://` or the explicit `memory:` form, instead of silently falling back to an in-memory store. The error bubbles up through `store.NewFromConfig` -> `cmd/*` startup so misconfiguration fails loudly.
- Tightened semantics: an empty/whitespace `blobStore.url` is now also rejected. Operators who genuinely want an in-memory store must opt in explicitly via `memory:` (or `memory://`). The previous default-to-memory behaviour was the same root cause as F-040.
- Updated `config.yaml` doc comments to list the two supported schemes and explicitly note that `s3://`, `gs://`, `http://`, and typos are rejected at startup.
- Error messages name the rejected scheme but never echo the full URL, so credentials embedded in userinfo are not logged.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/store/... -race` (incl. new `TestNewBlobStoreFromURL` with 8 sub-cases: file, memory:, memory://, s3 rejection + no-credential-leak, gs/azure/http rejection, typo `flie://`, empty/whitespace, non-URL garbage)
- [ ] Reviewer to confirm operators only use `file://` or explicit `memory:` today (k8s configmap/subtree-fetcher comments still mention s3/gs as a future option — those docs are not modified here per task scope; happy to follow up in a separate PR)

Closes #16