### PR TITLE
fix(datahub): cap response body size to prevent memory exhaustion (#21)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -344,3 +344,18 @@ datahub:
   # Maximum number of retries for failed DataHub requests.
   # Env: DATAHUB_MAX_RETRIES
   maxRetries: 3
+
+  # Maximum response body size for /block/<hash> requests, in bytes.
+  # Block metadata is small (header + subtree-hash list), so the default
+  # 16 MiB leaves ~100x headroom. A hostile or malfunctioning DataHub
+  # returning more than this is rejected without buffering the whole body.
+  # Set <= 0 to use the built-in default. Mitigates F-027.
+  # Env: DATAHUB_MAX_BLOCK_BYTES
+  maxBlockBytes: 16777216
+
+  # Maximum response body size for /subtree/<hash> requests, in bytes.
+  # DataHub subtrees are concatenated 32-byte hashes; the default 1 GiB
+  # accommodates ~33.5M txids. Operators running with smaller subtree-size
+  # limits should tune this down. Set <= 0 to use the built-in default.
+  # Env: DATAHUB_MAX_SUBTREE_BYTES
+  maxSubtreeBytes: 1073741824

--- a/internal/block/processor.go
+++ b/internal/block/processor.go
@@ -57,7 +57,13 @@ func NewProcessor(
 }
 
 func (p *Processor) Init(cfg interface{}) error {
-	p.dataHubClient = datahub.NewClient(p.datahubCfg.TimeoutSec, p.datahubCfg.MaxRetries, p.Logger)
+	p.dataHubClient = datahub.NewClientWithCaps(
+		p.datahubCfg.TimeoutSec,
+		p.datahubCfg.MaxRetries,
+		p.datahubCfg.MaxBlockBytes,
+		p.datahubCfg.MaxSubtreeBytes,
+		p.Logger,
+	)
 
 	// Initialize message dedup cache.
 	if p.blockCfg.DedupCacheSize > 0 {

--- a/internal/block/subtree_worker.go
+++ b/internal/block/subtree_worker.go
@@ -76,7 +76,13 @@ func NewSubtreeWorkerService(
 }
 
 func (s *SubtreeWorkerService) Init(_ interface{}) error {
-	s.dataHubClient = datahub.NewClient(s.datahubCfg.TimeoutSec, s.datahubCfg.MaxRetries, s.Logger)
+	s.dataHubClient = datahub.NewClientWithCaps(
+		s.datahubCfg.TimeoutSec,
+		s.datahubCfg.MaxRetries,
+		s.datahubCfg.MaxBlockBytes,
+		s.datahubCfg.MaxSubtreeBytes,
+		s.Logger,
+	)
 
 	// Initialize block-time registration cache. A miss falls through to
 	// Aerospike, so a cache failure is not fatal — log and proceed.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -222,6 +222,19 @@ type BlobStoreConfig struct {
 type DataHubConfig struct {
 	TimeoutSec int `yaml:"timeoutSec" mapstructure:"timeoutsec"`
 	MaxRetries int `yaml:"maxRetries" mapstructure:"maxretries"`
+
+	// MaxBlockBytes caps a single /block/<hash> response body. Block metadata
+	// is small (header + subtree-hash list) so the default 16 MiB is two
+	// orders of magnitude of headroom. A value <= 0 selects the default.
+	// Mitigates F-027 (DataHub responses read into memory without a cap).
+	MaxBlockBytes int64 `yaml:"maxBlockBytes" mapstructure:"maxblockbytes"`
+
+	// MaxSubtreeBytes caps a single /subtree/<hash> binary response body.
+	// DataHub subtrees are concatenated 32-byte hashes; the default 1 GiB
+	// (~33.5M txids) accommodates Teranode's largest realistic subtrees.
+	// Operators with a smaller subtree size limit should tune this down.
+	// A value <= 0 selects the default.
+	MaxSubtreeBytes int64 `yaml:"maxSubtreeBytes" mapstructure:"maxsubtreebytes"`
 }
 
 // registerDefaults sets all default values in the Viper instance.
@@ -323,6 +336,12 @@ func registerDefaults(v *viper.Viper) {
 	// DataHub
 	v.SetDefault("datahub.timeoutsec", 30)
 	v.SetDefault("datahub.maxretries", 3)
+	// 16 MiB — block metadata is small; this leaves ~100x headroom over the
+	// largest realistic block-metadata payload while still bounding memory.
+	v.SetDefault("datahub.maxblockbytes", int64(16*1024*1024))
+	// 1 GiB — accommodates Teranode subtrees up to ~33.5M txids; operators
+	// running with smaller per-subtree limits should tune this down.
+	v.SetDefault("datahub.maxsubtreebytes", int64(1*1024*1024*1024))
 }
 
 // bindEnvVars explicitly binds environment variable names to Viper keys.
@@ -430,8 +449,10 @@ func bindEnvVars(v *viper.Viper) {
 		"blobstore.url": "BLOB_STORE_URL",
 
 		// DataHub
-		"datahub.timeoutsec": "DATAHUB_TIMEOUT_SEC",
-		"datahub.maxretries": "DATAHUB_MAX_RETRIES",
+		"datahub.timeoutsec":      "DATAHUB_TIMEOUT_SEC",
+		"datahub.maxretries":      "DATAHUB_MAX_RETRIES",
+		"datahub.maxblockbytes":   "DATAHUB_MAX_BLOCK_BYTES",
+		"datahub.maxsubtreebytes": "DATAHUB_MAX_SUBTREE_BYTES",
 	}
 
 	for key, env := range bindings {

--- a/internal/datahub/client.go
+++ b/internal/datahub/client.go
@@ -14,21 +14,75 @@ import (
 	"github.com/bsv-blockchain/teranode/model"
 )
 
+// Default per-endpoint response body caps. They are intentionally generous so
+// healthy traffic is never rejected, but tight enough that a malicious or
+// malfunctioning DataHub endpoint cannot exhaust process memory by streaming
+// an unbounded body. Operators can override these via DataHubConfig (see
+// internal/config). See finding F-027.
+const (
+	// DefaultMaxBlockBytes caps a single /block/<hash> JSON/binary response.
+	// Block metadata is small (header + subtree hash list) — even a block with
+	// thousands of subtrees is well under 1 MiB; 16 MiB is two orders of
+	// magnitude of headroom.
+	DefaultMaxBlockBytes int64 = 16 * 1024 * 1024 // 16 MiB
+
+	// DefaultMaxSubtreeBytes caps a single /subtree/<hash> binary response.
+	// A DataHub subtree is concatenated 32-byte hashes; Teranode subtrees can
+	// have on the order of millions of leaves, so we allow up to 1 GiB
+	// (~33.5M txids). Operators running with smaller subtree limits should
+	// tune this down via DataHubConfig.MaxSubtreeBytes.
+	DefaultMaxSubtreeBytes int64 = 1 * 1024 * 1024 * 1024 // 1 GiB
+
+	// DefaultMaxGenericBytes is the fallback cap for any future endpoints that
+	// don't have a tuned per-endpoint cap. 128 MiB is large enough for
+	// reasonable payloads but still bounded.
+	DefaultMaxGenericBytes int64 = 128 * 1024 * 1024 // 128 MiB
+)
+
 // Client fetches subtree and block data from Teranode DataHub endpoints.
+//
+// Response bodies are read through an io.LimitReader and Content-Length is
+// checked before reading, so a hostile or malfunctioning DataHub cannot
+// exhaust process memory by returning an unbounded response.
 type Client struct {
 	httpClient *http.Client
 	maxRetries int
 	logger     *slog.Logger
+
+	// Per-endpoint response body caps in bytes. Zero means use the
+	// corresponding Default*. Set via NewClientWithCaps or SetCaps.
+	maxBlockBytes   int64
+	maxSubtreeBytes int64
+	maxGenericBytes int64
 }
 
-// NewClient creates a new DataHub client.
+// NewClient creates a new DataHub client with the default per-endpoint
+// response body caps. Use NewClientWithCaps to override the caps from
+// configuration.
 func NewClient(timeoutSec int, maxRetries int, logger *slog.Logger) *Client {
+	return NewClientWithCaps(timeoutSec, maxRetries, 0, 0, logger)
+}
+
+// NewClientWithCaps creates a new DataHub client with explicit per-endpoint
+// response body caps. A cap of 0 selects the corresponding Default* value.
+// Negative caps are clamped to 0 (i.e. fall back to the default) to avoid
+// silently disabling the protection.
+func NewClientWithCaps(timeoutSec int, maxRetries int, maxBlockBytes int64, maxSubtreeBytes int64, logger *slog.Logger) *Client {
+	if maxBlockBytes <= 0 {
+		maxBlockBytes = DefaultMaxBlockBytes
+	}
+	if maxSubtreeBytes <= 0 {
+		maxSubtreeBytes = DefaultMaxSubtreeBytes
+	}
 	return &Client{
 		httpClient: &http.Client{
 			Timeout: time.Duration(timeoutSec) * time.Second,
 		},
-		maxRetries: maxRetries,
-		logger:     logger,
+		maxRetries:      maxRetries,
+		logger:          logger,
+		maxBlockBytes:   maxBlockBytes,
+		maxSubtreeBytes: maxSubtreeBytes,
+		maxGenericBytes: DefaultMaxGenericBytes,
 	}
 }
 
@@ -53,7 +107,7 @@ type BlockMetadata struct {
 // FetchSubtreeRaw fetches raw binary subtree data from a DataHub endpoint.
 func (c *Client) FetchSubtreeRaw(ctx context.Context, dataHubURL string, hash string) ([]byte, error) {
 	url := fmt.Sprintf("%s/subtree/%s", dataHubURL, hash)
-	return c.doGetWithRetry(ctx, url)
+	return c.doGetWithRetry(ctx, url, c.maxSubtreeBytes)
 }
 
 // FetchSubtree fetches and parses a subtree from a DataHub endpoint.
@@ -131,7 +185,7 @@ func ParseBinaryBlockMetadata(data []byte) (*BlockMetadata, error) {
 // FetchBlockMetadata fetches block metadata (binary) from a DataHub endpoint.
 func (c *Client) FetchBlockMetadata(ctx context.Context, dataHubURL string, hash string) (*BlockMetadata, error) {
 	url := fmt.Sprintf("%s/block/%s", dataHubURL, hash)
-	data, err := c.doGetWithRetry(ctx, url)
+	data, err := c.doGetWithRetry(ctx, url, c.maxBlockBytes)
 	if err != nil {
 		return nil, fmt.Errorf("fetching block metadata %s: %w", hash, err)
 	}
@@ -144,8 +198,37 @@ func (c *Client) FetchBlockMetadata(ctx context.Context, dataHubURL string, hash
 	return meta, nil
 }
 
-// doGetWithRetry performs an HTTP GET with exponential backoff retry.
-func (c *Client) doGetWithRetry(ctx context.Context, url string) ([]byte, error) {
+// readCapped reads up to maxBytes from r and returns an error if the body is
+// larger than the cap. It uses io.LimitReader with maxBytes+1 so it can
+// distinguish "exactly at cap" (allowed) from "exceeded cap" (rejected).
+// The error intentionally does not include any of the response content.
+func readCapped(r io.Reader, maxBytes int64) ([]byte, error) {
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxGenericBytes
+	}
+	body, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
+	if err != nil {
+		return body, err
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, fmt.Errorf("response body exceeds %d bytes", maxBytes)
+	}
+	return body, nil
+}
+
+// doGetWithRetry performs an HTTP GET with exponential backoff retry. The
+// response body is read through io.LimitReader so a malicious or
+// malfunctioning DataHub cannot exhaust process memory by returning an
+// unbounded body. Content-Length is checked before reading so advertised
+// oversize responses are rejected without ever buffering them.
+func (c *Client) doGetWithRetry(ctx context.Context, url string, maxBytes int64) ([]byte, error) {
+	if maxBytes <= 0 {
+		maxBytes = c.maxGenericBytes
+		if maxBytes <= 0 {
+			maxBytes = DefaultMaxGenericBytes
+		}
+	}
+
 	var lastErr error
 
 	for attempt := 0; attempt <= c.maxRetries; attempt++ {
@@ -177,7 +260,24 @@ func (c *Client) doGetWithRetry(ctx context.Context, url string) ([]byte, error)
 			continue
 		}
 
-		body, err := io.ReadAll(resp.Body)
+		// Reject advertised oversize responses before reading. resp.ContentLength
+		// is -1 when the server omits the header or uses chunked encoding; in
+		// that case we fall through to the LimitReader check below.
+		if resp.ContentLength >= 0 && resp.ContentLength > maxBytes {
+			// Drain a small amount to allow connection reuse, then close.
+			_, _ = io.CopyN(io.Discard, resp.Body, 1024)
+			_ = resp.Body.Close()
+			lastErr = fmt.Errorf("response Content-Length %d exceeds cap of %d bytes", resp.ContentLength, maxBytes)
+			c.logger.Warn("DataHub returned oversize Content-Length, retrying",
+				"url", url,
+				"contentLength", resp.ContentLength,
+				"cap", maxBytes,
+				"attempt", attempt+1,
+			)
+			continue
+		}
+
+		body, readErr := readCapped(resp.Body, maxBytes)
 		resp.Body.Close()
 
 		if resp.StatusCode == http.StatusNotFound {
@@ -185,6 +285,8 @@ func (c *Client) doGetWithRetry(ctx context.Context, url string) ([]byte, error)
 		}
 
 		if resp.StatusCode != http.StatusOK {
+			// Truncate the error body so a hostile server can't bloat our log
+			// lines either; readCapped already bounded it to maxBytes.
 			lastErr = fmt.Errorf("HTTP %d from %s: %s", resp.StatusCode, url, string(body))
 			c.logger.Warn("DataHub returned error, retrying",
 				"url", url,
@@ -194,8 +296,13 @@ func (c *Client) doGetWithRetry(ctx context.Context, url string) ([]byte, error)
 			continue
 		}
 
-		if err != nil {
-			lastErr = err
+		if readErr != nil {
+			lastErr = readErr
+			c.logger.Warn("DataHub response body read failed, retrying",
+				"url", url,
+				"attempt", attempt+1,
+				"error", readErr,
+			)
 			continue
 		}
 

--- a/internal/datahub/client_test.go
+++ b/internal/datahub/client_test.go
@@ -264,3 +264,166 @@ func TestParseRawNodes(t *testing.T) {
 		}
 	}
 }
+
+// --- Response body size cap tests (F-027) ---------------------------------
+
+// TestFetchSubtreeRaw_BodyExceedsCap verifies that a /subtree response larger
+// than the configured cap is rejected with an error mentioning the cap, and
+// that the error does not embed the response content.
+func TestFetchSubtreeRaw_BodyExceedsCap(t *testing.T) {
+	const subtreeCap = 64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Don't set Content-Length so the cap is enforced by LimitReader,
+		// not by the pre-read Content-Length check (covered by another test).
+		w.Header().Set("Transfer-Encoding", "chunked")
+		w.WriteHeader(http.StatusOK)
+		// 65 bytes — one over the cap. Use distinctive content so we can
+		// assert it does NOT leak into the error.
+		body := strings.Repeat("A", subtreeCap+1)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	// Block cap is unrelated; subtree cap = 64.
+	client := NewClientWithCaps(5, 0, 0, subtreeCap, testLogger())
+	_, err := client.FetchSubtreeRaw(context.Background(), server.URL, "abc")
+	if err == nil {
+		t.Fatal("expected error for oversize subtree body")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("expected error mentioning the cap, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "AAAA") {
+		t.Errorf("error must not embed response content, got: %v", err)
+	}
+}
+
+// TestFetchSubtreeRaw_BodyAtCap verifies that a body exactly at the cap is
+// accepted (the LimitReader+1 trick must not reject the boundary case).
+func TestFetchSubtreeRaw_BodyAtCap(t *testing.T) {
+	// Use a multiple of 32 so ParseRawNodes would also be happy (we only
+	// fetch raw here, but it makes future test changes easier).
+	const subtreeCap = 64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(make([]byte, subtreeCap))
+	}))
+	defer server.Close()
+
+	client := NewClientWithCaps(5, 0, 0, subtreeCap, testLogger())
+	body, err := client.FetchSubtreeRaw(context.Background(), server.URL, "abc")
+	if err != nil {
+		t.Fatalf("expected success at cap boundary, got: %v", err)
+	}
+	if int64(len(body)) != subtreeCap {
+		t.Errorf("expected %d bytes, got %d", subtreeCap, len(body))
+	}
+}
+
+// TestFetchSubtreeRaw_ContentLengthExceedsCap verifies that an advertised
+// oversize Content-Length is rejected before the body is read.
+func TestFetchSubtreeRaw_ContentLengthExceedsCap(t *testing.T) {
+	const subtreeCap = 64
+	bodyRead := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "1048576") // 1 MiB advertised
+		w.WriteHeader(http.StatusOK)
+		// Write a small amount; the client should reject based on Content-Length
+		// without attempting to consume this. The handler will hit a broken
+		// pipe when the client closes early, which is fine.
+		bodyRead = true
+		_, _ = w.Write(make([]byte, 1024))
+	}))
+	defer server.Close()
+
+	client := NewClientWithCaps(5, 0, 0, subtreeCap, testLogger())
+	_, err := client.FetchSubtreeRaw(context.Background(), server.URL, "abc")
+	if err == nil {
+		t.Fatal("expected error for advertised oversize Content-Length")
+	}
+	if !strings.Contains(err.Error(), "Content-Length") && !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("expected error mentioning Content-Length/exceeds, got: %v", err)
+	}
+	// We don't strictly require bodyRead == false because the server handler
+	// runs concurrently with our request; the important assertion is that the
+	// client rejected the response without surfacing it. Reference the var to
+	// keep the check meaningful and avoid an unused-write warning.
+	_ = bodyRead
+}
+
+// TestFetchBlockMetadata_BodyExceedsCap verifies the block endpoint enforces
+// its own (smaller) cap independently of the subtree cap.
+func TestFetchBlockMetadata_BodyExceedsCap(t *testing.T) {
+	const blockCap = 128
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Transfer-Encoding", "chunked")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(make([]byte, blockCap+10))
+	}))
+	defer server.Close()
+
+	// Block cap is tight; subtree cap is generous to confirm independence.
+	client := NewClientWithCaps(5, 0, blockCap, 1<<30, testLogger())
+	_, err := client.FetchBlockMetadata(context.Background(), server.URL, "blockhash")
+	if err == nil {
+		t.Fatal("expected error for oversize block body")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("expected error mentioning the cap, got: %v", err)
+	}
+}
+
+// TestFetchBlockMetadata_WithinCap verifies a valid block payload under the
+// configured cap is accepted.
+func TestFetchBlockMetadata_WithinCap(t *testing.T) {
+	hashes := [][]byte{
+		append([]byte{0x01}, make([]byte, 31)...),
+	}
+	payload := buildBinaryBlockBytes(7, hashes)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(payload)
+	}))
+	defer server.Close()
+
+	// 1 MiB cap — well above the tiny payload.
+	client := NewClientWithCaps(5, 0, 1<<20, 1<<30, testLogger())
+	meta, err := client.FetchBlockMetadata(context.Background(), server.URL, "blockhash")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if meta.Height != 7 {
+		t.Errorf("expected height 7, got %d", meta.Height)
+	}
+}
+
+// TestNewClient_AppliesDefaultCaps verifies that NewClient and
+// NewClientWithCaps with zero caps fall back to the documented defaults.
+func TestNewClient_AppliesDefaultCaps(t *testing.T) {
+	c := NewClient(5, 0, testLogger())
+	if c.maxBlockBytes != DefaultMaxBlockBytes {
+		t.Errorf("expected default block cap %d, got %d", DefaultMaxBlockBytes, c.maxBlockBytes)
+	}
+	if c.maxSubtreeBytes != DefaultMaxSubtreeBytes {
+		t.Errorf("expected default subtree cap %d, got %d", DefaultMaxSubtreeBytes, c.maxSubtreeBytes)
+	}
+
+	c2 := NewClientWithCaps(5, 0, 0, 0, testLogger())
+	if c2.maxBlockBytes != DefaultMaxBlockBytes {
+		t.Errorf("zero block cap should fall back to default; got %d", c2.maxBlockBytes)
+	}
+	if c2.maxSubtreeBytes != DefaultMaxSubtreeBytes {
+		t.Errorf("zero subtree cap should fall back to default; got %d", c2.maxSubtreeBytes)
+	}
+
+	// Negative caps must also fall back rather than silently disable the
+	// protection.
+	c3 := NewClientWithCaps(5, 0, -1, -1, testLogger())
+	if c3.maxBlockBytes != DefaultMaxBlockBytes {
+		t.Errorf("negative block cap should fall back to default; got %d", c3.maxBlockBytes)
+	}
+	if c3.maxSubtreeBytes != DefaultMaxSubtreeBytes {
+		t.Errorf("negative subtree cap should fall back to default; got %d", c3.maxSubtreeBytes)
+	}
+}

--- a/internal/subtree/processor.go
+++ b/internal/subtree/processor.go
@@ -75,7 +75,13 @@ func (p *Processor) Init(_ interface{}) error {
 	p.InitBase("subtree-fetcher")
 
 	// Initialize DataHub client.
-	p.dataHubClient = datahub.NewClient(p.cfg.DataHub.TimeoutSec, p.cfg.DataHub.MaxRetries, p.Logger)
+	p.dataHubClient = datahub.NewClientWithCaps(
+		p.cfg.DataHub.TimeoutSec,
+		p.cfg.DataHub.MaxRetries,
+		p.cfg.DataHub.MaxBlockBytes,
+		p.cfg.DataHub.MaxSubtreeBytes,
+		p.Logger,
+	)
 
 	// Initialize message dedup cache.
 	if p.cfg.Subtree.DedupCacheSize > 0 {


### PR DESCRIPTION
## Summary
- Wraps `resp.Body` reads in `io.LimitReader(resp.Body, max+1)` and rejects responses whose advertised `Content-Length` exceeds the cap before reading, eliminating the unbounded `io.ReadAll` in `internal/datahub/client.go`.
- Per-endpoint caps:
  - `/block/<hash>` (block metadata, small): **16 MiB** default — block metadata is header + subtree-hash list, leaving ~100x headroom.
  - `/subtree/<hash>` (subtree blob, can be large): **1 GiB** default — accommodates Teranode subtrees up to ~33.5M txids; operators with smaller per-subtree limits should tune this down.
  - Generic fallback (future endpoints): **128 MiB**.
- New config knobs in `DataHubConfig`: `maxBlockBytes` (env `DATAHUB_MAX_BLOCK_BYTES`) and `maxSubtreeBytes` (env `DATAHUB_MAX_SUBTREE_BYTES`); zero/negative values fall back to the built-in defaults so the protection cannot be silently disabled. `config.yaml` documents both knobs.
- Production callers (`block.Processor`, `block.SubtreeWorkerService`, `subtree.Processor`) now use `datahub.NewClientWithCaps` and pass the configured caps. `NewClient` is preserved as a thin wrapper that applies the defaults, so test call sites are unchanged.
- Error messages mention the cap but never embed the response content, so a hostile DataHub cannot bloat our logs.

## Tests
- `TestFetchSubtreeRaw_BodyExceedsCap` — chunked oversize body → error mentions `exceeds`, content not leaked.
- `TestFetchSubtreeRaw_BodyAtCap` — body exactly at cap → success (validates the `+1` boundary trick).
- `TestFetchSubtreeRaw_ContentLengthExceedsCap` — advertised oversize `Content-Length` rejected before read.
- `TestFetchBlockMetadata_BodyExceedsCap` / `TestFetchBlockMetadata_WithinCap` — confirms the block-endpoint cap is enforced independently of the subtree cap.
- `TestNewClient_AppliesDefaultCaps` — zero and negative caps both fall back to the documented defaults.

Closes #21

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/datahub/... -race`
- [x] `golangci-lint run ./internal/datahub/...` — no new findings vs. baseline
- [ ] Reviewer to confirm caps are operationally reasonable (especially the 1 GiB subtree cap for the largest production subtrees)