### PR TITLE
fix(api,callback): SSRF guards at registration and dial (#20)

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -27,6 +27,7 @@ func main() {
 	defer registry.Close()
 
 	server := api.NewServer(cfg.API, registry.Registration, registry.CallbackURLRegistry, registry.Health, logger)
+	server.SetAllowPrivateCallbackIPs(cfg.Callback.AllowPrivateIPs)
 
 	if err := server.Init(nil); err != nil {
 		log.Fatal("failed to init api server: ", err)

--- a/cmd/merkle-service/main.go
+++ b/cmd/merkle-service/main.go
@@ -44,6 +44,7 @@ func main() {
 	defer blockProducer.Close()
 
 	apiServer := api.NewServer(cfg.API, registry.Registration, registry.CallbackURLRegistry, registry.Health, logger)
+	apiServer.SetAllowPrivateCallbackIPs(cfg.Callback.AllowPrivateIPs)
 	p2pClient := p2p.NewClient(cfg.P2P, subtreeProducer, blockProducer, logger)
 	subtreeFetcher := subtree.NewProcessor(cfg, registry.Registration, registry.SeenCounter, registry.Subtree)
 	blockProcessor := block.NewProcessor(cfg.Kafka, cfg.Block, cfg.DataHub, registry.Registration, registry.Subtree, registry.CallbackURLRegistry, registry.SubtreeCounter, logger)

--- a/config.yaml
+++ b/config.yaml
@@ -321,6 +321,18 @@ callback:
   # Env: CALLBACK_MAX_IDLE_CONNS_PER_HOST
   maxIdleConnsPerHost: 16
 
+  # SSRF guard escape hatch. When false (the default), callback URLs that
+  # resolve to loopback (127.0.0.0/8, ::1), link-local (169.254.0.0/16,
+  # fe80::/10), or RFC1918 (10/8, 172.16/12, 192.168/16) addresses are
+  # rejected at /watch registration AND the callback delivery client
+  # refuses to dial them. Cloud metadata hostnames (metadata.google.internal,
+  # 169.254.169.254) are always blocked. Set to true ONLY if you need to
+  # deliver to internal services on purpose (e.g. local testing,
+  # in-cluster sidecars). The service logs a warning at startup when this
+  # is enabled.
+  # Env: CALLBACK_ALLOW_PRIVATE_IPS
+  allowPrivateIPs: false
+
 # ---------------------------------------------------------------------------
 # Blob Store — subtree data storage
 # ---------------------------------------------------------------------------

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -2,11 +2,13 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
-	"net/url"
 	"regexp"
 
 	"github.com/go-chi/chi/v5"
+
+	"github.com/bsv-blockchain/merkle-service/internal/ssrfguard"
 )
 
 var txidRegex = regexp.MustCompile(`^[a-fA-F0-9]{64}$`)
@@ -56,14 +58,31 @@ func (s *Server) handleWatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate callback URL
+	// Validate callback URL. ValidateURL covers scheme/host syntax AND the
+	// SSRF deny-list (loopback / link-local / RFC1918 / metadata endpoints
+	// / 0.0.0.0 / multicast). The dial-time guard in
+	// internal/callback.deliverCallback re-checks at connection time so a
+	// URL that survives validation but later DNS-rebinds onto a private
+	// IP is still refused.
 	if req.CallbackURL == "" {
 		writeJSON(w, http.StatusBadRequest, ErrorResponse{Error: "callbackUrl is required"})
 		return
 	}
-	parsedURL, err := url.Parse(req.CallbackURL)
-	if err != nil || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") || parsedURL.Host == "" {
-		writeJSON(w, http.StatusBadRequest, ErrorResponse{Error: "invalid callbackUrl: must be a valid HTTP/HTTPS URL"})
+	if err := ssrfguard.ValidateURL(req.CallbackURL, s.allowPrivateCallbackIPs, nil); err != nil {
+		// Distinguish the two error classes so callers get a useful 400 message
+		// without leaking internal lookup details.
+		var msg string
+		switch {
+		case errors.Is(err, ssrfguard.ErrBlockedAddress):
+			msg = "invalid callbackUrl: host is on the SSRF deny-list (private, loopback, link-local, or metadata-endpoint address)"
+		default:
+			msg = "invalid callbackUrl: must be a valid HTTP/HTTPS URL with a public host"
+		}
+		s.Logger.Warn("rejected callback URL registration",
+			"reason", err.Error(),
+			"txid", req.TxID,
+		)
+		writeJSON(w, http.StatusBadRequest, ErrorResponse{Error: msg})
 		return
 	}
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/bsv-blockchain/merkle-service/internal/config"
 	"github.com/go-chi/chi/v5"
@@ -130,5 +131,105 @@ func TestServerHasURLRegistryField(t *testing.T) {
 	s2 := NewServer(config.APIConfig{Port: 8080}, nil, nil, nil, nil)
 	if s2.urlRegistry != nil {
 		t.Error("expected nil urlRegistry when nil passed to NewServer")
+	}
+}
+
+// TestHandleWatch_RejectsSSRFTargets ensures /watch refuses callback URLs
+// pointing at private/loopback/link-local destinations and metadata
+// endpoints. Verifies the registration-time SSRF guard for F-008.
+func TestHandleWatch_RejectsSSRFTargets(t *testing.T) {
+	const txid = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"loopback v4", "http://127.0.0.1/cb"},
+		{"loopback v6", "http://[::1]/cb"},
+		{"link-local metadata", "http://169.254.169.254/latest/meta-data/"},
+		{"rfc1918 10/8", "http://10.0.0.1/cb"},
+		{"rfc1918 192.168", "http://192.168.1.1/cb"},
+		{"rfc1918 172.16", "http://172.16.0.1/cb"},
+		{"link-local v6", "http://[fe80::1]/cb"},
+		{"unspecified v4", "http://0.0.0.0/cb"},
+		{"metadata.google.internal", "http://metadata.google.internal/computeMetadata/v1/"},
+		// URL parser quirk: this parses with hostname=127.0.0.1 (the
+		// "@" splits userinfo from host). Userinfo is independently
+		// rejected and the resolved hostname is loopback — either path
+		// must fail.
+		{"userinfo bypass", "https://example.com:80@127.0.0.1/foo"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			router, _ := newTestRouter()
+			body := `{"txid": "` + txid + `", "callbackUrl": "` + tc.url + `"}`
+			w := postWatch(router, body)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400 for %s (%q), got %d (body=%s)", tc.name, tc.url, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestHandleWatch_RejectsBadScheme ensures non-http(s) schemes are
+// refused. file:, gopher:, etc. are SSRF amplifiers in Go's net/http.
+func TestHandleWatch_RejectsBadScheme(t *testing.T) {
+	const txid = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+	for _, raw := range []string{
+		"file:///etc/passwd",
+		"gopher://example.com/foo",
+		"ftp://example.com/foo",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			router, _ := newTestRouter()
+			body := `{"txid": "` + txid + `", "callbackUrl": "` + raw + `"}`
+			w := postWatch(router, body)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d (%s)", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+// fakeRegStore is a minimal in-memory RegistrationStore used by tests
+// that need /watch to make it past validation without standing up
+// Aerospike or SQL.
+type fakeRegStore struct {
+	added []struct{ txid, url string }
+}
+
+func (f *fakeRegStore) Add(txid, url string) error {
+	f.added = append(f.added, struct{ txid, url string }{txid, url})
+	return nil
+}
+func (f *fakeRegStore) Get(string) ([]string, error)                  { return nil, nil }
+func (f *fakeRegStore) BatchGet([]string) (map[string][]string, error) { return nil, nil }
+func (f *fakeRegStore) UpdateTTL(string, time.Duration) error          { return nil }
+func (f *fakeRegStore) BatchUpdateTTL([]string, time.Duration) error   { return nil }
+
+// TestHandleWatch_AllowPrivateIPs verifies the operator escape hatch:
+// when SetAllowPrivateCallbackIPs(true) is set, private/loopback URLs
+// are accepted at registration time.
+func TestHandleWatch_AllowPrivateIPs(t *testing.T) {
+	router := chi.NewRouter()
+	fake := &fakeRegStore{}
+	s := NewServer(config.APIConfig{Port: 8080}, fake, nil, nil, nil)
+	router.Post("/watch", s.handleWatch)
+
+	// Default deny: same URL is rejected with 400.
+	const txid = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+	body := `{"txid": "` + txid + `", "callbackUrl": "http://127.0.0.1:9000/cb"}`
+	w := postWatch(router, body)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("default-deny: expected 400, got %d", w.Code)
+	}
+
+	// Opt in: now the same URL is accepted.
+	s.SetAllowPrivateCallbackIPs(true)
+	w = postWatch(router, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("allowPrivate=true: expected 200, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	if len(fake.added) != 1 || fake.added[0].url != "http://127.0.0.1:9000/cb" {
+		t.Fatalf("expected fakeRegStore to record private callback, got %+v", fake.added)
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -27,6 +27,11 @@ type Server struct {
 	regStore    store.RegistrationStore
 	urlRegistry store.CallbackURLRegistry
 	health      store.BackendHealth
+	// allowPrivateCallbackIPs, when true, lets /watch accept callback
+	// URLs that resolve to loopback/link-local/RFC1918 addresses.
+	// Defaults to false (deny). See SetAllowPrivateCallbackIPs and
+	// CallbackConfig.AllowPrivateIPs.
+	allowPrivateCallbackIPs bool
 }
 
 func NewServer(cfg config.APIConfig, regStore store.RegistrationStore, urlRegistry store.CallbackURLRegistry, health store.BackendHealth, logger *slog.Logger) *Server {
@@ -41,6 +46,20 @@ func NewServer(cfg config.APIConfig, regStore store.RegistrationStore, urlRegist
 		s.Logger = logger
 	}
 	return s
+}
+
+// SetAllowPrivateCallbackIPs toggles the SSRF guard on /watch. When false
+// (the default) callback URLs resolving to private/loopback/link-local
+// destinations are rejected at registration time. Wire this from
+// CallbackConfig.AllowPrivateIPs at startup.
+func (s *Server) SetAllowPrivateCallbackIPs(allow bool) {
+	s.allowPrivateCallbackIPs = allow
+	if allow && s.Logger != nil {
+		s.Logger.Warn(
+			"SSRF guard relaxed: /watch will accept callback URLs pointing at private/loopback/link-local addresses",
+			"setting", "callback.allowPrivateIPs",
+		)
+	}
 }
 
 // Router returns the chi router. Must be called after Init.

--- a/internal/callback/delivery.go
+++ b/internal/callback/delivery.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/IBM/sarama"
@@ -22,6 +23,7 @@ import (
 	"github.com/bsv-blockchain/merkle-service/internal/config"
 	"github.com/bsv-blockchain/merkle-service/internal/kafka"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
+	"github.com/bsv-blockchain/merkle-service/internal/ssrfguard"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
 )
 
@@ -126,32 +128,13 @@ func NewDeliveryService(cfg *config.Config, dedupStore CallbackDeduper, stumpSto
 func (d *DeliveryService) Init(_ interface{}) error {
 	d.InitBase("callback-delivery")
 
-	// Set up the HTTP client with tuned transport for high-throughput delivery.
-	maxConnsPerHost := d.cfg.Callback.MaxConnsPerHost
-	if maxConnsPerHost <= 0 {
-		maxConnsPerHost = 32
+	if d.cfg.Callback.AllowPrivateIPs {
+		d.Logger.Warn(
+			"SSRF guard relaxed: callback delivery will dial private/loopback/link-local addresses",
+			"setting", "callback.allowPrivateIPs",
+		)
 	}
-	maxIdleConnsPerHost := d.cfg.Callback.MaxIdleConnsPerHost
-	if maxIdleConnsPerHost <= 0 {
-		maxIdleConnsPerHost = 16
-	}
-
-	transport := &http.Transport{
-		MaxIdleConns:        maxConnsPerHost * 10, // global pool
-		MaxIdleConnsPerHost: maxIdleConnsPerHost,
-		MaxConnsPerHost:     maxConnsPerHost,
-		IdleConnTimeout:     90 * time.Second,
-		DisableCompression:  true, // small JSON payloads — compression adds latency
-		DialContext: (&net.Dialer{
-			Timeout:   10 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-	}
-
-	d.httpClient = &http.Client{
-		Timeout:   time.Duration(d.cfg.Callback.TimeoutSec) * time.Second,
-		Transport: transport,
-	}
+	d.httpClient = newDeliveryHTTPClient(d.cfg.Callback)
 
 	// Create producer for publishing permanently failed messages to the DLQ topic.
 	dlqProducer, err := kafka.NewProducer(
@@ -197,8 +180,9 @@ func (d *DeliveryService) Init(_ interface{}) error {
 		"backoffBaseSec", d.cfg.Callback.BackoffBaseSec,
 		"timeoutSec", d.cfg.Callback.TimeoutSec,
 		"futureRetryWaitCap", futureRetryWaitCap,
-		"maxConnsPerHost", maxConnsPerHost,
-		"maxIdleConnsPerHost", maxIdleConnsPerHost,
+		"maxConnsPerHost", maxConnsPerHostOrDefault(d.cfg.Callback.MaxConnsPerHost),
+		"maxIdleConnsPerHost", maxIdleConnsPerHostOrDefault(d.cfg.Callback.MaxIdleConnsPerHost),
+		"allowPrivateIPs", d.cfg.Callback.AllowPrivateIPs,
 	)
 
 	return nil
@@ -690,6 +674,54 @@ func hashTxIDs(txids []string) string {
 	sort.Strings(sorted)
 	h := sha256.Sum256([]byte(strings.Join(sorted, ",")))
 	return hex.EncodeToString(h[:8])
+}
+
+// maxConnsPerHostOrDefault returns v or 32 when v <= 0.
+func maxConnsPerHostOrDefault(v int) int {
+	if v <= 0 {
+		return 32
+	}
+	return v
+}
+
+// maxIdleConnsPerHostOrDefault returns v or 16 when v <= 0.
+func maxIdleConnsPerHostOrDefault(v int) int {
+	if v <= 0 {
+		return 16
+	}
+	return v
+}
+
+// newDeliveryHTTPClient builds the HTTP client used to deliver callbacks.
+// It applies an SSRF-aware Dialer.Control hook that rejects connections
+// to private/loopback/link-local IPs unless cfg.AllowPrivateIPs is set.
+// The hook fires after DNS resolution so DNS rebinding cannot bypass it
+// (Go's resolver passes the resolved IP to Control as part of address).
+func newDeliveryHTTPClient(cfg config.CallbackConfig) *http.Client {
+	allowPrivate := cfg.AllowPrivateIPs
+	transport := &http.Transport{
+		MaxIdleConns:        maxConnsPerHostOrDefault(cfg.MaxConnsPerHost) * 10,
+		MaxIdleConnsPerHost: maxIdleConnsPerHostOrDefault(cfg.MaxIdleConnsPerHost),
+		MaxConnsPerHost:     maxConnsPerHostOrDefault(cfg.MaxConnsPerHost),
+		IdleConnTimeout:     90 * time.Second,
+		DisableCompression:  true, // small JSON payloads — compression adds latency
+		DialContext: (&net.Dialer{
+			Timeout:   10 * time.Second,
+			KeepAlive: 30 * time.Second,
+			Control: func(network, address string, _ syscall.RawConn) error {
+				// Only filter inet sockets — Control is also called for
+				// unix sockets in pathological cases; ignore those.
+				if network != "tcp" && network != "tcp4" && network != "tcp6" {
+					return nil
+				}
+				return ssrfguard.CheckDialAddress(address, allowPrivate)
+			},
+		}).DialContext,
+	}
+	return &http.Client{
+		Timeout:   time.Duration(cfg.TimeoutSec) * time.Second,
+		Transport: transport,
+	}
 }
 
 // publishToDLQ publishes a permanently failed message to the dead-letter queue topic.

--- a/internal/callback/delivery_ssrf_test.go
+++ b/internal/callback/delivery_ssrf_test.go
@@ -1,0 +1,93 @@
+package callback
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bsv-blockchain/merkle-service/internal/config"
+	"github.com/bsv-blockchain/merkle-service/internal/kafka"
+)
+
+// TestDeliveryHTTPClient_BlocksLoopbackByDefault verifies the SSRF
+// dial-time guard refuses to connect to a 127.0.0.1 server even though
+// httptest.NewServer happily accepts it. This catches the DNS-rebinding
+// scenario where a callback URL points at "evil.example.com" but the
+// attacker has flipped their DNS to return 127.0.0.1 between
+// registration time and delivery time.
+func TestDeliveryHTTPClient_BlocksLoopbackByDefault(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("server should not have been reached: %s %s", r.Method, r.URL)
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := config.CallbackConfig{TimeoutSec: 2, AllowPrivateIPs: false}
+	client := newDeliveryHTTPClient(cfg)
+
+	// httptest binds to 127.0.0.1; attempting to reach it must fail.
+	resp, err := client.Get(srv.URL)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatalf("expected dial-time block, got status %d", resp.StatusCode)
+	}
+	if !strings.Contains(err.Error(), "blocked") &&
+		!strings.Contains(err.Error(), "refusing to dial") {
+		t.Fatalf("expected SSRF guard error, got: %v", err)
+	}
+}
+
+// TestDeliveryHTTPClient_AllowPrivateOptIn verifies the operator
+// escape-hatch: with AllowPrivateIPs=true the same client successfully
+// dials 127.0.0.1.
+func TestDeliveryHTTPClient_AllowPrivateOptIn(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := config.CallbackConfig{TimeoutSec: 5, AllowPrivateIPs: true}
+	client := newDeliveryHTTPClient(cfg)
+
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("expected success with allowPrivateIPs=true, got %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", resp.StatusCode)
+	}
+	if !hit {
+		t.Fatal("server handler was not reached")
+	}
+}
+
+// TestDeliverCallback_RefusesPrivateIPViaTransport ensures
+// deliverCallback (the high-level entry point) reports a transport
+// error when the URL host is private and the SSRF guard is on. This is
+// the end-to-end check at the delivery layer.
+func TestDeliverCallback_RefusesPrivateIPViaTransport(t *testing.T) {
+	cfg := defaultTestConfig()
+	cfg.Callback.AllowPrivateIPs = false
+	client := newDeliveryHTTPClient(cfg.Callback)
+
+	ds, _, _, _ := newTestDeliveryServiceWithStumps(t, cfg, client)
+
+	msg := &kafka.CallbackTopicMessage{
+		// Valid public-looking URL parse, but resolves to loopback.
+		CallbackURL: "http://127.0.0.1:1/cb",
+		Type:        kafka.CallbackSeenOnNetwork,
+		TxID:        "deadbeef",
+	}
+	err := ds.deliverCallback(context.Background(), msg)
+	if err == nil {
+		t.Fatal("expected delivery to fail with SSRF block, got nil")
+	}
+	if !strings.Contains(err.Error(), "blocked") &&
+		!strings.Contains(err.Error(), "refusing") {
+		t.Fatalf("expected SSRF block error, got: %v", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -211,6 +211,13 @@ type CallbackConfig struct {
 	DeliveryWorkers     int `yaml:"deliveryWorkers"     mapstructure:"deliveryworkers"`
 	MaxConnsPerHost     int `yaml:"maxConnsPerHost"     mapstructure:"maxconnsperhost"`
 	MaxIdleConnsPerHost int `yaml:"maxIdleConnsPerHost" mapstructure:"maxidleconnsperhost"`
+	// AllowPrivateIPs disables the SSRF guard that normally rejects
+	// callback URLs (or dial addresses) pointing at loopback,
+	// link-local, or RFC1918 destinations. Default false. Operators
+	// who legitimately need to deliver to internal services (testing,
+	// in-cluster sidecars) can set this to true. The guard against
+	// 0.0.0.0/multicast destinations remains in force regardless.
+	AllowPrivateIPs bool `yaml:"allowPrivateIPs" mapstructure:"allowprivateips"`
 }
 
 // BlobStoreConfig holds blob store configuration.
@@ -316,6 +323,7 @@ func registerDefaults(v *viper.Viper) {
 	v.SetDefault("callback.deliveryworkers", 64)
 	v.SetDefault("callback.maxconnsperhost", 32)
 	v.SetDefault("callback.maxidleconnsperhost", 16)
+	v.SetDefault("callback.allowprivateips", false)
 
 	// BlobStore
 	v.SetDefault("blobstore.url", "file:///tmp/merkle-subtrees")
@@ -425,6 +433,7 @@ func bindEnvVars(v *viper.Viper) {
 		"callback.deliveryworkers":     "CALLBACK_DELIVERY_WORKERS",
 		"callback.maxconnsperhost":     "CALLBACK_MAX_CONNS_PER_HOST",
 		"callback.maxidleconnsperhost": "CALLBACK_MAX_IDLE_CONNS_PER_HOST",
+		"callback.allowprivateips":     "CALLBACK_ALLOW_PRIVATE_IPS",
 
 		// BlobStore
 		"blobstore.url": "BLOB_STORE_URL",

--- a/internal/ssrfguard/ssrfguard.go
+++ b/internal/ssrfguard/ssrfguard.go
@@ -1,0 +1,201 @@
+// Package ssrfguard implements a shared SSRF (Server-Side Request Forgery)
+// blocking predicate used by both /watch URL validation at registration time
+// and the callback delivery HTTP client at dial time.
+//
+// The same predicate runs in both layers so a URL that survives validation
+// (e.g. due to DNS rebinding between validation and delivery) is still
+// rejected when the dial actually happens. Callers can opt out via
+// AllowPrivate when an operator has explicitly allow-listed internal
+// callbacks.
+//
+// Threat model
+//
+// The /watch endpoint accepts a callback URL from a potentially untrusted
+// caller and the callback delivery worker later POSTs to that URL from
+// inside the cluster. Without guards an attacker can register, e.g.,
+//
+//	http://169.254.169.254/latest/meta-data/iam/security-credentials/
+//
+// and turn the delivery worker into an SSRF primitive against cloud
+// metadata endpoints, kubernetes services, or any RFC1918 neighbour. We
+// block by destination IP rather than hostname so an attacker cannot
+// bypass via DNS, IP literal, or rebinding.
+package ssrfguard
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// ErrBlockedAddress is returned when a URL or destination address points
+// at a private/loopback/link-local/multicast/unspecified IP and the
+// caller has not opted in to allow private destinations.
+var ErrBlockedAddress = errors.New("destination address is blocked by SSRF policy")
+
+// ErrInvalidURL is returned when a callback URL is structurally invalid
+// (parse failure, missing scheme/host, disallowed scheme, etc.).
+var ErrInvalidURL = errors.New("invalid callback URL")
+
+// blockedHostnames is a small allow-deny list of hostnames that are
+// considered SSRF-relevant on top of the IP-based predicate. They mostly
+// resolve to link-local IPs (e.g. 169.254.169.254) which are already
+// covered by IsLinkLocalUnicast, but we list them defensively so the
+// rejection message is human-readable when someone tries them by name.
+var blockedHostnames = map[string]struct{}{
+	"metadata.google.internal":           {},
+	"metadata":                           {},
+	"metadata.goog":                      {},
+	"169.254.169.254":                    {},
+	"fd00:ec2::254":                      {}, // AWS IMDSv2 link-local IPv6
+}
+
+// IsBlockedIP reports whether ip is on the SSRF deny-list. The deny-list
+// covers loopback, link-local unicast/multicast, multicast, RFC1918
+// private (10/8, 172.16/12, 192.168/16) and CGNAT (100.64/10),
+// unique-local IPv6 (fc00::/7), the IPv4 unspecified address (0.0.0.0)
+// and the IPv6 unspecified address (::). Loopback covers 127/8 and ::1.
+//
+// Pass allowPrivate=true to opt out of the private/loopback/link-local
+// checks (operator-controlled escape hatch for testing or legitimately
+// internal callbacks).
+func IsBlockedIP(ip net.IP, allowPrivate bool) bool {
+	if ip == nil {
+		// A nil IP cannot be safely dialed; treat as blocked.
+		return true
+	}
+	if ip.IsUnspecified() {
+		// 0.0.0.0 and :: never identify a real remote host. They
+		// resolve to the local machine's own listening sockets, which
+		// is exactly what an SSRF attacker wants.
+		return true
+	}
+	if ip.IsMulticast() || ip.IsInterfaceLocalMulticast() || ip.IsLinkLocalMulticast() {
+		return true
+	}
+	if allowPrivate {
+		return false
+	}
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsPrivate() {
+		return true
+	}
+	// IPv6 unique local (fc00::/7) — IsPrivate covers this in Go 1.17+
+	// but we keep an explicit fallback for clarity / future-proofing.
+	if ip.To4() == nil && len(ip) == net.IPv6len && ip[0]&0xfe == 0xfc {
+		return true
+	}
+	return false
+}
+
+// IsBlockedHostname returns true if the hostname (lowercased, port
+// stripped) matches a known cloud metadata or internal hostname.
+// Hostname-based blocking is a best-effort defence-in-depth check on top
+// of IP-based blocking; the IP check is authoritative.
+func IsBlockedHostname(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" {
+		return false
+	}
+	// Strip an optional brackets + port from IPv6 literals.
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	host = strings.Trim(host, "[]")
+	_, ok := blockedHostnames[host]
+	return ok
+}
+
+// ValidateURL parses raw and rejects it if the URL is malformed, uses a
+// scheme other than http/https, has no host, or resolves to a blocked
+// destination. lookup is the DNS function used to resolve a hostname to
+// IP addresses; pass net.LookupIP in production and a stub in tests. If
+// lookup is nil, net.LookupIP is used.
+//
+// allowPrivate lets operators opt in to private/loopback/link-local
+// destinations. The metadata-hostname and unspecified/multicast checks
+// remain in force regardless.
+func ValidateURL(raw string, allowPrivate bool, lookup func(host string) ([]net.IP, error)) error {
+	if raw == "" {
+		return fmt.Errorf("%w: empty URL", ErrInvalidURL)
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidURL, err)
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("%w: scheme %q not allowed (must be http or https)", ErrInvalidURL, u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("%w: missing host", ErrInvalidURL)
+	}
+	// Reject userinfo entirely — `https://example.com:80@127.0.0.1/` would
+	// parse with Hostname() == "127.0.0.1" so the IP check below already
+	// catches the canonical form, but stripping userinfo also dodges any
+	// downstream tooling that incorrectly treats user@host as the host.
+	if u.User != nil {
+		return fmt.Errorf("%w: URL must not contain userinfo", ErrInvalidURL)
+	}
+
+	if IsBlockedHostname(host) {
+		return fmt.Errorf("%w: hostname %q is on the metadata-endpoint deny list", ErrBlockedAddress, host)
+	}
+
+	// If host is an IP literal, check it directly. Otherwise resolve and
+	// check every returned address — an attacker who controls DNS could
+	// otherwise return a single internal address that we miss if we only
+	// check the first.
+	if ip := net.ParseIP(host); ip != nil {
+		if IsBlockedIP(ip, allowPrivate) {
+			return fmt.Errorf("%w: %s", ErrBlockedAddress, ip.String())
+		}
+		return nil
+	}
+
+	if lookup == nil {
+		lookup = net.LookupIP
+	}
+	ips, err := lookup(host)
+	if err != nil {
+		// DNS resolution failure at registration time is treated as a
+		// validation error so the caller knows their URL is unusable;
+		// a typo'd hostname must not slip through validation only to
+		// silently DLQ later.
+		return fmt.Errorf("%w: failed to resolve %s: %v", ErrInvalidURL, host, err)
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("%w: %s did not resolve to any addresses", ErrInvalidURL, host)
+	}
+	for _, ip := range ips {
+		if IsBlockedIP(ip, allowPrivate) {
+			return fmt.Errorf("%w: %s resolves to %s", ErrBlockedAddress, host, ip.String())
+		}
+	}
+	return nil
+}
+
+// CheckDialAddress validates a host:port address that the dialer is
+// about to connect to. Used as a hook in net.Dialer.Control so DNS
+// rebinding or any host that slipped past ValidateURL is rejected at
+// connection time. address is the canonical "ip:port" form passed to
+// the network stack — it is always an IP literal at this point.
+func CheckDialAddress(address string, allowPrivate bool) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		// If we can't even parse the address, fail closed.
+		return fmt.Errorf("%w: cannot parse dial address %q: %v", ErrBlockedAddress, address, err)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		// Dialer.Control receives the resolved IP, so a non-IP host is
+		// itself anomalous; refuse rather than guess.
+		return fmt.Errorf("%w: dial address %q is not an IP", ErrBlockedAddress, host)
+	}
+	if IsBlockedIP(ip, allowPrivate) {
+		return fmt.Errorf("%w: refusing to dial %s", ErrBlockedAddress, ip.String())
+	}
+	return nil
+}

--- a/internal/ssrfguard/ssrfguard_test.go
+++ b/internal/ssrfguard/ssrfguard_test.go
@@ -1,0 +1,271 @@
+package ssrfguard
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestIsBlockedIP(t *testing.T) {
+	cases := []struct {
+		name         string
+		ip           string
+		allowPrivate bool
+		blocked      bool
+	}{
+		{"loopback v4", "127.0.0.1", false, true},
+		{"loopback v4 random", "127.10.20.30", false, true},
+		{"loopback v6", "::1", false, true},
+		{"link-local v4 metadata", "169.254.169.254", false, true},
+		{"link-local v4 generic", "169.254.0.1", false, true},
+		{"link-local v6", "fe80::1", false, true},
+		{"rfc1918 10/8", "10.0.0.1", false, true},
+		{"rfc1918 172.16/12", "172.16.0.1", false, true},
+		{"rfc1918 172.31/12 edge", "172.31.255.255", false, true},
+		{"rfc1918 192.168/16", "192.168.1.1", false, true},
+		{"unspecified v4", "0.0.0.0", false, true},
+		{"unspecified v6", "::", false, true},
+		{"multicast v4", "224.0.0.1", false, true},
+		{"multicast v6", "ff02::1", false, true},
+		{"unique-local v6", "fc00::1", false, true},
+		{"unique-local v6 fd", "fd12:3456:789a::1", false, true},
+		{"public v4", "8.8.8.8", false, false},
+		{"public v6", "2606:4700:4700::1111", false, false},
+		{"public v4 (allowPrivate)", "8.8.8.8", true, false},
+		// allowPrivate flips RFC1918/loopback/link-local but NOT
+		// unspecified/multicast which are never reachable destinations.
+		{"loopback (allowPrivate)", "127.0.0.1", true, false},
+		{"rfc1918 (allowPrivate)", "10.0.0.1", true, false},
+		{"link-local (allowPrivate)", "169.254.169.254", true, false},
+		{"unspecified (allowPrivate)", "0.0.0.0", true, true},
+		{"multicast (allowPrivate)", "224.0.0.1", true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ip := net.ParseIP(tc.ip)
+			if ip == nil {
+				t.Fatalf("could not parse %q as IP", tc.ip)
+			}
+			got := IsBlockedIP(ip, tc.allowPrivate)
+			if got != tc.blocked {
+				t.Fatalf("IsBlockedIP(%s, allowPrivate=%v) = %v, want %v", tc.ip, tc.allowPrivate, got, tc.blocked)
+			}
+		})
+	}
+}
+
+func TestIsBlockedIP_NilIP(t *testing.T) {
+	if !IsBlockedIP(nil, false) {
+		t.Fatal("nil IP should be blocked")
+	}
+	if !IsBlockedIP(nil, true) {
+		t.Fatal("nil IP should be blocked even when allowPrivate=true")
+	}
+}
+
+func TestIsBlockedHostname(t *testing.T) {
+	cases := []struct {
+		host    string
+		blocked bool
+	}{
+		{"metadata.google.internal", true},
+		{"METADATA.GOOGLE.INTERNAL", true},
+		{"metadata", true},
+		{"169.254.169.254", true},
+		{"example.com", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.host, func(t *testing.T) {
+			got := IsBlockedHostname(tc.host)
+			if got != tc.blocked {
+				t.Fatalf("IsBlockedHostname(%q) = %v, want %v", tc.host, got, tc.blocked)
+			}
+		})
+	}
+}
+
+// stubLookup builds a fake DNS function for tests.
+func stubLookup(m map[string][]string) func(string) ([]net.IP, error) {
+	return func(host string) ([]net.IP, error) {
+		ips, ok := m[host]
+		if !ok {
+			return nil, fmt.Errorf("no such host: %s", host)
+		}
+		out := make([]net.IP, 0, len(ips))
+		for _, s := range ips {
+			out = append(out, net.ParseIP(s))
+		}
+		return out, nil
+	}
+}
+
+func TestValidateURL_AcceptsPublic(t *testing.T) {
+	lookup := stubLookup(map[string][]string{
+		"example.com": {"93.184.216.34"},
+	})
+	if err := ValidateURL("https://example.com/foo", false, lookup); err != nil {
+		t.Fatalf("expected accept, got %v", err)
+	}
+}
+
+func TestValidateURL_RejectsBadScheme(t *testing.T) {
+	cases := []string{
+		"file:///etc/passwd",
+		"gopher://evil.example.com/",
+		"ftp://example.com/",
+		"javascript:alert(1)",
+	}
+	for _, raw := range cases {
+		t.Run(raw, func(t *testing.T) {
+			err := ValidateURL(raw, false, nil)
+			if !errors.Is(err, ErrInvalidURL) {
+				t.Fatalf("expected ErrInvalidURL, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateURL_RejectsIPLiterals(t *testing.T) {
+	cases := []string{
+		"http://127.0.0.1/foo",
+		"http://10.0.0.1/foo",
+		"http://192.168.1.1/foo",
+		"http://172.16.0.1/foo",
+		"http://172.31.255.255/foo",
+		"http://169.254.169.254/latest/meta-data/",
+		"http://0.0.0.0/foo",
+		"http://[::1]/foo",
+		"http://[fe80::1]/foo",
+		"http://[fc00::1]/foo",
+	}
+	for _, raw := range cases {
+		t.Run(raw, func(t *testing.T) {
+			err := ValidateURL(raw, false, nil)
+			if !errors.Is(err, ErrBlockedAddress) {
+				t.Fatalf("expected ErrBlockedAddress, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateURL_RejectsResolvedToPrivate(t *testing.T) {
+	lookup := stubLookup(map[string][]string{
+		"sneaky.example.com": {"10.0.0.42"},
+	})
+	err := ValidateURL("https://sneaky.example.com/foo", false, lookup)
+	if !errors.Is(err, ErrBlockedAddress) {
+		t.Fatalf("expected ErrBlockedAddress for hostname resolving to RFC1918, got %v", err)
+	}
+}
+
+func TestValidateURL_RejectsAnyOfMultiResolved(t *testing.T) {
+	// Attacker DNS returns one public + one private; must reject.
+	lookup := stubLookup(map[string][]string{
+		"mixed.example.com": {"8.8.8.8", "10.0.0.1"},
+	})
+	err := ValidateURL("https://mixed.example.com/foo", false, lookup)
+	if !errors.Is(err, ErrBlockedAddress) {
+		t.Fatalf("expected ErrBlockedAddress when any resolved IP is private, got %v", err)
+	}
+}
+
+func TestValidateURL_RejectsUserinfo(t *testing.T) {
+	// Even though Go's url.Parse correctly extracts hostname=127.0.0.1,
+	// we explicitly reject userinfo to dodge downstream parser quirks.
+	err := ValidateURL("https://example.com:80@127.0.0.1/foo", false, nil)
+	if !errors.Is(err, ErrInvalidURL) && !errors.Is(err, ErrBlockedAddress) {
+		t.Fatalf("expected rejection of userinfo URL, got %v", err)
+	}
+}
+
+func TestValidateURL_RejectsMetadataHostname(t *testing.T) {
+	lookup := stubLookup(map[string][]string{
+		"metadata.google.internal": {"8.8.8.8"}, // Even if it "resolves" public.
+	})
+	err := ValidateURL("https://metadata.google.internal/computeMetadata/v1/", false, lookup)
+	if !errors.Is(err, ErrBlockedAddress) {
+		t.Fatalf("expected ErrBlockedAddress for metadata hostname, got %v", err)
+	}
+}
+
+func TestValidateURL_AllowPrivateOptIn(t *testing.T) {
+	lookup := stubLookup(map[string][]string{
+		"internal.example": {"10.0.0.1"},
+	})
+	// allowPrivate=true: same input now passes.
+	if err := ValidateURL("https://internal.example/foo", true, lookup); err != nil {
+		t.Fatalf("expected accept with allowPrivate=true, got %v", err)
+	}
+	if err := ValidateURL("http://127.0.0.1:8080/cb", true, nil); err != nil {
+		t.Fatalf("expected accept with allowPrivate=true, got %v", err)
+	}
+}
+
+func TestValidateURL_DNSFailureIsValidationError(t *testing.T) {
+	lookup := stubLookup(map[string][]string{}) // empty = always errors
+	err := ValidateURL("https://nonexistent.example/", false, lookup)
+	if !errors.Is(err, ErrInvalidURL) {
+		t.Fatalf("expected ErrInvalidURL on DNS failure, got %v", err)
+	}
+}
+
+func TestValidateURL_EmptyAndMissingPieces(t *testing.T) {
+	if err := ValidateURL("", false, nil); !errors.Is(err, ErrInvalidURL) {
+		t.Fatalf("expected ErrInvalidURL for empty, got %v", err)
+	}
+	if err := ValidateURL("https:///foo", false, nil); !errors.Is(err, ErrInvalidURL) {
+		t.Fatalf("expected ErrInvalidURL for missing host, got %v", err)
+	}
+	// url.Parse rejects this with a parse error.
+	if err := ValidateURL("http://[::1", false, nil); !errors.Is(err, ErrInvalidURL) {
+		t.Fatalf("expected ErrInvalidURL for malformed IPv6 literal, got %v", err)
+	}
+}
+
+func TestCheckDialAddress(t *testing.T) {
+	cases := []struct {
+		name         string
+		address      string
+		allowPrivate bool
+		blocked      bool
+	}{
+		{"loopback", "127.0.0.1:8080", false, true},
+		{"loopback v6", "[::1]:443", false, true},
+		{"private", "10.0.0.1:80", false, true},
+		{"link-local", "169.254.169.254:80", false, true},
+		{"public", "93.184.216.34:443", false, false},
+		{"loopback (allowPrivate)", "127.0.0.1:8080", true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := CheckDialAddress(tc.address, tc.allowPrivate)
+			if tc.blocked {
+				if err == nil {
+					t.Fatalf("expected block, got nil")
+				}
+				if !errors.Is(err, ErrBlockedAddress) {
+					t.Fatalf("expected ErrBlockedAddress, got %v", err)
+				}
+				if !strings.Contains(err.Error(), "refusing") && !strings.Contains(err.Error(), "blocked") && !strings.Contains(err.Error(), "is not an IP") && !strings.Contains(err.Error(), "cannot parse") {
+					t.Fatalf("expected meaningful message, got %v", err)
+				}
+			} else if err != nil {
+				t.Fatalf("expected accept, got %v", err)
+			}
+		})
+	}
+}
+
+func TestCheckDialAddress_Malformed(t *testing.T) {
+	if err := CheckDialAddress("not-a-real-address", false); !errors.Is(err, ErrBlockedAddress) {
+		t.Fatalf("expected ErrBlockedAddress, got %v", err)
+	}
+	// Hostname rather than IP — Dialer.Control always receives an IP, so a
+	// non-IP host is anomalous and must fail closed.
+	if err := CheckDialAddress("example.com:80", false); !errors.Is(err, ErrBlockedAddress) {
+		t.Fatalf("expected ErrBlockedAddress for non-IP host, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- /watch now rejects callback URLs whose hosts resolve to private, loopback, link-local, multicast, unspecified, or cloud-metadata-endpoint IPs.
- Callback delivery's HTTP client installs a `net.Dialer.Control` hook that refuses to dial those addresses at connection time, catching DNS rebinding and any URL that survives validation.
- Both layers share a single predicate in the new `internal/ssrfguard` package so they cannot drift.
- New config knob `callback.allowPrivateIPs` (env `CALLBACK_ALLOW_PRIVATE_IPS`, default `false`) for operators that need internal callbacks. Both the API server and the delivery service log a noisy `WARN` at startup when the guard is relaxed. Unspecified/multicast remain blocked even when `allowPrivateIPs=true`.
- Bad schemes (`file:`, `gopher:`, `ftp:`, ...) are now rejected explicitly. URLs containing userinfo (e.g. `https://example.com:80@127.0.0.1/foo`) are also rejected to dodge URL-parser quirks.

## Files changed
- `internal/ssrfguard/{ssrfguard.go,ssrfguard_test.go}` — shared predicate + tests.
- `internal/api/handlers.go` — /watch uses `ssrfguard.ValidateURL`.
- `internal/api/server.go` — adds `SetAllowPrivateCallbackIPs`.
- `internal/api/handlers_test.go` — SSRF target rejection + opt-in tests.
- `internal/callback/delivery.go` — delivery HTTP client now installs the dial-time guard.
- `internal/callback/delivery_ssrf_test.go` — dial-time guard tests (loopback blocked, opt-in works, end-to-end via `deliverCallback`).
- `internal/config/config.go` — new `CallbackConfig.AllowPrivateIPs`, defaults + env binding.
- `cmd/api-server/main.go`, `cmd/merkle-service/main.go` — wire the flag into the API server.
- `config.yaml` — documents the new knob.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/... -count=1 -race` (all packages green)
- [x] `golangci-lint run ./internal/api/... ./internal/callback/... ./internal/ssrfguard/... ./internal/config/...` — only pre-existing errcheck noise remains; no new issues
- [ ] Reviewer to confirm the threat model: is /watch reachable by untrusted clients today? README/docs do not document an auth boundary; today the endpoint is unauthenticated and accepts callback URLs from any caller, so the registration-time guard is a real attack-surface reduction in addition to defence-in-depth.

Closes #20