### PR TITLE
fix(store/sql): cascade child rows when sweeping expired parents (#17)

### DIFF
--- a/internal/store/sql/sweeper.go
+++ b/internal/store/sql/sweeper.go
@@ -5,17 +5,48 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 )
 
+// ttlTable describes a single TTL-bearing parent table, plus any child tables
+// whose rows must be deleted alongside the parent. Children are matched by a
+// foreign-key column referencing the parent's primary key.
+//
+// The schema (0001_init.sql) does not declare ON DELETE CASCADE on child
+// tables — adding that constraint to SQLite requires a full table-recreate
+// dance which is operationally awkward to apply to existing data. Instead we
+// enforce the relationship at the application level: every sweep deletes
+// orphan-eligible child rows in the same transaction as the parent. See
+// F-055 / issue #17.
+type ttlTable struct {
+	parent    string
+	parentKey string // primary key column on parent (also referenced by children)
+	children  []ttlChild
+}
+
+type ttlChild struct {
+	table string
+	fk    string // column on child referencing parent.parentKey
+}
+
 // ttlTables lists every table with an expires_at column. The sweeper deletes
-// expired rows from each on every tick.
-var ttlTables = []string{
-	"registrations",
-	"callback_dedup",
-	"subtree_counters",
-	"callback_accumulator",
+// expired rows from each on every tick, plus any child rows whose parent is
+// expiring in this batch.
+var ttlTables = []ttlTable{
+	{
+		parent:    "registrations",
+		parentKey: "txid",
+		children:  []ttlChild{{table: "registration_urls", fk: "txid"}},
+	},
+	{parent: "callback_dedup"},
+	{parent: "subtree_counters"},
+	{
+		parent:    "callback_accumulator",
+		parentKey: "block_hash",
+		children:  []ttlChild{{table: "callback_accumulator_entries", fk: "block_hash"}},
+	},
 }
 
 // sweeper runs a periodic DELETE pass over TTL-bearing tables. One goroutine
@@ -61,46 +92,144 @@ func (s *sweeper) waitStopped() {
 }
 
 func (s *sweeper) sweepOnce(ctx context.Context) {
-	for _, table := range ttlTables {
-		rows, err := s.sweepTable(ctx, table)
+	for _, t := range ttlTables {
+		rows, err := s.sweepTable(ctx, t)
 		if err != nil {
 			if s.logger != nil {
-				s.logger.Warn("ttl sweeper: delete failed", "table", table, "error", err)
+				s.logger.Warn("ttl sweeper: delete failed", "table", t.parent, "error", err)
 			}
 			continue
 		}
 		if rows > 0 && s.logger != nil {
-			s.logger.Debug("ttl sweeper: expired rows deleted", "table", table, "rows", rows)
+			s.logger.Debug("ttl sweeper: expired rows deleted", "table", t.parent, "rows", rows)
 		}
 	}
 }
 
-// sweepTable deletes up to 1000 rows per call to keep locks short. Repeats
-// until no more rows or a sweeper tick elapses.
-func (s *sweeper) sweepTable(ctx context.Context, table string) (int64, error) {
+// sweepTable deletes up to 1000 parent rows per call to keep locks short.
+// Repeats until no more rows or a small batch cap is reached. When the parent
+// has child tables (see ttlTable.children) each batch runs in a single
+// transaction that deletes the matching child rows before the parents — this
+// prevents the orphaned-child rows that F-055 / issue #17 reported.
+func (s *sweeper) sweepTable(ctx context.Context, t ttlTable) (int64, error) {
 	const batch = 1000
 	var total int64
 	// Small cap to avoid pathological long sweeps blocking shutdown.
 	for i := 0; i < 10; i++ {
-		var q string
-		if isPostgres(s.d) {
-			q = fmt.Sprintf(
-				"DELETE FROM %s WHERE ctid IN (SELECT ctid FROM %s WHERE expires_at IS NOT NULL AND expires_at < now() LIMIT %d)",
-				table, table, batch)
-		} else {
-			q = fmt.Sprintf(
-				"DELETE FROM %s WHERE rowid IN (SELECT rowid FROM %s WHERE expires_at IS NOT NULL AND expires_at < %s LIMIT %d)",
-				table, table, s.d.now, batch)
-		}
-		res, err := s.db.ExecContext(ctx, q)
+		n, err := s.sweepTableBatch(ctx, t, batch)
 		if err != nil {
 			return total, err
 		}
-		n, _ := res.RowsAffected()
 		total += n
-		if n < batch {
+		if n < int64(batch) {
 			break
 		}
 	}
 	return total, nil
+}
+
+// sweepTableBatch deletes a single batch of expired parent rows (and any
+// matching child rows) inside one transaction, returning the number of parent
+// rows deleted.
+//
+// For tables without children we delete by rowid/ctid in a single statement.
+// When children are present we must delete the matching child rows in the
+// same transaction; doing so requires a stable set of parent keys shared by
+// both DELETEs (otherwise the parent and child DELETEs could race against
+// the LIMIT and leave orphans). We solve that by selecting the expired
+// parent keys first, then deleting children and parents using IN (those keys).
+func (s *sweeper) sweepTableBatch(ctx context.Context, t ttlTable, batch int) (int64, error) {
+	if len(t.children) == 0 {
+		return s.sweepParentByPhysicalRowID(ctx, t.parent, batch)
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	// 1. Snapshot up to `batch` expired parent keys. Holding the txn means
+	//    concurrent writers may block (sqlite) or wait for row locks
+	//    (postgres) but we never delete a child whose parent we won't also
+	//    delete in this same batch.
+	var selectQ string
+	if isPostgres(s.d) {
+		selectQ = fmt.Sprintf(
+			"SELECT %s FROM %s WHERE expires_at IS NOT NULL AND expires_at < now() LIMIT %d",
+			t.parentKey, t.parent, batch)
+	} else {
+		selectQ = fmt.Sprintf(
+			"SELECT %s FROM %s WHERE expires_at IS NOT NULL AND expires_at < %s LIMIT %d",
+			t.parentKey, t.parent, s.d.now, batch)
+	}
+	rows, err := tx.QueryContext(ctx, selectQ)
+	if err != nil {
+		return 0, fmt.Errorf("select expired %s keys: %w", t.parent, err)
+	}
+	var keys []interface{}
+	for rows.Next() {
+		var k string
+		if err := rows.Scan(&k); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		keys = append(keys, k)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return 0, err
+	}
+	rows.Close()
+	if len(keys) == 0 {
+		return 0, nil
+	}
+
+	placeholders := make([]string, len(keys))
+	for i := range keys {
+		placeholders[i] = s.d.placeholder(i + 1)
+	}
+	inList := strings.Join(placeholders, ", ")
+
+	// 2. Delete child rows for those parents.
+	for _, c := range t.children {
+		q := fmt.Sprintf("DELETE FROM %s WHERE %s IN (%s)", c.table, c.fk, inList)
+		if _, err := tx.ExecContext(ctx, q, keys...); err != nil {
+			return 0, fmt.Errorf("delete children %s: %w", c.table, err)
+		}
+	}
+
+	// 3. Delete the parents themselves.
+	q := fmt.Sprintf("DELETE FROM %s WHERE %s IN (%s)", t.parent, t.parentKey, inList)
+	res, err := tx.ExecContext(ctx, q, keys...)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+// sweepParentByPhysicalRowID deletes a batch of expired rows from a
+// childless table using the driver's physical row identifier (ctid/rowid).
+// This is the historical fast path retained for tables that have no children.
+func (s *sweeper) sweepParentByPhysicalRowID(ctx context.Context, table string, batch int) (int64, error) {
+	var q string
+	if isPostgres(s.d) {
+		q = fmt.Sprintf(
+			"DELETE FROM %s WHERE ctid IN (SELECT ctid FROM %s WHERE expires_at IS NOT NULL AND expires_at < now() LIMIT %d)",
+			table, table, batch)
+	} else {
+		q = fmt.Sprintf(
+			"DELETE FROM %s WHERE rowid IN (SELECT rowid FROM %s WHERE expires_at IS NOT NULL AND expires_at < %s LIMIT %d)",
+			table, table, s.d.now, batch)
+	}
+	res, err := s.db.ExecContext(ctx, q)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
 }

--- a/internal/store/sql/sweeper_test.go
+++ b/internal/store/sql/sweeper_test.go
@@ -1,0 +1,148 @@
+package sql
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestSweeper_CascadesRegistrationChildren is the regression test for F-055
+// (issue #17): when a parent row in `registrations` expires and is swept,
+// the child rows in `registration_urls` for that txid must also be deleted
+// so we don't leak an unbounded set of orphaned URLs.
+func TestSweeper_CascadesRegistrationChildren(t *testing.T) {
+	db, d := newTestDB(t)
+	r := newRegistrationStore(db, d)
+
+	// Two txids: one we'll expire in the past, one fresh.
+	if err := r.Add("tx-old", "http://old1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Add("tx-old", "http://old2"); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Add("tx-fresh", "http://fresh"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Push tx-old into the past, leave tx-fresh with no expiry.
+	if err := r.UpdateTTL("tx-old", -1*time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.UpdateTTL("tx-fresh", 1*time.Hour); err != nil {
+		t.Fatal(err)
+	}
+
+	sw := newSweeper(db, d, time.Hour, slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})))
+	sw.sweepOnce(context.Background())
+
+	// Parent row should be gone.
+	var parentCount int
+	if err := db.QueryRow("SELECT COUNT(*) FROM registrations WHERE txid = ?", "tx-old").Scan(&parentCount); err != nil {
+		t.Fatal(err)
+	}
+	if parentCount != 0 {
+		t.Fatalf("expired parent registrations row still present: count=%d", parentCount)
+	}
+
+	// And — the bug: child rows must also be gone.
+	var orphanCount int
+	if err := db.QueryRow("SELECT COUNT(*) FROM registration_urls WHERE txid = ?", "tx-old").Scan(&orphanCount); err != nil {
+		t.Fatal(err)
+	}
+	if orphanCount != 0 {
+		t.Fatalf("orphan registration_urls rows after sweep: count=%d (want 0); F-055 regression",
+			orphanCount)
+	}
+
+	// Fresh entry untouched.
+	urls, err := r.Get("tx-fresh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(urls) != 1 || urls[0] != "http://fresh" {
+		t.Fatalf("fresh registration mutated: got %v", urls)
+	}
+}
+
+// TestSweeper_CascadesAccumulatorChildren is the matching regression for the
+// callback_accumulator → callback_accumulator_entries pair.
+func TestSweeper_CascadesAccumulatorChildren(t *testing.T) {
+	db, d := newTestDB(t)
+	// Use a -ve effective expiry by writing the parent's expires_at directly
+	// in the past; Append's TTL is positive. We bypass Append for the expired
+	// entry to avoid waiting on real time, then use a normal Append for fresh.
+	a := newCallbackAccumulator(db, d, 600)
+	if err := a.Append("blk-fresh", "http://u", []string{"tx1"}, 0, []byte{0xAA}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert an expired parent + entries directly to simulate what would
+	// otherwise require waiting on real time. The shape mirrors what Append
+	// would produce.
+	if _, err := db.Exec(
+		"INSERT INTO callback_accumulator (block_hash, expires_at) VALUES (?, datetime('now', '-1 hour'))",
+		"blk-old"); err != nil {
+		t.Fatal(err)
+	}
+	for i, txns := range [][]string{{"tx-old-1"}, {"tx-old-2", "tx-old-3"}} {
+		if _, err := db.Exec(
+			`INSERT INTO callback_accumulator_entries
+                (block_hash, callback_url, subtree_index, txids_json, stump_data)
+             VALUES (?, ?, ?, ?, ?)`,
+			"blk-old", "http://u", i, mustJSON(txns), []byte{0xBB}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	sw := newSweeper(db, d, time.Hour, slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})))
+	sw.sweepOnce(context.Background())
+
+	// Parent gone.
+	var parentCount int
+	if err := db.QueryRow("SELECT COUNT(*) FROM callback_accumulator WHERE block_hash = ?", "blk-old").Scan(&parentCount); err != nil {
+		t.Fatal(err)
+	}
+	if parentCount != 0 {
+		t.Fatalf("expired callback_accumulator row still present: count=%d", parentCount)
+	}
+
+	// No orphan child rows.
+	var orphanCount int
+	if err := db.QueryRow("SELECT COUNT(*) FROM callback_accumulator_entries WHERE block_hash = ?", "blk-old").Scan(&orphanCount); err != nil {
+		t.Fatal(err)
+	}
+	if orphanCount != 0 {
+		t.Fatalf("orphan callback_accumulator_entries rows after sweep: count=%d (want 0); F-055 regression",
+			orphanCount)
+	}
+
+	// Fresh accumulator entries survived.
+	got, err := a.ReadAndDelete("blk-fresh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || len(got["http://u"].Entries) != 1 {
+		t.Fatalf("fresh accumulator mutated: got %v", got)
+	}
+}
+
+// mustJSON is a tiny helper to build a JSON string for an array of txids.
+// We construct it by hand to avoid pulling encoding/json into a test that's
+// otherwise stdlib-light.
+func mustJSON(items []string) string {
+	var b []byte
+	b = append(b, '[')
+	for i, s := range items {
+		if i > 0 {
+			b = append(b, ',')
+		}
+		b = append(b, '"')
+		b = append(b, s...)
+		b = append(b, '"')
+	}
+	b = append(b, ']')
+	return string(b)
+}


### PR DESCRIPTION
## Summary
- **Approach B** (sweeper-only): every sweep batch now runs in a single transaction that selects the expired parent keys, deletes matching rows from the child tables, then deletes the parents. No schema migration. Approach A (`ALTER TABLE ADD CONSTRAINT`) is not portable to SQLite, and Approach C (full child-table recreate migration) is operationally risky against existing prod data — calling that out here so a reviewer can decide if a follow-up is wanted.
- **Files changed:**
  - `internal/store/sql/sweeper.go` — `ttlTables` is now `[]ttlTable{parent, parentKey, children}`; new `sweepTableBatch` that handles parents-with-children inside one txn, falls back to the original physical-rowid fast path for childless tables.
  - `internal/store/sql/sweeper_test.go` (new) — regression tests for both `registrations → registration_urls` and `callback_accumulator → callback_accumulator_entries` pairs. Verified failing on the unfixed sweeper, passing after the fix.
- **Test summary:** `go build ./...`, `go vet ./...`, `go test ./internal/store/sql/... -count=1 -race` all green. The two new tests fail with `count=2 (want 0); F-055 regression` against the original code.

Closes #17

## Why no migration
SQLite cannot add a FK via `ALTER TABLE ADD CONSTRAINT`; the only portable option is the temp-table-rename dance, which copies every row and briefly takes a write lock against existing data. Postgres can do `ALTER TABLE ... ADD CONSTRAINT ... ON DELETE CASCADE`. The mixed-dialect migration would be invasive to land cleanly in both. The sweeper-level fix is correct and small; defense-in-depth via FK constraints can be a separate follow-up if reviewers want it.

## Operational notes
- No schema change → no migration risk.
- Behavior change: each sweep tick now takes a `BEGIN ... COMMIT` per parent table that has children (today: `registrations`, `callback_accumulator`). Childless tables (`callback_dedup`, `subtree_counters`) keep the original auto-commit single-DELETE path. Lock duration scales with the per-batch cap (1000 keys), unchanged from before.
- A pre-existing batch of orphaned rows from prior sweeps is **not** retroactively cleaned by this change — they have no `expires_at` and no parent. If reviewers want a one-time backfill cleanup that's a separate trivial DELETE script.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/store/sql/... -race`
- [x] New regression tests fail against unfixed sweeper, pass with the fix
- [ ] Reviewer to confirm Postgres path is exercised (CI Postgres job, if any) — schema unchanged so risk is low