### PR TITLE
fix(store): atomically transition seen-threshold fired flag (#10)

### DIFF
--- a/internal/store/seen_counter.go
+++ b/internal/store/seen_counter.go
@@ -1,15 +1,23 @@
 package store
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	as "github.com/aerospike/aerospike-client-go/v7"
+	astypes "github.com/aerospike/aerospike-client-go/v7/types"
 )
 
 const (
 	seenSubtreesBin    = "subtrees"
 	seenThresholdFired = "tfired"
+
+	// seenCASMaxAttempts caps the generation-checked retry loop. Real-world
+	// contention is bounded by the number of concurrent subtree workers per
+	// txid; 32 is generous and keeps a runaway loop from holding a connection.
+	seenCASMaxAttempts = 32
 )
 
 // aerospikeSeenCounter is the Aerospike-backed SeenCounterStore implementation.
@@ -35,71 +43,116 @@ func NewSeenCounterStore(client *AerospikeClient, setName string, threshold int,
 	}
 }
 
-// Increment idempotently records that a txid was seen in a specific subtree.
-// Uses Aerospike CDT list with AddUnique to ensure each subtreeID is counted only once.
-// ThresholdReached is true only once: when the unique count first reaches the threshold.
+// Increment idempotently records that a txid was seen in a specific subtree
+// and atomically transitions the threshold-fired flag from false to true the
+// first time the unique-subtree count reaches the threshold. ThresholdReached
+// is true only on the single call that observes that 0->1 transition.
+//
+// The atomic transition is implemented as a generation-checked
+// read-modify-write: each attempt reads the record (capturing generation),
+// computes the next state locally, and issues an Operate with
+// GenerationPolicy=EXPECT_GEN_EQUAL so a concurrent writer that bumped the
+// generation in between forces a retry. F-045: previously the threshold check
+// and the marker write were two unrelated operations, so two concurrent
+// observations could both pass `alreadyFired == false` and emit duplicate
+// SEEN_MULTIPLE_NODES callbacks.
 func (s *aerospikeSeenCounter) Increment(txid string, subtreeID string) (*IncrementResult, error) {
 	key, err := as.NewKey(s.client.Namespace(), s.setName, txid)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create key: %w", err)
 	}
 
-	wp := s.client.WritePolicy(s.maxRetries, s.retryBaseMs)
-	wp.RecordExistsAction = as.UPDATE
-
-	// AddUnique + NoFail: appends subtreeID only if not already present, no error on duplicate.
-	listPolicy := as.NewListPolicy(as.ListOrderUnordered, as.ListWriteFlagsAddUnique|as.ListWriteFlagsNoFail)
-	ops := []*as.Operation{
-		as.ListAppendWithPolicyOp(listPolicy, seenSubtreesBin, subtreeID),
-		as.ListSizeOp(seenSubtreesBin),
-		as.GetBinOp(seenThresholdFired),
-	}
-
-	record, err := s.client.Client().Operate(wp, key, ops...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to increment seen counter: %w", err)
-	}
-
-	// When multiple operations target the same bin, Aerospike returns results
-	// as []interface{}. Index 0 = ListAppend result, index 1 = ListSize result.
-	var newSize int
-	switch v := record.Bins[seenSubtreesBin].(type) {
-	case int:
-		newSize = v
-	case []interface{}:
-		if len(v) < 2 {
-			return nil, fmt.Errorf("expected at least 2 results for seen counter ops, got %d", len(v))
+	for attempt := 0; attempt < seenCASMaxAttempts; attempt++ {
+		// Step 1: read current state + generation. Treat KEY_NOT_FOUND as a
+		// brand-new record (generation 0, empty subtree list, fired=0).
+		readPolicy := s.client.ReadPolicy()
+		current, err := s.client.Client().Get(readPolicy, key, seenSubtreesBin, seenThresholdFired)
+		if err != nil {
+			var asErr as.Error
+			if errors.As(err, &asErr) && asErr.Matches(astypes.KEY_NOT_FOUND_ERROR) {
+				current = nil
+			} else {
+				return nil, fmt.Errorf("failed to read seen counter: %w", err)
+			}
 		}
-		size, ok := v[1].(int)
-		if !ok {
-			return nil, fmt.Errorf("unexpected type for list size result: %T", v[1])
+
+		var (
+			gen           uint32
+			priorFired    bool
+			currentMember bool
+			currentSize   int
+		)
+		if current != nil {
+			gen = current.Generation
+			if firedVal, ok := current.Bins[seenThresholdFired].(int); ok && firedVal == 1 {
+				priorFired = true
+			}
+			if list, ok := current.Bins[seenSubtreesBin].([]interface{}); ok {
+				currentSize = len(list)
+				for _, v := range list {
+					if str, ok := v.(string); ok && str == subtreeID {
+						currentMember = true
+						break
+					}
+				}
+			}
 		}
-		newSize = size
-	default:
-		return nil, fmt.Errorf("unexpected type for seen counter list size: %T", v)
-	}
 
-	// Check if threshold was already fired previously.
-	alreadyFired := false
-	if firedVal := record.Bins[seenThresholdFired]; firedVal != nil {
-		if v, ok := firedVal.(int); ok && v == 1 {
-			alreadyFired = true
+		// Step 2: compute next state locally. AddUnique semantics: only count
+		// distinct subtreeIDs.
+		newSize := currentSize
+		if !currentMember {
+			newSize++
 		}
+		shouldFire := !priorFired && newSize >= s.threshold
+
+		// Step 3: write next state with EXPECT_GEN_EQUAL. We always update the
+		// subtree list (idempotent ListAppend with AddUnique|NoFail handles
+		// re-runs) and only set tfired=1 when this attempt observed the
+		// 0->threshold transition. New records skip the generation check via
+		// CREATE_ONLY so two concurrent first-writers also resolve cleanly.
+		wp := s.client.WritePolicy(s.maxRetries, s.retryBaseMs)
+		if current == nil {
+			wp.RecordExistsAction = as.CREATE_ONLY
+		} else {
+			wp.RecordExistsAction = as.UPDATE
+			wp.GenerationPolicy = as.EXPECT_GEN_EQUAL
+			wp.Generation = gen
+		}
+
+		listPolicy := as.NewListPolicy(as.ListOrderUnordered, as.ListWriteFlagsAddUnique|as.ListWriteFlagsNoFail)
+		ops := []*as.Operation{
+			as.ListAppendWithPolicyOp(listPolicy, seenSubtreesBin, subtreeID),
+		}
+		if shouldFire {
+			ops = append(ops, as.PutOp(as.NewBin(seenThresholdFired, 1)))
+		}
+
+		_, err = s.client.Client().Operate(wp, key, ops...)
+		if err != nil {
+			var asErr as.Error
+			if errors.As(err, &asErr) {
+				// Generation mismatch (concurrent writer beat us) or
+				// CREATE_ONLY collision (two concurrent first-writers): retry
+				// with the now-current state.
+				if asErr.Matches(astypes.GENERATION_ERROR) || asErr.Matches(astypes.KEY_EXISTS_ERROR) {
+					// Tiny backoff to avoid hot-spinning on pathological contention.
+					if s.retryBaseMs > 0 {
+						time.Sleep(time.Duration(s.retryBaseMs) * time.Millisecond)
+					}
+					continue
+				}
+			}
+			return nil, fmt.Errorf("failed to write seen counter: %w", err)
+		}
+
+		return &IncrementResult{
+			NewCount:         newSize,
+			ThresholdReached: shouldFire,
+		}, nil
 	}
 
-	thresholdReached := false
-	if newSize >= s.threshold && !alreadyFired {
-		// Mark threshold as fired so it won't fire again.
-		thresholdReached = true
-		markWP := s.client.WritePolicy(s.maxRetries, s.retryBaseMs)
-		markWP.RecordExistsAction = as.UPDATE
-		_ = s.client.Client().Put(markWP, key, as.BinMap{seenThresholdFired: 1})
-	}
-
-	return &IncrementResult{
-		NewCount:         newSize,
-		ThresholdReached: thresholdReached,
-	}, nil
+	return nil, fmt.Errorf("seen counter CAS exhausted after %d attempts (txid=%s)", seenCASMaxAttempts, txid)
 }
 
 // Threshold returns the configured threshold.

--- a/internal/store/seen_counter_test.go
+++ b/internal/store/seen_counter_test.go
@@ -1,0 +1,160 @@
+package store
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func newSeenCounterTestStore(t *testing.T, threshold int) (SeenCounterStore, *AerospikeClient, string) {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	client, err := NewAerospikeClient("localhost", 3000, "merkle", 2, 50, logger)
+	if err != nil {
+		t.Skipf("Aerospike not available: %v", err)
+	}
+	t.Cleanup(func() { client.Close() })
+
+	setName := fmt.Sprintf("test_seen_%d", os.Getpid())
+	return NewSeenCounterStore(client, setName, threshold, 2, 50, logger), client, setName
+}
+
+func TestSeenCounter_BasicIncrement(t *testing.T) {
+	store, _, _ := newSeenCounterTestStore(t, 3)
+
+	txid := fmt.Sprintf("tx-basic-%d", os.Getpid())
+	for i := 1; i <= 5; i++ {
+		res, err := store.Increment(txid, fmt.Sprintf("subtree-%d", i))
+		if err != nil {
+			t.Fatalf("Increment %d: %v", i, err)
+		}
+		if res.NewCount != i {
+			t.Errorf("Increment %d: NewCount=%d, want %d", i, res.NewCount, i)
+		}
+	}
+}
+
+func TestSeenCounter_DuplicateSubtreeIsIdempotent(t *testing.T) {
+	store, _, _ := newSeenCounterTestStore(t, 3)
+
+	txid := fmt.Sprintf("tx-dup-%d", os.Getpid())
+	for i := 0; i < 4; i++ {
+		res, err := store.Increment(txid, "subtree-A")
+		if err != nil {
+			t.Fatalf("Increment %d: %v", i, err)
+		}
+		if res.NewCount != 1 {
+			t.Errorf("Increment %d: NewCount=%d, want 1 (duplicate subtreeID)", i, res.NewCount)
+		}
+		if res.ThresholdReached {
+			t.Errorf("Increment %d: threshold fired despite single distinct subtree", i)
+		}
+	}
+}
+
+func TestSeenCounter_ThresholdFiresExactlyOnce(t *testing.T) {
+	store, _, _ := newSeenCounterTestStore(t, 3)
+
+	txid := fmt.Sprintf("tx-thresh-%d", os.Getpid())
+	fired := 0
+	for i := 0; i < 8; i++ {
+		res, err := store.Increment(txid, fmt.Sprintf("subtree-%d", i))
+		if err != nil {
+			t.Fatalf("Increment %d: %v", i, err)
+		}
+		if res.ThresholdReached {
+			fired++
+		}
+	}
+	if fired != 1 {
+		t.Fatalf("ThresholdReached fired %d times across 8 distinct subtrees, want exactly 1", fired)
+	}
+}
+
+// TestSeenCounter_ConcurrentThresholdFiresOnce is the F-045 regression test.
+// Many goroutines call Increment for the same txid past the threshold and
+// exactly one must observe ThresholdReached=true. The previous Get-then-Put
+// sequence had a window where two concurrent observations could both see
+// alreadyFired=false and both fire SEEN_MULTIPLE_NODES; the marker-write
+// error was also silently dropped. The fix folds the read + check + set into
+// a generation-checked CAS retry loop, so exactly one caller observes the
+// false->true transition and any write failure is surfaced.
+func TestSeenCounter_ConcurrentThresholdFiresOnce(t *testing.T) {
+	const (
+		threshold = 5
+		workers   = 32
+	)
+	store, _, _ := newSeenCounterTestStore(t, threshold)
+
+	txid := fmt.Sprintf("tx-race-%d", os.Getpid())
+
+	var firedCount int64
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			res, err := store.Increment(txid, fmt.Sprintf("subtree-%d", i))
+			if err != nil {
+				t.Errorf("Increment %d: %v", i, err)
+				return
+			}
+			if res.ThresholdReached {
+				atomic.AddInt64(&firedCount, 1)
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	got := atomic.LoadInt64(&firedCount)
+	if got != 1 {
+		t.Fatalf("F-045 regression: threshold fired %d times across %d concurrent workers, want exactly 1", got, workers)
+	}
+}
+
+// TestSeenCounter_ConcurrentDistinctTxidsAllFire ensures the per-record CAS
+// loop does not falsely serialize unrelated txids: each txid past its
+// threshold should fire independently.
+func TestSeenCounter_ConcurrentDistinctTxidsAllFire(t *testing.T) {
+	const (
+		threshold = 3
+		txids     = 8
+		perTxid   = 5
+	)
+	store, _, _ := newSeenCounterTestStore(t, threshold)
+
+	pid := os.Getpid()
+	firedPerTxid := make([]int64, txids)
+	var wg sync.WaitGroup
+	for i := 0; i < txids; i++ {
+		for j := 0; j < perTxid; j++ {
+			wg.Add(1)
+			go func(i, j int) {
+				defer wg.Done()
+				txid := fmt.Sprintf("tx-multi-%d-%d", pid, i)
+				res, err := store.Increment(txid, fmt.Sprintf("subtree-%d", j))
+				if err != nil {
+					t.Errorf("Increment(%s,%d): %v", txid, j, err)
+					return
+				}
+				if res.ThresholdReached {
+					atomic.AddInt64(&firedPerTxid[i], 1)
+				}
+			}(i, j)
+		}
+	}
+	wg.Wait()
+
+	for i, n := range firedPerTxid {
+		if n != 1 {
+			t.Errorf("txid #%d fired %d times, want exactly 1", i, n)
+		}
+	}
+}

--- a/internal/store/sql/seen_counter.go
+++ b/internal/store/sql/seen_counter.go
@@ -24,9 +24,17 @@ func newSeenCounter(db *sql.DB, d *dialect, threshold int) *seenCounter {
 func (s *seenCounter) Threshold() int { return s.threshold }
 
 // Increment inserts (txid, subtreeID) into seen_counter_subtrees (idempotent
-// via the compound PK), counts distinct subtrees for the txid, and flips the
-// threshold_fired flag atomically on the first call that reaches the threshold.
-// The caller observes ThresholdReached=true on exactly one call.
+// via the compound PK), counts distinct subtrees for the txid, and atomically
+// transitions threshold_fired from 0 to 1 on the first call that reaches the
+// threshold. Exactly one caller observes ThresholdReached=true.
+//
+// F-045: previously the read-then-update of threshold_fired could race when
+// two concurrent callers both saw fired=0 with count >= threshold and each
+// independently set fired=1, both reporting ThresholdReached=true. The fix
+// flips the flag with a single conditional `UPDATE … RETURNING`-style
+// statement (or, on SQLite, an UPDATE that filters on the prior value and
+// then inspects RowsAffected) so the transition is observed by exactly one
+// caller.
 func (s *seenCounter) Increment(txid, subtreeID string) (*storepkg.IncrementResult, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -58,29 +66,62 @@ func (s *seenCounter) Increment(txid, subtreeID string) (*storepkg.IncrementResu
 		return nil, fmt.Errorf("count subtrees: %w", err)
 	}
 
-	// Lock the counter row and check/flip the fired flag atomically.
-	var lockQuery string
-	if isPostgres(s.d) {
-		lockQuery = fmt.Sprintf("SELECT threshold_fired FROM seen_counters WHERE txid = %s FOR UPDATE", s.d.placeholder(1))
-	} else {
-		lockQuery = fmt.Sprintf("SELECT threshold_fired FROM seen_counters WHERE txid = %s", s.d.placeholder(1))
-	}
-	var fired int
-	if err := tx.QueryRowContext(ctx, lockQuery, txid).Scan(&fired); err != nil {
-		return nil, fmt.Errorf("read fired flag: %w", err)
-	}
-
+	// Atomically attempt the 0 -> 1 transition. The WHERE clause guarantees
+	// only one writer succeeds: any concurrent attempt sees threshold_fired
+	// already set to 1 and matches zero rows.
 	thresholdReached := false
-	if fired == 0 && count >= s.threshold {
-		qFire := fmt.Sprintf("UPDATE seen_counters SET threshold_fired = 1 WHERE txid = %s", s.d.placeholder(1))
-		if _, err := tx.ExecContext(ctx, qFire, txid); err != nil {
-			return nil, fmt.Errorf("set fired: %w", err)
+	if count >= s.threshold {
+		thresholdReached, err = s.tryFireThreshold(ctx, tx, txid)
+		if err != nil {
+			return nil, err
 		}
-		thresholdReached = true
 	}
 
 	if err := tx.Commit(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("commit seen counter tx: %w", err)
 	}
 	return &storepkg.IncrementResult{NewCount: count, ThresholdReached: thresholdReached}, nil
+}
+
+// tryFireThreshold flips threshold_fired from 0 to 1 atomically. Returns true
+// if THIS caller performed the transition; false if a concurrent caller had
+// already fired (the row's prior value was already 1). Errors are surfaced —
+// the previous implementation swallowed marker-write failures, masking real
+// faults like a row-level lock timeout.
+func (s *seenCounter) tryFireThreshold(ctx context.Context, tx *sql.Tx, txid string) (bool, error) {
+	if isPostgres(s.d) {
+		// Postgres: UPDATE … RETURNING. RETURNING emits a row only when the
+		// WHERE matches, so the presence of a result row IS the false->true
+		// transition signal.
+		q := fmt.Sprintf(`UPDATE seen_counters
+            SET threshold_fired = 1
+            WHERE txid = %s AND threshold_fired = 0
+            RETURNING 1`, s.d.placeholder(1))
+		var one int
+		err := tx.QueryRowContext(ctx, q, txid).Scan(&one)
+		if err != nil {
+			if err == sql.ErrNoRows {
+				return false, nil
+			}
+			return false, fmt.Errorf("fire threshold (postgres): %w", err)
+		}
+		return true, nil
+	}
+
+	// SQLite path. Modern SQLite (>= 3.35) supports RETURNING, but we keep
+	// portability with older builds by inspecting RowsAffected: the WHERE
+	// filter on threshold_fired = 0 makes the UPDATE itself the CAS, and
+	// RowsAffected > 0 means we won the race.
+	q := fmt.Sprintf(`UPDATE seen_counters
+        SET threshold_fired = 1
+        WHERE txid = %s AND threshold_fired = 0`, s.d.placeholder(1))
+	res, err := tx.ExecContext(ctx, q, txid)
+	if err != nil {
+		return false, fmt.Errorf("fire threshold (sqlite): %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("rows affected after fire threshold: %w", err)
+	}
+	return n > 0, nil
 }

--- a/internal/store/sql/sql_test.go
+++ b/internal/store/sql/sql_test.go
@@ -186,6 +186,64 @@ func TestSeenCounter_ThresholdFiresOnce(t *testing.T) {
 	}
 }
 
+// TestSeenCounter_ConcurrentThresholdFiresOnce is the F-045 regression test:
+// many goroutines call Increment for the same txid past the threshold and
+// exactly one must observe ThresholdReached=true. The previous
+// read-then-update sequence allowed two concurrent callers to both see
+// fired=0 and both report fired, producing duplicate SEEN_MULTIPLE_NODES
+// callbacks. The fix folds the check + flip into a single conditional UPDATE
+// so only one caller wins.
+func TestSeenCounter_ConcurrentThresholdFiresOnce(t *testing.T) {
+	tmp := t.TempDir() + "/concurrent.db"
+	// Allow multiple connections so goroutines actually contend; SQLite
+	// serializes writes via its file lock, which is exactly the property we
+	// rely on for atomicity. Without WAL + multiple conns the test would just
+	// queue every goroutine through one conn and never exercise the race.
+	db, err := sql.Open("sqlite", "file:"+tmp+"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(8)
+	t.Cleanup(func() { db.Close() })
+
+	d := sqliteDialect()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	if err := runMigrations(context.Background(), db, d, logger); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+
+	const (
+		threshold = 5
+		workers   = 32
+	)
+	s := newSeenCounter(db, d, threshold)
+
+	var firedCount int64
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			res, err := s.Increment("tx-race", fmt.Sprintf("st%d", i))
+			if err != nil {
+				t.Errorf("Increment %d: %v", i, err)
+				return
+			}
+			if res.ThresholdReached {
+				atomic.AddInt64(&firedCount, 1)
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	if got := atomic.LoadInt64(&firedCount); got != 1 {
+		t.Fatalf("F-045 regression: threshold fired %d times across %d concurrent workers, want exactly 1", got, workers)
+	}
+}
+
 func TestSubtreeCounter_InitAndDecrement(t *testing.T) {
 	db, d := newTestDB(t)
 	s := newSubtreeCounter(db, d, 600)


### PR DESCRIPTION
## Summary
- Aerospike `Increment` now uses a generation-checked CAS retry loop so the "increment + check threshold + set fired" sequence is one atomic record-level transition; only the writer that observes the `false -> true` flip on `tfired` reports `ThresholdReached=true`.
- SQL `Increment` collapses the read-then-update of `threshold_fired` into a single conditional `UPDATE seen_counters SET threshold_fired = 1 WHERE txid = ? AND threshold_fired = 0` (Postgres uses `RETURNING 1`, SQLite inspects `RowsAffected`), so exactly one concurrent caller wins the transition.
- Marker-write errors are no longer swallowed: both backends surface failures from the threshold-firing write.
- New tests: `TestSeenCounter_ConcurrentThresholdFiresOnce` for both backends spins up 32 goroutines crossing the threshold and asserts `ThresholdReached` fires exactly once. The SQL test also runs under `-race`. The Aerospike tests follow the existing `t.Skipf` pattern when no broker is reachable, matching `callback_accumulator_test.go`.

Closes #10

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/store/... -race`
- [ ] Reviewer to confirm Aerospike retry budget on generation conflicts