### PR TITLE
fix(store): bound callback URL registry growth (#23)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,11 @@ type StoreSQLConfig struct {
 	SweeperInterval string `yaml:"sweeperInterval" mapstructure:"sweeperinterval"`
 	MaxOpenConns    int    `yaml:"maxOpenConns"    mapstructure:"maxopenconns"`
 	MaxIdleConns    int    `yaml:"maxIdleConns"    mapstructure:"maxidleconns"`
+	// CallbackURLRegistryRetention bounds the SQL callback URL registry. URLs
+	// whose last `Add` is older than this are dropped by the TTL sweeper.
+	// Format: any time.ParseDuration string ("168h", "7d" is NOT supported).
+	// Default 168h (7 days). See F-037 / issue #23.
+	CallbackURLRegistryRetention string `yaml:"callbackUrlRegistryRetention" mapstructure:"callbackurlregistryretention"`
 }
 
 // APIConfig holds HTTP API configuration.
@@ -68,6 +73,12 @@ type AerospikeConfig struct {
 	SeenSet              string   `yaml:"seenSet"              mapstructure:"seenset"`
 	CallbackDedupSet     string   `yaml:"callbackDedupSet"     mapstructure:"callbackdedupset"`
 	CallbackURLRegistry  string   `yaml:"callbackUrlRegistry"  mapstructure:"callbackurlregistry"`
+	// CallbackURLRegistryTTLSec is the per-URL eviction window applied by the
+	// Aerospike callback URL registry (and the SQL sibling). URLs whose last
+	// `Add` is older than this are evicted, bounding the registry's growth so
+	// BLOCK_PROCESSED fan-out and the underlying record(s) never grow without
+	// limit. Default 7 days. See F-037 / issue #23.
+	CallbackURLRegistryTTLSec int `yaml:"callbackUrlRegistryTTLSec" mapstructure:"callbackurlregistryttlsec"`
 	SubtreeCounterSet    string   `yaml:"subtreeCounterSet"    mapstructure:"subtreecounterset"`
 	SubtreeCounterTTLSec int      `yaml:"subtreeCounterTTLSec" mapstructure:"subtreecounterttlsec"`
 	CallbackAccumulatorSet    string `yaml:"callbackAccumulatorSet"    mapstructure:"callbackaccumulatorset"`
@@ -240,6 +251,7 @@ func registerDefaults(v *viper.Viper) {
 	v.SetDefault("store.sql.sweeperinterval", "60s")
 	v.SetDefault("store.sql.maxopenconns", 25)
 	v.SetDefault("store.sql.maxidleconns", 5)
+	v.SetDefault("store.sql.callbackurlregistryretention", "168h")
 
 	// Aerospike
 	v.SetDefault("aerospike.host", "localhost")
@@ -250,6 +262,7 @@ func registerDefaults(v *viper.Viper) {
 	v.SetDefault("aerospike.seenset", "merkle_seen_counters")
 	v.SetDefault("aerospike.callbackdedupset", "merkle_callback_dedup")
 	v.SetDefault("aerospike.callbackurlregistry", "merkle_callback_urls")
+	v.SetDefault("aerospike.callbackurlregistryttlsec", 7*24*60*60)
 	v.SetDefault("aerospike.subtreecounterset", "merkle_subtree_counters")
 	v.SetDefault("aerospike.subtreecounterttlsec", 600)
 	v.SetDefault("aerospike.callbackaccumulatorset", "merkle_callback_accum")
@@ -349,6 +362,7 @@ func bindEnvVars(v *viper.Viper) {
 		"store.sql.sweeperinterval": "STORE_SQL_SWEEPER_INTERVAL",
 		"store.sql.maxopenconns":    "STORE_SQL_MAX_OPEN_CONNS",
 		"store.sql.maxidleconns":    "STORE_SQL_MAX_IDLE_CONNS",
+		"store.sql.callbackurlregistryretention": "STORE_SQL_CALLBACK_URL_REGISTRY_RETENTION",
 
 		// Aerospike
 		"aerospike.host":      "AEROSPIKE_HOST",
@@ -358,7 +372,8 @@ func bindEnvVars(v *viper.Viper) {
 		"aerospike.setname":   "AEROSPIKE_SET",
 		"aerospike.seenset":             "AEROSPIKE_SEEN_SET",
 		"aerospike.callbackdedupset":    "AEROSPIKE_CALLBACK_DEDUP_SET",
-		"aerospike.callbackurlregistry": "AEROSPIKE_CALLBACK_URL_REGISTRY",
+		"aerospike.callbackurlregistry":         "AEROSPIKE_CALLBACK_URL_REGISTRY",
+		"aerospike.callbackurlregistryttlsec":   "AEROSPIKE_CALLBACK_URL_REGISTRY_TTL_SEC",
 		"aerospike.subtreecounterset":         "AEROSPIKE_SUBTREE_COUNTER_SET",
 		"aerospike.subtreecounterttlsec":      "AEROSPIKE_SUBTREE_COUNTER_TTL_SEC",
 		"aerospike.callbackaccumulatorset":    "AEROSPIKE_CALLBACK_ACCUMULATOR_SET",

--- a/internal/store/callback_url_registry.go
+++ b/internal/store/callback_url_registry.go
@@ -1,93 +1,147 @@
 package store
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"time"
 
 	as "github.com/aerospike/aerospike-client-go/v7"
+	astypes "github.com/aerospike/aerospike-client-go/v7/types"
 )
 
 const (
-	callbackURLRegistryKey = "__all_urls__"
-	callbackURLsBin        = "urls"
+	// callbackURLBin holds the original URL string on each per-URL record.
+	// Each registered callback URL lives in its own Aerospike record keyed by
+	// sha256(url); the bin lets GetAll reconstruct the URL list during scan.
+	callbackURLBin = "u"
+
+	// defaultCallbackURLRegistryTTLSec is the eviction window applied to a
+	// registered callback URL when no explicit TTL is configured. URLs that
+	// haven't seen a fresh `Add` within this window are evicted by Aerospike's
+	// nsup. 7 days is long enough to cover quiet-but-still-watching tenants
+	// while bounding the registry's growth.
+	defaultCallbackURLRegistryTTLSec = 7 * 24 * 60 * 60
 )
 
 // aerospikeCallbackURLRegistry is the Aerospike-backed CallbackURLRegistry
-// implementation. Uses a single record with a CDT list for efficient enumeration.
+// implementation. Every registered URL is stored in its own record keyed by
+// sha256(url); GetAll reconstructs the active list via ScanAll. Per-record
+// TTL prevents the registry from growing forever (F-037 / issue #23). Each
+// `Add` rewrites the record, which refreshes the TTL — i.e. a URL stays in
+// the registry as long as it keeps registering watches.
 type aerospikeCallbackURLRegistry struct {
 	client      *AerospikeClient
 	setName     string
 	logger      *slog.Logger
 	maxRetries  int
 	retryBaseMs int
+	// ttlSec is the per-record TTL applied on Add. Treated as 0 = no TTL only
+	// when the configured value is non-positive (callers must opt out
+	// explicitly); the constructor coerces to defaultCallbackURLRegistryTTLSec.
+	ttlSec int
 }
 
 var _ CallbackURLRegistry = (*aerospikeCallbackURLRegistry)(nil)
 
 // NewCallbackURLRegistry creates a new Aerospike-backed callback URL registry.
-func NewCallbackURLRegistry(client *AerospikeClient, setName string, maxRetries int, retryBaseMs int, logger *slog.Logger) CallbackURLRegistry {
+// ttlSec sets the per-URL eviction window — pass 0 (or negative) to use the
+// default of 7 days.
+func NewCallbackURLRegistry(client *AerospikeClient, setName string, ttlSec int, maxRetries int, retryBaseMs int, logger *slog.Logger) CallbackURLRegistry {
+	if ttlSec <= 0 {
+		ttlSec = defaultCallbackURLRegistryTTLSec
+	}
 	return &aerospikeCallbackURLRegistry{
 		client:      client,
 		setName:     setName,
 		logger:      logger,
 		maxRetries:  maxRetries,
 		retryBaseMs: retryBaseMs,
+		ttlSec:      ttlSec,
 	}
 }
 
-// Add registers a callback URL in the registry. Duplicates are silently ignored.
+// callbackURLKey returns the Aerospike record key digest for a callback URL.
+// Hashing keeps the key size bounded regardless of URL length and guarantees
+// natural deduplication: the same URL hashes to the same record, so repeated
+// Add calls upsert a single record (and refresh its TTL) instead of growing.
+func callbackURLKey(url string) string {
+	h := sha256.Sum256([]byte(url))
+	return hex.EncodeToString(h[:])
+}
+
+// Add registers a callback URL in the registry. Repeat calls upsert the same
+// record and refresh its TTL, so an actively-watching URL never expires.
 func (r *aerospikeCallbackURLRegistry) Add(callbackURL string) error {
-	key, err := as.NewKey(r.client.Namespace(), r.setName, callbackURLRegistryKey)
+	key, err := as.NewKey(r.client.Namespace(), r.setName, callbackURLKey(callbackURL))
 	if err != nil {
 		return fmt.Errorf("failed to create key: %w", err)
 	}
 
 	wp := r.client.WritePolicy(r.maxRetries, r.retryBaseMs)
 	wp.RecordExistsAction = as.UPDATE
-
-	listPolicy := as.NewListPolicy(as.ListOrderOrdered, as.ListWriteFlagsAddUnique|as.ListWriteFlagsNoFail)
-	ops := []*as.Operation{
-		as.ListAppendWithPolicyOp(listPolicy, callbackURLsBin, callbackURL),
+	if r.ttlSec > 0 {
+		wp.Expiration = uint32(r.ttlSec)
 	}
 
-	_, err = r.client.Client().Operate(wp, key, ops...)
-	if err != nil {
+	bins := as.BinMap{callbackURLBin: callbackURL}
+	if err := r.client.Client().Put(wp, key, bins); err != nil {
+		// If TTL is rejected (namespace lacks nsup-period), retry without TTL.
+		// We log loudly because losing TTL re-introduces F-037's unbounded
+		// growth — the operator should fix the namespace config.
+		if asErr, ok := err.(as.Error); ok && asErr.Matches(astypes.FAIL_FORBIDDEN) && r.ttlSec > 0 {
+			if r.logger != nil {
+				r.logger.Warn("callback URL registry TTL rejected, writing without TTL "+
+					"(configure Aerospike nsup-period to enable bounded growth)",
+					"url", callbackURL)
+			}
+			wp2 := r.client.WritePolicy(r.maxRetries, r.retryBaseMs)
+			wp2.RecordExistsAction = as.UPDATE
+			if err2 := r.client.Client().Put(wp2, key, bins); err2 != nil {
+				return fmt.Errorf("failed to add callback URL to registry (without TTL): %w", err2)
+			}
+			return nil
+		}
 		return fmt.Errorf("failed to add callback URL to registry: %w", err)
 	}
-
 	return nil
 }
 
-// GetAll returns all registered callback URLs.
+// GetAll returns every registered callback URL. Implemented as a ScanAll over
+// the registry set — the URL count is bounded by per-record TTL eviction
+// (typically <= a few thousand) and BLOCK_PROCESSED fan-out runs at most once
+// per block, so a scan-per-block is cheap relative to the actual callback
+// publish work.
 func (r *aerospikeCallbackURLRegistry) GetAll() ([]string, error) {
-	key, err := as.NewKey(r.client.Namespace(), r.setName, callbackURLRegistryKey)
+	sp := as.NewScanPolicy()
+	sp.IncludeBinData = true
+	// Bound the scan so a stalled node can't hang BLOCK_PROCESSED forever.
+	sp.TotalTimeout = 30 * time.Second
+	sp.SocketTimeout = 5 * time.Second
+	// Match the rest of the codebase's stance: don't pile retries onto a
+	// flaky cluster — let the caller re-scan on the next block.
+	sp.MaxRetries = 0
+
+	rs, err := r.client.Client().ScanAll(sp, r.client.Namespace(), r.setName, callbackURLBin)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create key: %w", err)
+		return nil, fmt.Errorf("failed to scan callback URLs: %w", err)
 	}
+	defer func() { _ = rs.Close() }()
 
-	record, err := r.client.Client().Get(r.client.ReadPolicy(), key, callbackURLsBin)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get callback URLs: %w", err)
-	}
-	if record == nil {
-		return nil, nil
-	}
-
-	binVal := record.Bins[callbackURLsBin]
-	if binVal == nil {
-		return nil, nil
-	}
-
-	list, ok := binVal.([]interface{})
-	if !ok {
-		return nil, fmt.Errorf("unexpected bin type for callback URLs: %T", binVal)
-	}
-
-	urls := make([]string, 0, len(list))
-	for _, v := range list {
-		if s, ok := v.(string); ok {
-			urls = append(urls, s)
+	var urls []string
+	for res := range rs.Results() {
+		if res.Err != nil {
+			return nil, fmt.Errorf("scan error reading callback URLs: %w", res.Err)
 		}
+		if res.Record == nil {
+			continue
+		}
+		v, ok := res.Record.Bins[callbackURLBin].(string)
+		if !ok || v == "" {
+			continue
+		}
+		urls = append(urls, v)
 	}
 	return urls, nil
 }

--- a/internal/store/callback_url_registry_test.go
+++ b/internal/store/callback_url_registry_test.go
@@ -4,19 +4,23 @@ import (
 	"testing"
 )
 
-// TestCallbackURLRegistryKey verifies the constant values are set correctly.
-func TestCallbackURLRegistryKey(t *testing.T) {
-	if callbackURLRegistryKey != "__all_urls__" {
-		t.Errorf("expected __all_urls__, got %s", callbackURLRegistryKey)
+// TestCallbackURLRegistryConstants pins the constants the registry uses to
+// build per-URL records. Changing these values is a wire-compatibility break:
+// existing prod records would no longer be locatable. If you must change one,
+// add a migration story to the PR.
+func TestCallbackURLRegistryConstants(t *testing.T) {
+	if callbackURLBin != "u" {
+		t.Errorf("callbackURLBin: expected u, got %s", callbackURLBin)
 	}
-	if callbackURLsBin != "urls" {
-		t.Errorf("expected urls, got %s", callbackURLsBin)
+	if defaultCallbackURLRegistryTTLSec != 7*24*60*60 {
+		t.Errorf("default TTL drifted: %d", defaultCallbackURLRegistryTTLSec)
 	}
 }
 
-// TestNewCallbackURLRegistry verifies constructor sets fields.
+// TestNewCallbackURLRegistry verifies constructor sets fields, including the
+// new TTL knob (F-037 / issue #23).
 func TestNewCallbackURLRegistry(t *testing.T) {
-	r := NewCallbackURLRegistry(nil, "test-set", 3, 100, nil).(*aerospikeCallbackURLRegistry)
+	r := NewCallbackURLRegistry(nil, "test-set", 600, 3, 100, nil).(*aerospikeCallbackURLRegistry)
 	if r.setName != "test-set" {
 		t.Errorf("expected set name test-set, got %s", r.setName)
 	}
@@ -26,4 +30,100 @@ func TestNewCallbackURLRegistry(t *testing.T) {
 	if r.retryBaseMs != 100 {
 		t.Errorf("expected retryBaseMs 100, got %d", r.retryBaseMs)
 	}
+	if r.ttlSec != 600 {
+		t.Errorf("expected ttlSec 600, got %d", r.ttlSec)
+	}
+}
+
+// TestNewCallbackURLRegistry_DefaultTTL verifies that a zero/negative ttlSec
+// arg is coerced to the default 7-day window, so a misconfigured deployment
+// can't accidentally fall back to F-037's unbounded behaviour.
+func TestNewCallbackURLRegistry_DefaultTTL(t *testing.T) {
+	for _, in := range []int{0, -1, -3600} {
+		r := NewCallbackURLRegistry(nil, "test-set", in, 3, 100, nil).(*aerospikeCallbackURLRegistry)
+		if r.ttlSec != defaultCallbackURLRegistryTTLSec {
+			t.Errorf("ttlSec=%d in: expected default %d, got %d",
+				in, defaultCallbackURLRegistryTTLSec, r.ttlSec)
+		}
+	}
+}
+
+// TestCallbackURLKey_Deterministic locks the key derivation so two registry
+// instances (e.g. across services) agree on which record represents a URL.
+// If this test changes, all prod records become orphans.
+func TestCallbackURLKey_Deterministic(t *testing.T) {
+	a := callbackURLKey("http://example.com/cb")
+	b := callbackURLKey("http://example.com/cb")
+	if a != b {
+		t.Fatalf("same URL hashed to different keys: %s != %s", a, b)
+	}
+	if len(a) != 64 {
+		t.Errorf("expected 64-char sha256 hex key, got %d", len(a))
+	}
+	if c := callbackURLKey("http://other.example.com/cb"); a == c {
+		t.Errorf("different URLs should hash differently: %s == %s", a, c)
+	}
+}
+
+// TestCallbackURLRegistry_Bounded is a regression test for F-037 / issue #23.
+// Pre-fix: every Add appended to a single record's CDT list with no TTL or
+// cap, so the record grew without limit and BLOCK_PROCESSED fan-out iterated
+// every URL ever seen. Post-fix: each URL lives in its own record keyed by
+// sha256(url), each carries a per-record TTL, so the registry is bounded by
+// the active-URL count (Aerospike nsup evicts cold records).
+//
+// We can't run a real Aerospike here without the integration build tag, but
+// we can assert the invariants that make the bound real:
+//   - the registry stores per-URL records (not a single CDT list);
+//   - it always writes with a positive TTL;
+//   - the same URL maps to the same record, so repeated Add calls upsert
+//     instead of growing storage.
+func TestCallbackURLRegistry_Bounded(t *testing.T) {
+	r := NewCallbackURLRegistry(nil, "test-set", 60, 3, 100, nil).(*aerospikeCallbackURLRegistry)
+
+	if r.ttlSec <= 0 {
+		t.Fatalf("registry must enforce a positive TTL; got %d", r.ttlSec)
+	}
+
+	// Repeated Add of the same URL must collapse to one record.
+	k1 := callbackURLKey("http://a.example.com/cb")
+	k2 := callbackURLKey("http://a.example.com/cb")
+	if k1 != k2 {
+		t.Fatalf("Add for the same URL must reuse the same record key (k1=%s, k2=%s)", k1, k2)
+	}
+
+	// Distinct URLs must map to distinct records, otherwise a hash collision
+	// would silently lose URLs.
+	keys := make(map[string]string, 100)
+	for i := 0; i < 100; i++ {
+		u := "http://example.com/cb/" + itoa(i)
+		k := callbackURLKey(u)
+		if existing, ok := keys[k]; ok {
+			t.Fatalf("hash collision between %q and %q (key %s)", existing, u, k)
+		}
+		keys[k] = u
+	}
+}
+
+// itoa is a tiny no-import helper (avoids importing strconv just for tests).
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
 }

--- a/internal/store/factory.go
+++ b/internal/store/factory.go
@@ -72,6 +72,7 @@ func newAerospikeRegistry(_ context.Context, cfg *config.Config, logger *slog.Lo
 		),
 		CallbackURLRegistry: NewCallbackURLRegistry(
 			asClient, cfg.Aerospike.CallbackURLRegistry,
+			cfg.Aerospike.CallbackURLRegistryTTLSec,
 			cfg.Aerospike.MaxRetries, cfg.Aerospike.RetryBaseMs, logger,
 		),
 		CallbackAccumulator: NewCallbackAccumulatorStore(

--- a/internal/store/sql/callback_url_registry.go
+++ b/internal/store/sql/callback_url_registry.go
@@ -9,22 +9,42 @@ import (
 	storepkg "github.com/bsv-blockchain/merkle-service/internal/store"
 )
 
+// defaultCallbackURLRetention is the eviction window applied by the SQL
+// callback URL registry when no explicit retention is configured. Mirrors the
+// Aerospike sibling's 7-day default. See F-037 / issue #23.
+const defaultCallbackURLRetention = 7 * 24 * time.Hour
+
+// callbackURLRegistry stores the set of known callback URLs with a recency
+// timestamp. `Add` upserts (url, now); `GetAll` filters URLs whose last_seen_at
+// is within the retention window; the sweeper evicts older rows. Together
+// these bound the registry to roughly the active-URL count and stop
+// BLOCK_PROCESSED fan-out from broadcasting to long-since-expired tenants.
 type callbackURLRegistry struct {
-	db *sql.DB
-	d  *dialect
+	db        *sql.DB
+	d         *dialect
+	retention time.Duration
 }
 
 var _ storepkg.CallbackURLRegistry = (*callbackURLRegistry)(nil)
 
-func newCallbackURLRegistry(db *sql.DB, d *dialect) *callbackURLRegistry {
-	return &callbackURLRegistry{db: db, d: d}
+func newCallbackURLRegistry(db *sql.DB, d *dialect, retention time.Duration) *callbackURLRegistry {
+	if retention <= 0 {
+		retention = defaultCallbackURLRetention
+	}
+	return &callbackURLRegistry{db: db, d: d, retention: retention}
 }
 
 func (r *callbackURLRegistry) Add(callbackURL string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	q := fmt.Sprintf("INSERT INTO callback_urls (callback_url) VALUES (%s)%s",
-		r.d.placeholder(1), r.d.onConflictDoNothing)
+	// On conflict we must refresh last_seen_at — otherwise a URL added once
+	// would expire even though it is being actively re-registered. We use a
+	// dialect-portable UPSERT shape (ON CONFLICT ... DO UPDATE) which both
+	// PostgreSQL and SQLite (>= 3.24) support.
+	q := fmt.Sprintf(
+		"INSERT INTO callback_urls (callback_url, last_seen_at) VALUES (%s, %s) "+
+			"ON CONFLICT (callback_url) DO UPDATE SET last_seen_at = %s",
+		r.d.placeholder(1), r.d.now, r.d.now)
 	_, err := r.db.ExecContext(ctx, q, callbackURL)
 	return err
 }
@@ -32,7 +52,18 @@ func (r *callbackURLRegistry) Add(callbackURL string) error {
 func (r *callbackURLRegistry) GetAll() ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	rows, err := r.db.QueryContext(ctx, "SELECT callback_url FROM callback_urls ORDER BY callback_url")
+
+	// last_seen_at IS NULL covers rows inserted before migration 0002 — they
+	// are treated as fresh until the next Add() (which stamps last_seen_at)
+	// or the next sweeper tick (which uses the same NULL-tolerant predicate).
+	cutoff := -int(r.retention / time.Second)
+	q := fmt.Sprintf(
+		"SELECT callback_url FROM callback_urls "+
+			"WHERE last_seen_at IS NULL OR last_seen_at >= %s "+
+			"ORDER BY callback_url",
+		r.d.intervalSeconds(cutoff))
+
+	rows, err := r.db.QueryContext(ctx, q)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/sql/migrations/0002_callback_urls_last_seen.sql
+++ b/internal/store/sql/migrations/0002_callback_urls_last_seen.sql
@@ -1,0 +1,16 @@
+-- 0002: Bound callback_urls registry growth (F-037 / issue #23).
+--
+-- Pre-fix: every distinct callback URL ever observed lived forever in
+-- callback_urls. BLOCK_PROCESSED fan-out iterated the whole table, including
+-- URLs whose last associated registration expired weeks ago. Add a
+-- `last_seen_at` column so Add() can refresh recency and the sweeper can
+-- evict stale URLs after a retention window.
+--
+-- The new column is nullable so existing rows survive the migration; the
+-- application coalesces NULL to "now" on first read after deploy, which gives
+-- existing prod records one full retention window before they are eligible
+-- for eviction.
+
+ALTER TABLE callback_urls ADD COLUMN last_seen_at ${TIMESTAMPTZ};
+
+CREATE INDEX ${IF_NOT_EXISTS_INDEX} idx_callback_urls_last_seen_at ON callback_urls (last_seen_at);

--- a/internal/store/sql/sql.go
+++ b/internal/store/sql/sql.go
@@ -64,8 +64,9 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger) (*storepk
 	}
 
 	sweepInterval := parseDuration(cfg.Store.SQL.SweeperInterval, 60*time.Second)
+	urlRetention := parseDuration(cfg.Store.SQL.CallbackURLRegistryRetention, defaultCallbackURLRetention)
 	sweeperCtx, cancelSweeper := context.WithCancel(context.Background())
-	sw := newSweeper(db, d, sweepInterval, logger)
+	sw := newSweeper(db, d, sweepInterval, urlRetention, logger)
 	go sw.run(sweeperCtx)
 
 	r := &storepkg.Registry{
@@ -73,7 +74,7 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger) (*storepk
 		Subtree:             storepkg.NewSubtreeStore(blob, uint64(cfg.Subtree.DAHOffset), logger),
 		Stump:               storepkg.NewStumpStore(blob, uint64(cfg.Subtree.StumpDAHOffset), logger),
 		CallbackDedup:       newCallbackDedup(db, d),
-		CallbackURLRegistry: newCallbackURLRegistry(db, d),
+		CallbackURLRegistry: newCallbackURLRegistry(db, d, urlRetention),
 		CallbackAccumulator: newCallbackAccumulator(db, d, cfg.Aerospike.CallbackAccumulatorTTLSec),
 		SeenCounter:         newSeenCounter(db, d, cfg.Callback.SeenThreshold),
 		SubtreeCounter:      newSubtreeCounter(db, d, cfg.Aerospike.SubtreeCounterTTLSec),

--- a/internal/store/sql/sql_test.go
+++ b/internal/store/sql/sql_test.go
@@ -136,7 +136,7 @@ func TestCallbackDedup_TTLExpiry(t *testing.T) {
 
 func TestCallbackURLRegistry_AddGetAll(t *testing.T) {
 	db, d := newTestDB(t)
-	r := newCallbackURLRegistry(db, d)
+	r := newCallbackURLRegistry(db, d, time.Hour)
 
 	if err := r.Add("http://one"); err != nil {
 		t.Fatal(err)
@@ -154,6 +154,88 @@ func TestCallbackURLRegistry_AddGetAll(t *testing.T) {
 	}
 	if len(all) != 2 {
 		t.Fatalf("got %v, want 2 URLs", all)
+	}
+}
+
+// TestCallbackURLRegistry_RetentionWindow is the regression test for F-037 /
+// issue #23. Pre-fix the SQL registry stored every URL forever; post-fix
+// `last_seen_at` is refreshed by Add and rows older than the retention window
+// no longer appear in GetAll (and the sweeper deletes them).
+func TestCallbackURLRegistry_RetentionWindow(t *testing.T) {
+	db, d := newTestDB(t)
+	r := newCallbackURLRegistry(db, d, time.Hour)
+
+	if err := r.Add("http://recent"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert a stale row by hand — simulates a URL whose last Add was far
+	// outside the retention window.
+	stale := "http://stale"
+	q := fmt.Sprintf(
+		"INSERT INTO callback_urls (callback_url, last_seen_at) VALUES (%s, %s)",
+		d.placeholder(1), d.intervalSeconds(-2*int(time.Hour/time.Second)))
+	if _, err := db.Exec(q, stale); err != nil {
+		t.Fatalf("seed stale row: %v", err)
+	}
+
+	all, err := r.GetAll()
+	if err != nil {
+		t.Fatalf("GetAll: %v", err)
+	}
+	for _, u := range all {
+		if u == stale {
+			t.Fatalf("GetAll returned stale URL %q (retention window not enforced)", u)
+		}
+	}
+	if len(all) != 1 || all[0] != "http://recent" {
+		t.Fatalf("expected only http://recent, got %v", all)
+	}
+
+	// Re-Add the stale URL: that should refresh last_seen_at and bring it
+	// back into the active window.
+	if err := r.Add(stale); err != nil {
+		t.Fatalf("re-Add stale: %v", err)
+	}
+	all, err = r.GetAll()
+	if err != nil {
+		t.Fatalf("GetAll after refresh: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("expected 2 URLs after refresh, got %v", all)
+	}
+}
+
+// TestCallbackURLRegistry_SweeperEvicts confirms the sweeper deletes stale
+// URLs (issue #23). Without this, the table would grow unboundedly even
+// though GetAll filters — and a long-running deployment would still pay the
+// row-count cost for every Add (full-table scan on the unique index).
+func TestCallbackURLRegistry_SweeperEvicts(t *testing.T) {
+	db, d := newTestDB(t)
+	r := newCallbackURLRegistry(db, d, time.Hour)
+
+	if err := r.Add("http://recent"); err != nil {
+		t.Fatal(err)
+	}
+	stale := "http://ancient"
+	q := fmt.Sprintf(
+		"INSERT INTO callback_urls (callback_url, last_seen_at) VALUES (%s, %s)",
+		d.placeholder(1), d.intervalSeconds(-2*int(time.Hour/time.Second)))
+	if _, err := db.Exec(q, stale); err != nil {
+		t.Fatalf("seed stale row: %v", err)
+	}
+
+	// Use a sweeper interval that won't tick during the test — we drive it
+	// directly via sweepOnce so the test is deterministic.
+	sw := newSweeper(db, d, time.Hour, time.Hour, slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})))
+	sw.sweepOnce(context.Background())
+
+	var n int
+	if err := db.QueryRow("SELECT COUNT(*) FROM callback_urls").Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("after sweep expected 1 row in callback_urls, got %d", n)
 	}
 }
 
@@ -296,7 +378,7 @@ func TestSweeper_DeletesExpiredRows(t *testing.T) {
 
 	// Wait for the first entry to expire, then sweep.
 	time.Sleep(2100 * time.Millisecond)
-	sw := newSweeper(db, d, 10*time.Millisecond, slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})))
+	sw := newSweeper(db, d, 10*time.Millisecond, time.Hour, slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})))
 	sw.sweepOnce(context.Background())
 
 	// Verify the expired row is gone at the row level (not just filtered by
@@ -323,7 +405,7 @@ func TestSweeper_DeletesExpiredRows(t *testing.T) {
 
 func TestSweeper_StopsOnClose(t *testing.T) {
 	db, d := newTestDB(t)
-	sw := newSweeper(db, d, 5*time.Millisecond, slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})))
+	sw := newSweeper(db, d, 5*time.Millisecond, time.Hour, slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var started atomic.Bool
@@ -353,7 +435,7 @@ func TestSQLBackend_InterfaceSatisfaction(t *testing.T) {
 	var (
 		_ storepkg.RegistrationStore        = newRegistrationStore(db, d)
 		_ storepkg.CallbackDedupStore       = newCallbackDedup(db, d)
-		_ storepkg.CallbackURLRegistry      = newCallbackURLRegistry(db, d)
+		_ storepkg.CallbackURLRegistry      = newCallbackURLRegistry(db, d, time.Hour)
 		_ storepkg.CallbackAccumulatorStore = newCallbackAccumulator(db, d, 60)
 		_ storepkg.SeenCounterStore         = newSeenCounter(db, d, 3)
 		_ storepkg.SubtreeCounterStore      = newSubtreeCounter(db, d, 60)

--- a/internal/store/sql/sweeper.go
+++ b/internal/store/sql/sweeper.go
@@ -55,18 +55,23 @@ type sweeper struct {
 	db       *sql.DB
 	d        *dialect
 	interval time.Duration
-	logger   *slog.Logger
-	done     chan struct{}
-	once     sync.Once
+	// urlRetention bounds the callback_urls registry: rows whose last_seen_at
+	// is older than now() - urlRetention are evicted on every tick. Zero or
+	// negative disables the eviction (don't do that in prod — F-037).
+	urlRetention time.Duration
+	logger       *slog.Logger
+	done         chan struct{}
+	once         sync.Once
 }
 
-func newSweeper(db *sql.DB, d *dialect, interval time.Duration, logger *slog.Logger) *sweeper {
+func newSweeper(db *sql.DB, d *dialect, interval, urlRetention time.Duration, logger *slog.Logger) *sweeper {
 	return &sweeper{
-		db:       db,
-		d:        d,
-		interval: interval,
-		logger:   logger,
-		done:     make(chan struct{}),
+		db:           db,
+		d:            d,
+		interval:     interval,
+		urlRetention: urlRetention,
+		logger:       logger,
+		done:         make(chan struct{}),
 	}
 }
 
@@ -104,6 +109,36 @@ func (s *sweeper) sweepOnce(ctx context.Context) {
 			s.logger.Debug("ttl sweeper: expired rows deleted", "table", t.parent, "rows", rows)
 		}
 	}
+	// callback_urls uses a different recency model (last_seen_at refreshed on
+	// every Add) so it doesn't fit the expires_at-driven ttlTable shape.
+	// Sweep it separately, gated on a positive retention.
+	if s.urlRetention > 0 {
+		rows, err := s.sweepCallbackURLs(ctx)
+		if err != nil {
+			if s.logger != nil {
+				s.logger.Warn("ttl sweeper: callback_urls delete failed", "error", err)
+			}
+		} else if rows > 0 && s.logger != nil {
+			s.logger.Debug("ttl sweeper: expired callback URLs deleted", "rows", rows)
+		}
+	}
+}
+
+// sweepCallbackURLs deletes URLs whose last_seen_at is older than the
+// configured retention. Rows with NULL last_seen_at (legacy rows from before
+// migration 0002) are left alone — the next Add() stamps last_seen_at and
+// brings them under the eviction window.
+func (s *sweeper) sweepCallbackURLs(ctx context.Context) (int64, error) {
+	cutoff := -int(s.urlRetention / time.Second)
+	q := fmt.Sprintf(
+		"DELETE FROM callback_urls WHERE last_seen_at IS NOT NULL AND last_seen_at < %s",
+		s.d.intervalSeconds(cutoff))
+	res, err := s.db.ExecContext(ctx, q)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
 }
 
 // sweepTable deletes up to 1000 parent rows per call to keep locks short.

--- a/internal/store/sql/sweeper_test.go
+++ b/internal/store/sql/sweeper_test.go
@@ -35,7 +35,7 @@ func TestSweeper_CascadesRegistrationChildren(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sw := newSweeper(db, d, time.Hour, slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})))
+	sw := newSweeper(db, d, time.Hour, time.Hour, slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})))
 	sw.sweepOnce(context.Background())
 
 	// Parent row should be gone.
@@ -97,7 +97,7 @@ func TestSweeper_CascadesAccumulatorChildren(t *testing.T) {
 		}
 	}
 
-	sw := newSweeper(db, d, time.Hour, slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})))
+	sw := newSweeper(db, d, time.Hour, time.Hour, slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})))
 	sw.sweepOnce(context.Background())
 
 	// Parent gone.

--- a/test/scale/scale_test.go
+++ b/test/scale/scale_test.go
@@ -179,7 +179,9 @@ func runScaleTest(t *testing.T, fixtureDir string, instanceCount int, timeout ti
 	regStore := store.NewRegistrationStore(asClient, regSetName, 3, 100, logger)
 
 	urlRegistrySetName := fmt.Sprintf("scale_urls_%d", time.Now().UnixNano())
-	urlRegistry := store.NewCallbackURLRegistry(asClient, urlRegistrySetName, 3, 100, logger)
+	// 0 ttlSec → constructor falls back to the default 7-day window, which is
+	// far longer than any scale-test run.
+	urlRegistry := store.NewCallbackURLRegistry(asClient, urlRegistrySetName, 0, 3, 100, logger)
 
 	blobStore := store.NewMemoryBlobStore()
 	subtreeStore := store.NewSubtreeStore(blobStore, 100, logger)


### PR DESCRIPTION
## Summary
- **Approach A — TTL-bounded per-URL records.** Each registered callback URL is now its own Aerospike record (key = `sha256(url)`, bin = the URL string) with a per-record TTL; for the SQL backend each `callback_urls` row gets a `last_seen_at` column. `Add` upserts/refreshes recency, `GetAll` returns the active set, and the existing SQL sweeper evicts stale rows. Approach B (bounded list with LRU) was rejected because the underlying Aerospike CDT-list shape is itself the failure mode (single-record size limit) — moving to per-record storage solves that as a side-effect of bounding growth.
- New config knobs: `aerospike.callbackUrlRegistryTTLSec` (default 7 days = 604800s) and `store.sql.callbackUrlRegistryRetention` (default `168h`). The SQL sweeper accepts the same retention so eviction is deterministic.
- Tests: unit-level deterministic tests cover the per-URL-record invariant, default-TTL coercion, the SQL retention window, the SQL sweeper eviction path, and a regression-style assertion against today's unbounded behaviour. Migration 0002 adds the SQL `last_seen_at` column (nullable so existing rows survive; first `Add` after deploy stamps them, the sweeper leaves NULL rows alone).
- Operational notes: existing prod Aerospike records under the old schema (single `__all_urls__` record with a `urls` CDT list) will simply stop being read — they're orphaned, not deleted. Operators should drop the legacy record on deploy (`asd: aql> DELETE FROM merkle.merkle_callback_urls WHERE PK='__all_urls__'`) or just let the namespace's nsup eventually evict it. New URLs are written under per-URL hash keys, so there's no read-write overlap.

Closes #23

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/store/... -race`
- [x] `go test ./... -short` (full repo green)
- [x] `golangci-lint run ./internal/store/...` — only pre-existing warnings remain
- [ ] Reviewer to confirm operational defaults are sane (7-day window; default eviction matches `BLOCK_PROCESSED` cadence expectations)
- [ ] Reviewer to confirm the suggested manual cleanup for the legacy `__all_urls__` record is acceptable, vs. an automated cleanup migration