### PR TITLE
fix(store/sql,api): enforce per-txid callback URL limit (#27)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -377,3 +377,16 @@ datahub:
   # limits should tune this down. Set <= 0 to use the built-in default.
   # Env: DATAHUB_MAX_SUBTREE_BYTES
   maxSubtreeBytes: 1073741824
+
+# ---------------------------------------------------------------------------
+# Registry — policy for the txid -> callback URL registration store.
+# (applies regardless of whether the backend is Aerospike or SQL)
+# ---------------------------------------------------------------------------
+registry:
+  # Maximum number of distinct callback URLs that may be registered against
+  # a single txid. Once reached, further /watch calls for the same txid
+  # return HTTP 429. Re-registering an already-known URL is idempotent and
+  # is unaffected by the cap. 0 disables the cap (legacy unbounded
+  # behavior — strongly discouraged in production; see F-050).
+  # Env: REGISTRY_MAX_CALLBACKS_PER_TXID
+  maxCallbacksPerTxID: 10

--- a/internal/api/api_integration_test.go
+++ b/internal/api/api_integration_test.go
@@ -29,7 +29,7 @@ func setupTestServer(t *testing.T) (*httptest.Server, *store.RegistrationStore, 
 	t.Cleanup(func() { asClient.Close() })
 
 	setName := fmt.Sprintf("api_integ_%d", time.Now().UnixNano())
-	regStore := store.NewRegistrationStore(asClient, setName, 3, 100, slog.Default())
+	regStore := store.NewRegistrationStore(asClient, setName, 3, 100, 0, slog.Default())
 
 	srv := api.NewServer(config.APIConfig{Port: 0}, regStore, asClient, slog.Default())
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"regexp"
 
+	"github.com/bsv-blockchain/merkle-service/internal/store"
 	"github.com/go-chi/chi/v5"
 
 	"github.com/bsv-blockchain/merkle-service/internal/ssrfguard"
@@ -88,6 +89,17 @@ func (s *Server) handleWatch(w http.ResponseWriter, r *http.Request) {
 
 	// Store registration
 	if err := s.regStore.Add(req.TxID, req.CallbackURL); err != nil {
+		// F-050: surface the per-txid callback cap as a 429 so the caller can
+		// distinguish a quota error from a transient backend failure and back
+		// off accordingly. The body still uses the standard ErrorResponse shape.
+		if errors.Is(err, store.ErrMaxCallbacksPerTxIDExceeded) {
+			s.Logger.Warn("registration rejected: per-txid callback cap exceeded",
+				"txid", req.TxID, "callbackUrl", req.CallbackURL)
+			writeJSON(w, http.StatusTooManyRequests, ErrorResponse{
+				Error: "too many callback URLs registered for this txid",
+			})
+			return
+		}
 		s.Logger.Error("failed to add registration", "txid", req.TxID, "error", err)
 		writeJSON(w, http.StatusInternalServerError, ErrorResponse{Error: "internal server error"})
 		return

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -9,8 +9,44 @@ import (
 	"time"
 
 	"github.com/bsv-blockchain/merkle-service/internal/config"
+	"github.com/bsv-blockchain/merkle-service/internal/store"
 	"github.com/go-chi/chi/v5"
 )
+
+// fakeRegStore is a minimal RegistrationStore stub used by tests. When
+// addErr is non-nil, Add returns it (so error-mapping behavior can be
+// exercised). Otherwise Add records each (txid, url) pair in `added`.
+type fakeRegStore struct {
+	addErr error
+	added  []struct{ txid, url string }
+}
+
+func (f *fakeRegStore) Add(txid, url string) error {
+	if f.addErr != nil {
+		return f.addErr
+	}
+	f.added = append(f.added, struct{ txid, url string }{txid, url})
+	return nil
+}
+func (f *fakeRegStore) Get(string) ([]string, error) {
+	return nil, nil
+}
+func (f *fakeRegStore) BatchGet([]string) (map[string][]string, error) {
+	return nil, nil
+}
+func (f *fakeRegStore) UpdateTTL(string, time.Duration) error        { return nil }
+func (f *fakeRegStore) BatchUpdateTTL([]string, time.Duration) error { return nil }
+
+func newTestRouterWithRegStore(rs store.RegistrationStore) (*chi.Mux, *Server) {
+	router := chi.NewRouter()
+	s := &Server{regStore: rs}
+	s.InitBase("test")
+	router.Get("/", handleDashboard)
+	router.Post("/watch", s.handleWatch)
+	router.Get("/health", s.handleHealth)
+	router.Get("/api/lookup/{txid}", s.handleLookup)
+	return router, s
+}
 
 func newTestRouter() (*chi.Mux, *Server) {
 	router := chi.NewRouter()
@@ -119,6 +155,24 @@ func TestHandleDashboard(t *testing.T) {
 	}
 }
 
+// TestHandleWatch_MaxCallbacksReturns429 verifies that the /watch endpoint
+// translates store.ErrMaxCallbacksPerTxIDExceeded to HTTP 429 with a clear
+// JSON error body. F-050 / issue #27.
+func TestHandleWatch_MaxCallbacksReturns429(t *testing.T) {
+	router, _ := newTestRouterWithRegStore(&fakeRegStore{addErr: store.ErrMaxCallbacksPerTxIDExceeded})
+	w := postWatch(router, `{"txid":"a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2","callbackUrl":"https://example.com/cb"}`)
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", w.Code)
+	}
+	var resp ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if resp.Error == "" {
+		t.Fatal("expected non-empty error message in 429 body")
+	}
+}
+
 // TestServerHasURLRegistryField verifies the Server struct holds a urlRegistry
 // field and that NewServer wires it correctly.
 func TestServerHasURLRegistryField(t *testing.T) {
@@ -189,22 +243,6 @@ func TestHandleWatch_RejectsBadScheme(t *testing.T) {
 		})
 	}
 }
-
-// fakeRegStore is a minimal in-memory RegistrationStore used by tests
-// that need /watch to make it past validation without standing up
-// Aerospike or SQL.
-type fakeRegStore struct {
-	added []struct{ txid, url string }
-}
-
-func (f *fakeRegStore) Add(txid, url string) error {
-	f.added = append(f.added, struct{ txid, url string }{txid, url})
-	return nil
-}
-func (f *fakeRegStore) Get(string) ([]string, error)                  { return nil, nil }
-func (f *fakeRegStore) BatchGet([]string) (map[string][]string, error) { return nil, nil }
-func (f *fakeRegStore) UpdateTTL(string, time.Duration) error          { return nil }
-func (f *fakeRegStore) BatchUpdateTTL([]string, time.Duration) error   { return nil }
 
 // TestHandleWatch_AllowPrivateIPs verifies the operator escape hatch:
 // when SetAllowPrivateCallbackIPs(true) is set, private/loopback URLs

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,20 @@ type Config struct {
 	Callback  CallbackConfig  `yaml:"callback"  mapstructure:"callback"`
 	BlobStore BlobStoreConfig `yaml:"blobStore" mapstructure:"blobstore"`
 	DataHub   DataHubConfig   `yaml:"datahub"   mapstructure:"datahub"`
+	Registry  RegistryConfig  `yaml:"registry"  mapstructure:"registry"`
+}
+
+// RegistryConfig holds policy for the txid -> callback URL registration store.
+// Limits and quotas live here regardless of whether the backend is Aerospike
+// or SQL, so behavior stays identical across deployments.
+type RegistryConfig struct {
+	// MaxCallbacksPerTxID caps the number of distinct callback URLs that may
+	// be registered for a single txid. Once reached, further Add calls fail
+	// with store.ErrMaxCallbacksPerTxIDExceeded. Idempotent re-registration
+	// of an already-known URL is unaffected by the limit. 0 disables the cap
+	// (matches the legacy unbounded behavior — not recommended in
+	// production; F-050 documents the resource-exhaustion risk).
+	MaxCallbacksPerTxID int `yaml:"maxCallbacksPerTxID" mapstructure:"maxcallbackspertxid"`
 }
 
 // Backend names. Kept as package-level consts so callers don't stringly-type.
@@ -363,6 +377,9 @@ func registerDefaults(v *viper.Viper) {
 	// 1 GiB — accommodates Teranode subtrees up to ~33.5M txids; operators
 	// running with smaller per-subtree limits should tune this down.
 	v.SetDefault("datahub.maxsubtreebytes", int64(1*1024*1024*1024))
+
+	// Registry
+	v.SetDefault("registry.maxcallbackspertxid", 10)
 }
 
 // bindEnvVars explicitly binds environment variable names to Viper keys.
@@ -477,6 +494,9 @@ func bindEnvVars(v *viper.Viper) {
 		"datahub.maxretries":      "DATAHUB_MAX_RETRIES",
 		"datahub.maxblockbytes":   "DATAHUB_MAX_BLOCK_BYTES",
 		"datahub.maxsubtreebytes": "DATAHUB_MAX_SUBTREE_BYTES",
+
+		// Registry
+		"registry.maxcallbackspertxid": "REGISTRY_MAX_CALLBACKS_PER_TXID",
 	}
 
 	for key, env := range bindings {

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -130,7 +130,7 @@ func determineNamespace(t *testing.T) string {
 			continue
 		}
 		// Try a write to verify the namespace is usable.
-		regStore := store.NewRegistrationStore(client, "ns_probe", 1, 50, testLogger())
+		regStore := store.NewRegistrationStore(client, "ns_probe", 1, 50, 0, testLogger())
 		if err := regStore.Add("probe_txid", "http://probe"); err != nil {
 			client.Close()
 			continue
@@ -215,7 +215,7 @@ func TestSeenOnNetworkCallback(t *testing.T) {
 	// 1. Register a txid with a callback URL in Aerospike.
 	txid := randomTxID()
 	setName := uniqueSetName("reg")
-	regStore := store.NewRegistrationStore(asClient, setName, 3, 100, logger)
+	regStore := store.NewRegistrationStore(asClient, setName, 3, 100, 0, logger)
 
 	collector := newCallbackCollector()
 	mockServer := httptest.NewServer(collector.handler())
@@ -279,7 +279,7 @@ func TestMinedCallbackWithSTUMP(t *testing.T) {
 	// 1. Register a txid.
 	txid := randomTxID()
 	setName := uniqueSetName("reg")
-	regStore := store.NewRegistrationStore(asClient, setName, 3, 100, logger)
+	regStore := store.NewRegistrationStore(asClient, setName, 3, 100, 0, logger)
 
 	collector := newCallbackCollector()
 	mockServer := httptest.NewServer(collector.handler())
@@ -348,7 +348,7 @@ func TestMultipleCallbacks(t *testing.T) {
 	// 1. Register a txid with 2 different callback URLs.
 	txid := randomTxID()
 	setName := uniqueSetName("reg")
-	regStore := store.NewRegistrationStore(asClient, setName, 3, 100, logger)
+	regStore := store.NewRegistrationStore(asClient, setName, 3, 100, 0, logger)
 
 	collector1 := newCallbackCollector()
 	mockServer1 := httptest.NewServer(collector1.handler())
@@ -432,7 +432,7 @@ func TestSeenMultipleNodes(t *testing.T) {
 	// 1. Register a txid.
 	txid := randomTxID()
 	regSetName := uniqueSetName("reg")
-	regStore := store.NewRegistrationStore(asClient, regSetName, 3, 100, logger)
+	regStore := store.NewRegistrationStore(asClient, regSetName, 3, 100, 0, logger)
 
 	collector := newCallbackCollector()
 	mockServer := httptest.NewServer(collector.handler())

--- a/internal/store/factory.go
+++ b/internal/store/factory.go
@@ -62,7 +62,8 @@ func newAerospikeRegistry(_ context.Context, cfg *config.Config, logger *slog.Lo
 	r := &Registry{
 		Registration: NewRegistrationStore(
 			asClient, cfg.Aerospike.SetName,
-			cfg.Aerospike.MaxRetries, cfg.Aerospike.RetryBaseMs, logger,
+			cfg.Aerospike.MaxRetries, cfg.Aerospike.RetryBaseMs,
+			cfg.Registry.MaxCallbacksPerTxID, logger,
 		),
 		Subtree: NewSubtreeStore(blob, uint64(cfg.Subtree.DAHOffset), logger),
 		Stump:   NewStumpStore(blob, uint64(cfg.Subtree.StumpDAHOffset), logger),

--- a/internal/store/registration.go
+++ b/internal/store/registration.go
@@ -1,63 +1,153 @@
 package store
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
 
 	as "github.com/aerospike/aerospike-client-go/v7"
+	astypes "github.com/aerospike/aerospike-client-go/v7/types"
 )
 
 const (
 	callbacksBin = "callbacks"
 )
 
+// ErrMaxCallbacksPerTxIDExceeded is returned by RegistrationStore.Add when
+// the configured per-txid callback URL cap (RegistryConfig.MaxCallbacksPerTxID)
+// has already been reached for the txid and the URL being registered is not
+// already present. Adding a URL that is already registered is treated as a
+// no-op success and never produces this error. F-050.
+var ErrMaxCallbacksPerTxIDExceeded = errors.New("max callbacks per txid exceeded")
+
 // aerospikeRegistration is the Aerospike-backed RegistrationStore implementation.
 type aerospikeRegistration struct {
-	client      *AerospikeClient
-	setName     string
-	logger      *slog.Logger
-	maxRetries  int
-	retryBaseMs int
+	client              *AerospikeClient
+	setName             string
+	logger              *slog.Logger
+	maxRetries          int
+	retryBaseMs         int
+	maxCallbacksPerTxID int
 }
 
 // Compile-time check: aerospikeRegistration satisfies RegistrationStore.
 var _ RegistrationStore = (*aerospikeRegistration)(nil)
 
 // NewRegistrationStore constructs an Aerospike-backed RegistrationStore.
-func NewRegistrationStore(client *AerospikeClient, setName string, maxRetries int, retryBaseMs int, logger *slog.Logger) RegistrationStore {
+//
+// maxCallbacksPerTxID caps how many distinct callback URLs may be registered
+// against a single txid. 0 disables the cap (legacy unbounded behavior —
+// strongly discouraged; see F-050). Adds that would exceed the cap return
+// ErrMaxCallbacksPerTxIDExceeded; idempotent re-adds of an already-registered
+// URL succeed regardless of the cap.
+func NewRegistrationStore(client *AerospikeClient, setName string, maxRetries int, retryBaseMs int, maxCallbacksPerTxID int, logger *slog.Logger) RegistrationStore {
+	if maxCallbacksPerTxID < 0 {
+		maxCallbacksPerTxID = 0
+	}
 	return &aerospikeRegistration{
-		client:      client,
-		setName:     setName,
-		logger:      logger,
-		maxRetries:  maxRetries,
-		retryBaseMs: retryBaseMs,
+		client:              client,
+		setName:             setName,
+		logger:              logger,
+		maxRetries:          maxRetries,
+		retryBaseMs:         retryBaseMs,
+		maxCallbacksPerTxID: maxCallbacksPerTxID,
 	}
 }
 
-// Add registers a callback URL for a txid using CDT list operations with UNIQUE flag to ensure set semantics.
+// addCASMaxAttempts caps how many times Add will retry the optimistic
+// generation-CAS append cycle when a concurrent writer changes the record
+// between our read and write. A small bound is sufficient because the only
+// contention is multiple registrations for the same txid in flight at once —
+// in practice we rarely see more than two or three such collisions before the
+// loser finds the URL already present (idempotent success).
+const addCASMaxAttempts = 5
+
+// Add registers a callback URL for a txid using CDT list operations with the
+// UNIQUE flag for set semantics. When maxCallbacksPerTxID > 0, the read-and-
+// write is gated by an optimistic generation CAS so concurrent registrations
+// can't both observe (count == max-1) and both succeed past the cap.
 func (s *aerospikeRegistration) Add(txid string, callbackURL string) error {
 	key, err := as.NewKey(s.client.Namespace(), s.setName, txid)
 	if err != nil {
 		return fmt.Errorf("failed to create key: %w", err)
 	}
 
-	wp := s.client.WritePolicy(s.maxRetries, s.retryBaseMs)
-	wp.RecordExistsAction = as.UPDATE
-
-	// Use ListAppendWithPolicyOp with REPLACE to simulate set behavior
-	// (ListOrderOrdered + ADD_UNIQUE flag)
-	listPolicy := as.NewListPolicy(as.ListOrderOrdered, as.ListWriteFlagsAddUnique|as.ListWriteFlagsNoFail)
-	ops := []*as.Operation{
-		as.ListAppendWithPolicyOp(listPolicy, callbacksBin, callbackURL),
+	// Cap disabled: preserve the original best-effort append, which already
+	// honors set semantics via ListWriteFlagsAddUnique|NoFail.
+	if s.maxCallbacksPerTxID <= 0 {
+		wp := s.client.WritePolicy(s.maxRetries, s.retryBaseMs)
+		wp.RecordExistsAction = as.UPDATE
+		listPolicy := as.NewListPolicy(as.ListOrderOrdered, as.ListWriteFlagsAddUnique|as.ListWriteFlagsNoFail)
+		ops := []*as.Operation{as.ListAppendWithPolicyOp(listPolicy, callbacksBin, callbackURL)}
+		if _, err := s.client.Client().Operate(wp, key, ops...); err != nil {
+			return fmt.Errorf("failed to add registration: %w", err)
+		}
+		return nil
 	}
 
-	_, err = s.client.Client().Operate(wp, key, ops...)
-	if err != nil {
-		return fmt.Errorf("failed to add registration: %w", err)
-	}
+	// Cap enabled: read current list + record generation, decide, then write
+	// under EXPECT_GEN_EQUAL. Loop on generation mismatch.
+	for attempt := 0; attempt < addCASMaxAttempts; attempt++ {
+		record, err := s.client.Client().Get(s.client.ReadPolicy(), key, callbacksBin)
+		if err != nil {
+			var asErr *as.AerospikeError
+			if errors.As(err, &asErr) && asErr.Matches(astypes.KEY_NOT_FOUND_ERROR) {
+				record = nil
+			} else {
+				return fmt.Errorf("failed to read registration: %w", err)
+			}
+		}
 
-	return nil
+		var existing []interface{}
+		var generation uint32
+		if record != nil {
+			generation = record.Generation
+			if v, ok := record.Bins[callbacksBin].([]interface{}); ok {
+				existing = v
+			}
+		}
+
+		// Idempotent: already registered, nothing to do (and the cap doesn't apply).
+		for _, v := range existing {
+			if s, ok := v.(string); ok && s == callbackURL {
+				return nil
+			}
+		}
+
+		if len(existing) >= s.maxCallbacksPerTxID {
+			return ErrMaxCallbacksPerTxIDExceeded
+		}
+
+		wp := s.client.WritePolicy(s.maxRetries, s.retryBaseMs)
+		if record == nil {
+			// Create-or-fail-if-exists: another writer beating us to record creation
+			// will trip a generation/exists error; we'll retry and re-evaluate.
+			wp.RecordExistsAction = as.CREATE_ONLY
+		} else {
+			wp.RecordExistsAction = as.UPDATE
+			wp.GenerationPolicy = as.EXPECT_GEN_EQUAL
+			wp.Generation = generation
+		}
+
+		listPolicy := as.NewListPolicy(as.ListOrderOrdered, as.ListWriteFlagsAddUnique|as.ListWriteFlagsNoFail)
+		ops := []*as.Operation{as.ListAppendWithPolicyOp(listPolicy, callbacksBin, callbackURL)}
+
+		if _, err := s.client.Client().Operate(wp, key, ops...); err != nil {
+			var asErr *as.AerospikeError
+			if errors.As(err, &asErr) {
+				if asErr.Matches(astypes.GENERATION_ERROR, astypes.KEY_EXISTS_ERROR) {
+					// Concurrent writer beat us — re-read and re-decide.
+					continue
+				}
+			}
+			return fmt.Errorf("failed to add registration: %w", err)
+		}
+		return nil
+	}
+	// Persistent contention: surface as a transient error rather than silently
+	// dropping the registration. The caller may retry.
+	return fmt.Errorf("failed to add registration: generation contention after %d attempts", addCASMaxAttempts)
 }
 
 // Get returns all callback URLs registered for a txid.

--- a/internal/store/registration_integration_test.go
+++ b/internal/store/registration_integration_test.go
@@ -31,7 +31,7 @@ func uniqueSet(t *testing.T, prefix string) string {
 func TestRegistrationStore_AddAndGet(t *testing.T) {
 	client := newAerospikeClient(t)
 	setName := uniqueSet(t, "reg_add")
-	regStore := store.NewRegistrationStore(client, setName, 3, 100, slog.Default())
+	regStore := store.NewRegistrationStore(client, setName, 3, 100, 0, slog.Default())
 
 	txid := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	callback := "https://example.com/cb1"
@@ -56,7 +56,7 @@ func TestRegistrationStore_AddAndGet(t *testing.T) {
 func TestRegistrationStore_MultipleCallbacksSameTxid(t *testing.T) {
 	client := newAerospikeClient(t)
 	setName := uniqueSet(t, "reg_multi")
-	regStore := store.NewRegistrationStore(client, setName, 3, 100, slog.Default())
+	regStore := store.NewRegistrationStore(client, setName, 3, 100, 0, slog.Default())
 
 	txid := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	cb1 := "https://example.com/cb1"
@@ -89,7 +89,7 @@ func TestRegistrationStore_MultipleCallbacksSameTxid(t *testing.T) {
 func TestRegistrationStore_IdempotentAdd(t *testing.T) {
 	client := newAerospikeClient(t)
 	setName := uniqueSet(t, "reg_idem")
-	regStore := store.NewRegistrationStore(client, setName, 3, 100, slog.Default())
+	regStore := store.NewRegistrationStore(client, setName, 3, 100, 0, slog.Default())
 
 	txid := "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
 	callback := "https://example.com/cb_dup"
@@ -117,7 +117,7 @@ func TestRegistrationStore_IdempotentAdd(t *testing.T) {
 func TestRegistrationStore_BatchGet(t *testing.T) {
 	client := newAerospikeClient(t)
 	setName := uniqueSet(t, "reg_batch")
-	regStore := store.NewRegistrationStore(client, setName, 3, 100, slog.Default())
+	regStore := store.NewRegistrationStore(client, setName, 3, 100, 0, slog.Default())
 
 	txid1 := "1111111111111111111111111111111111111111111111111111111111111111"
 	txid2 := "2222222222222222222222222222222222222222222222222222222222222222"
@@ -149,7 +149,7 @@ func TestRegistrationStore_BatchGet(t *testing.T) {
 func TestRegistrationStore_UpdateTTL(t *testing.T) {
 	client := newAerospikeClient(t)
 	setName := uniqueSet(t, "reg_ttl")
-	regStore := store.NewRegistrationStore(client, setName, 3, 100, slog.Default())
+	regStore := store.NewRegistrationStore(client, setName, 3, 100, 0, slog.Default())
 
 	txid := "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
 	callback := "https://example.com/ttl"
@@ -193,7 +193,7 @@ func TestRegistrationStore_UpdateTTL(t *testing.T) {
 func TestRegistrationStore_GetNonExistent(t *testing.T) {
 	client := newAerospikeClient(t)
 	setName := uniqueSet(t, "reg_noexist")
-	regStore := store.NewRegistrationStore(client, setName, 3, 100, slog.Default())
+	regStore := store.NewRegistrationStore(client, setName, 3, 100, 0, slog.Default())
 
 	urls, err := regStore.Get("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
 	if err != nil {

--- a/internal/store/sql/registration.go
+++ b/internal/store/sql/registration.go
@@ -13,14 +13,31 @@ import (
 type registrationStore struct {
 	db *sql.DB
 	d  *dialect
+	// maxCallbacksPerTxID caps the number of distinct callback URLs allowed
+	// per txid. 0 disables the cap (legacy unbounded behavior — F-050).
+	maxCallbacksPerTxID int
 }
 
 var _ storepkg.RegistrationStore = (*registrationStore)(nil)
 
-func newRegistrationStore(db *sql.DB, d *dialect) *registrationStore {
-	return &registrationStore{db: db, d: d}
+func newRegistrationStore(db *sql.DB, d *dialect, maxCallbacksPerTxID int) *registrationStore {
+	if maxCallbacksPerTxID < 0 {
+		maxCallbacksPerTxID = 0
+	}
+	return &registrationStore{db: db, d: d, maxCallbacksPerTxID: maxCallbacksPerTxID}
 }
 
+// Add registers callbackURL for txid. Re-adding an already-known URL is a
+// no-op (set semantics, idempotent). When maxCallbacksPerTxID > 0, exceeding
+// the cap returns store.ErrMaxCallbacksPerTxIDExceeded — the API layer maps
+// this to HTTP 429.
+//
+// Concurrency: on Postgres we acquire a SELECT ... FOR UPDATE on the parent
+// `registrations` row before counting and inserting, so two concurrent Add
+// calls for the same txid can't both observe count == max-1 and both succeed.
+// On SQLite the database serializes writers globally (BEGIN IMMEDIATE in the
+// driver), so the count-then-insert pair is already atomic without an
+// explicit lock.
 func (s *registrationStore) Add(txid, callbackURL string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -35,6 +52,44 @@ func (s *registrationStore) Add(txid, callbackURL string) error {
 	if _, err := tx.ExecContext(ctx, insertReg, txid); err != nil {
 		return fmt.Errorf("insert registration: %w", err)
 	}
+
+	if s.maxCallbacksPerTxID > 0 {
+		// Lock the parent row (Postgres) so the count + insert below race
+		// safely against concurrent registrations for the same txid.
+		if isPostgres(s.d) {
+			lockQ := fmt.Sprintf("SELECT 1 FROM registrations WHERE txid = %s FOR UPDATE", s.d.placeholder(1))
+			var dummy int
+			if err := tx.QueryRowContext(ctx, lockQ, txid).Scan(&dummy); err != nil {
+				return fmt.Errorf("lock registration: %w", err)
+			}
+		}
+
+		// Idempotency probe: if the URL is already registered, re-adding is
+		// a no-op regardless of the cap. Otherwise enforce the limit.
+		probeQ := fmt.Sprintf("SELECT 1 FROM registration_urls WHERE txid = %s AND callback_url = %s",
+			s.d.placeholder(1), s.d.placeholder(2))
+		var exists int
+		switch err := tx.QueryRowContext(ctx, probeQ, txid, callbackURL).Scan(&exists); err {
+		case nil:
+			// URL already present — commit so the registrations row sticks
+			// (preserving prior behavior where the parent row is upserted).
+			return tx.Commit()
+		case sql.ErrNoRows:
+			// fall through to count + insert
+		default:
+			return fmt.Errorf("probe registration url: %w", err)
+		}
+
+		countQ := fmt.Sprintf("SELECT COUNT(*) FROM registration_urls WHERE txid = %s", s.d.placeholder(1))
+		var count int
+		if err := tx.QueryRowContext(ctx, countQ, txid).Scan(&count); err != nil {
+			return fmt.Errorf("count registration urls: %w", err)
+		}
+		if count >= s.maxCallbacksPerTxID {
+			return storepkg.ErrMaxCallbacksPerTxIDExceeded
+		}
+	}
+
 	insertURL := fmt.Sprintf("INSERT INTO registration_urls (txid, callback_url) VALUES (%s, %s)%s",
 		s.d.placeholder(1), s.d.placeholder(2), s.d.onConflictDoNothing)
 	if _, err := tx.ExecContext(ctx, insertURL, txid, callbackURL); err != nil {

--- a/internal/store/sql/sql.go
+++ b/internal/store/sql/sql.go
@@ -70,7 +70,7 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger) (*storepk
 	go sw.run(sweeperCtx)
 
 	r := &storepkg.Registry{
-		Registration:        newRegistrationStore(db, d),
+		Registration:        newRegistrationStore(db, d, cfg.Registry.MaxCallbacksPerTxID),
 		Subtree:             storepkg.NewSubtreeStore(blob, uint64(cfg.Subtree.DAHOffset), logger),
 		Stump:               storepkg.NewStumpStore(blob, uint64(cfg.Subtree.StumpDAHOffset), logger),
 		CallbackDedup:       newCallbackDedup(db, d),

--- a/internal/store/sql/sql_test.go
+++ b/internal/store/sql/sql_test.go
@@ -3,6 +3,7 @@ package sql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -40,7 +41,7 @@ func newTestDB(t *testing.T) (*sql.DB, *dialect) {
 
 func TestRegistrationStore_IdempotentAdd(t *testing.T) {
 	db, d := newTestDB(t)
-	s := newRegistrationStore(db, d)
+	s := newRegistrationStore(db, d, 0)
 
 	for i := 0; i < 3; i++ {
 		if err := s.Add("tx1", "http://cb1"); err != nil {
@@ -58,7 +59,7 @@ func TestRegistrationStore_IdempotentAdd(t *testing.T) {
 
 func TestRegistrationStore_BatchGet(t *testing.T) {
 	db, d := newTestDB(t)
-	s := newRegistrationStore(db, d)
+	s := newRegistrationStore(db, d, 0)
 	if err := s.Add("a", "u1"); err != nil {
 		t.Fatal(err)
 	}
@@ -81,6 +82,101 @@ func TestRegistrationStore_BatchGet(t *testing.T) {
 	}
 	if _, ok := got["c"]; ok {
 		t.Fatalf("c should not be present")
+	}
+}
+
+// TestRegistrationStore_MaxCallbacksPerTxID covers F-050: once the per-txid
+// callback URL cap is reached, further Add calls return the sentinel error,
+// the row count in registration_urls is exactly the cap, and existing rows
+// are not mutated.
+func TestRegistrationStore_MaxCallbacksPerTxID(t *testing.T) {
+	db, d := newTestDB(t)
+	const max = 3
+	s := newRegistrationStore(db, d, max)
+
+	// First `max` distinct URLs succeed.
+	for i := 0; i < max; i++ {
+		if err := s.Add("tx1", fmt.Sprintf("http://cb/%d", i)); err != nil {
+			t.Fatalf("Add #%d: %v", i, err)
+		}
+	}
+
+	// (max+1)-th distinct URL is rejected with the sentinel.
+	err := s.Add("tx1", "http://cb/overflow")
+	if !errors.Is(err, storepkg.ErrMaxCallbacksPerTxIDExceeded) {
+		t.Fatalf("expected ErrMaxCallbacksPerTxIDExceeded, got %v", err)
+	}
+
+	// DB count is exactly `max` — the rejected insert did not slip through.
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM registration_urls WHERE txid = ?", "tx1").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != max {
+		t.Fatalf("registration_urls count = %d, want %d", count, max)
+	}
+
+	// A different txid is unaffected by the first txid's cap.
+	if err := s.Add("tx2", "http://cb/tx2"); err != nil {
+		t.Fatalf("unrelated txid Add: %v", err)
+	}
+}
+
+// TestRegistrationStore_MaxCallbacksIdempotent verifies that re-registering
+// an already-known URL is a no-op and never trips the cap, even when the
+// txid is already at `max` distinct URLs.
+func TestRegistrationStore_MaxCallbacksIdempotent(t *testing.T) {
+	db, d := newTestDB(t)
+	const max = 2
+	s := newRegistrationStore(db, d, max)
+
+	if err := s.Add("tx1", "http://cb/a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Add("tx1", "http://cb/b"); err != nil {
+		t.Fatal(err)
+	}
+
+	// At cap: re-adding either existing URL must succeed (idempotent set add).
+	for _, url := range []string{"http://cb/a", "http://cb/b"} {
+		if err := s.Add("tx1", url); err != nil {
+			t.Fatalf("idempotent re-add of %q: %v", url, err)
+		}
+	}
+
+	// And a NEW URL still trips the cap.
+	if err := s.Add("tx1", "http://cb/c"); !errors.Is(err, storepkg.ErrMaxCallbacksPerTxIDExceeded) {
+		t.Fatalf("expected ErrMaxCallbacksPerTxIDExceeded, got %v", err)
+	}
+
+	// Count should still be exactly `max`.
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM registration_urls WHERE txid = ?", "tx1").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != max {
+		t.Fatalf("registration_urls count = %d, want %d", count, max)
+	}
+}
+
+// TestRegistrationStore_MaxCallbacksDisabled covers the legacy unbounded
+// path: when maxCallbacksPerTxID is 0 the cap is disabled and arbitrarily
+// many URLs may be registered without ever returning the sentinel.
+func TestRegistrationStore_MaxCallbacksDisabled(t *testing.T) {
+	db, d := newTestDB(t)
+	s := newRegistrationStore(db, d, 0)
+
+	for i := 0; i < 25; i++ {
+		if err := s.Add("tx1", fmt.Sprintf("http://cb/%d", i)); err != nil {
+			t.Fatalf("Add #%d: %v", i, err)
+		}
+	}
+	urls, err := s.Get("tx1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(urls) != 25 {
+		t.Fatalf("got %d urls, want 25 (cap disabled)", len(urls))
 	}
 }
 
@@ -491,7 +587,7 @@ func TestSweeper_StopsOnClose(t *testing.T) {
 func TestSQLBackend_InterfaceSatisfaction(t *testing.T) {
 	db, d := newTestDB(t)
 	var (
-		_ storepkg.RegistrationStore        = newRegistrationStore(db, d)
+		_ storepkg.RegistrationStore        = newRegistrationStore(db, d, 0)
 		_ storepkg.CallbackDedupStore       = newCallbackDedup(db, d)
 		_ storepkg.CallbackURLRegistry      = newCallbackURLRegistry(db, d, time.Hour)
 		_ storepkg.CallbackAccumulatorStore = newCallbackAccumulator(db, d, 60)

--- a/internal/store/sql/sweeper_test.go
+++ b/internal/store/sql/sweeper_test.go
@@ -14,7 +14,7 @@ import (
 // so we don't leak an unbounded set of orphaned URLs.
 func TestSweeper_CascadesRegistrationChildren(t *testing.T) {
 	db, d := newTestDB(t)
-	r := newRegistrationStore(db, d)
+	r := newRegistrationStore(db, d, 0)
 
 	// Two txids: one we'll expire in the past, one fresh.
 	if err := r.Add("tx-old", "http://old1"); err != nil {

--- a/test/scale/scale_test.go
+++ b/test/scale/scale_test.go
@@ -56,7 +56,7 @@ func findNamespace() string {
 			continue
 		}
 		// Verify namespace is writable with a probe write.
-		regStore := store.NewRegistrationStore(client, "ns_probe", 1, 50, logger)
+		regStore := store.NewRegistrationStore(client, "ns_probe", 1, 50, 0, logger)
 		if err := regStore.Add("probe_txid", "http://probe"); err != nil {
 			client.Close()
 			continue
@@ -176,7 +176,7 @@ func runScaleTest(t *testing.T, fixtureDir string, instanceCount int, timeout ti
 	t.Cleanup(func() { asClient.Close() })
 
 	regSetName := fmt.Sprintf("scale_reg_%d", time.Now().UnixNano())
-	regStore := store.NewRegistrationStore(asClient, regSetName, 3, 100, logger)
+	regStore := store.NewRegistrationStore(asClient, regSetName, 3, 100, 0, logger)
 
 	urlRegistrySetName := fmt.Sprintf("scale_urls_%d", time.Now().UnixNano())
 	// 0 ttlSec → constructor falls back to the default 7-day window, which is

--- a/tools/debug-dashboard/main.go
+++ b/tools/debug-dashboard/main.go
@@ -52,6 +52,7 @@ func main() {
 		cfg.Aerospike.SetName,
 		cfg.Aerospike.MaxRetries,
 		cfg.Aerospike.RetryBaseMs,
+		cfg.Registry.MaxCallbacksPerTxID,
 		logger,
 	)
 


### PR DESCRIPTION
## Summary
- New config knob `registry.maxCallbacksPerTxID` (default 10) caps the number of distinct callback URLs per txid.
- Both Aerospike and SQL `Register` enforce the cap atomically (Postgres uses `SELECT ... FOR UPDATE` on the parent row; SQLite relies on `BEGIN IMMEDIATE` writer serialization; Aerospike uses an optimistic generation-CAS append loop). Idempotent re-registration of an already-known URL is unaffected.
- API maps `store.ErrMaxCallbacksPerTxIDExceeded` to HTTP **429** with a clear JSON error body; logs the rejection at WARN.
- New tests: SQL cap-hit returns sentinel + DB count is exactly `max`; idempotent re-add at cap succeeds; cap-disabled path; API handler returns 429.

Closes #27 (F-050).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/... -race`
- [x] `golangci-lint run ./internal/store/... ./internal/api/... ./internal/config/... ./tools/...` — zero new findings vs. main baseline.
- [ ] Reviewer to confirm a default of 10 is operationally reasonable