### PR TITLE
fix(block): retry on BLOCK_PROCESSED callback publish failure (#12)

### DIFF
--- a/internal/block/subtree_worker.go
+++ b/internal/block/subtree_worker.go
@@ -232,6 +232,15 @@ func (s *SubtreeWorkerService) maxAttempts() int {
 // BLOCK_PROCESSED once the counter store recovers. Without this, a transient
 // Decrement failure would silently leave the per-block counter > 0 forever,
 // arcade waiting for a BLOCK_PROCESSED that never fires.
+//
+// A failure of the BLOCK_PROCESSED publish itself (callback-topic Kafka
+// outage) is also propagated rather than swallowed (F-014). The counter has
+// already been decremented to 0 at this point; the work item is re-driven
+// through handleTransientFailure so the consumer retries. On redelivery the
+// counter goes negative; we treat remaining<=0 as "still need to emit" and
+// re-publish BLOCK_PROCESSED. Receiver-side dedup at the delivery service
+// (keyed by blockHash + callbackURL + type) ensures the registered endpoint
+// sees BLOCK_PROCESSED at most once per (block, URL) pair.
 func (s *SubtreeWorkerService) handleMessage(ctx context.Context, msg *sarama.ConsumerMessage) error {
 	workMsg, err := kafka.DecodeSubtreeWorkMessage(msg.Value)
 	if err != nil {
@@ -376,10 +385,22 @@ func (s *SubtreeWorkerService) handleTransientFailure(workMsg *kafka.SubtreeWork
 // decrementCounterAndMaybeEmit drives the per-block subtree counter and emits
 // BLOCK_PROCESSED when the last subtree finishes.
 //
-// Returns a non-nil error if the underlying counter store's Decrement fails.
-// The error MUST be propagated by callers so the work item is redelivered:
-// previously the failure was logged and swallowed, leaving the counter > 0
-// forever and BLOCK_PROCESSED never emitted for the affected block (F-013).
+// Returns a non-nil error if either the underlying counter store's Decrement
+// fails (F-013) or if BLOCK_PROCESSED emission fails (F-014). The error MUST
+// be propagated by callers so the work item is redelivered:
+//   - F-013: a Decrement failure left the counter > 0 forever and
+//     BLOCK_PROCESSED never emitted for the affected block.
+//   - F-014: a callback-topic publish failure during emit silently dropped
+//     BLOCK_PROCESSED — the counter had already hit 0, the work item was
+//     ack'd, and the registered callback endpoint never got the notification.
+//
+// Note: when emit fails on the success path, the counter has already been
+// decremented to 0. On redelivery the counter will go to -1 and emit will
+// fire again (we treat remaining<=0 as "last subtree, emit now"). Duplicate
+// BLOCK_PROCESSED messages are deduplicated at the callback delivery service
+// (keyed by blockHash + callbackURL + BLOCK_PROCESSED), so the receiver sees
+// at most one BLOCK_PROCESSED per (block, callbackURL) pair.
+//
 // If no counter store is configured (test/dry-run), this is a no-op.
 func (s *SubtreeWorkerService) decrementCounterAndMaybeEmit(blockHash string) error {
 	if s.subtreeCounter == nil {
@@ -393,8 +414,20 @@ func (s *SubtreeWorkerService) decrementCounterAndMaybeEmit(blockHash string) er
 		)
 		return err
 	}
-	if remaining == 0 {
-		s.emitBlockProcessed(blockHash)
+	// remaining<=0 covers both the normal "last subtree" case (==0) and the
+	// retry-after-emit-failure case (<0): if a previous attempt decremented to
+	// 0 but failed to publish BLOCK_PROCESSED, the redelivered work item will
+	// drive the counter negative; we still need to emit so the notification is
+	// not silently lost. Receiver-side dedup handles the duplicate.
+	if remaining <= 0 {
+		if emitErr := s.emitBlockProcessed(blockHash); emitErr != nil {
+			s.Logger.Error("failed to emit BLOCK_PROCESSED; work item will be redelivered",
+				"blockHash", blockHash,
+				"remaining", remaining,
+				"error", emitErr,
+			)
+			return fmt.Errorf("emitting BLOCK_PROCESSED for block %s: %w", blockHash, emitErr)
+		}
 	}
 	return nil
 }
@@ -467,45 +500,76 @@ func (s *SubtreeWorkerService) publishSubtreeCallbacks(workMsg *kafka.SubtreeWor
 	return firstErr
 }
 
-// emitBlockProcessed publishes a BLOCK_PROCESSED message to every registered callback URL.
-func (s *SubtreeWorkerService) emitBlockProcessed(blockHash string) {
+// emitBlockProcessed publishes a BLOCK_PROCESSED message to every registered
+// callback URL.
+//
+// Returns a non-nil error if the URL-registry lookup fails OR if any per-URL
+// encode/publish fails. The loop continues past a single per-URL failure so
+// independent callbacks still go out (partial-success), but the first error
+// encountered is returned to the caller so decrementCounterAndMaybeEmit can
+// propagate it back through handleMessage → handleTransientFailure rather
+// than silently swallowing it. Without this, a transient callback-topic
+// outage when the LAST subtree's decrement-to-zero triggers emit would
+// permanently drop BLOCK_PROCESSED — the counter has already reached zero,
+// the work item is ack'd, and the registered endpoint never receives the
+// notification (F-014).
+//
+// On retry, the redelivered work item drives the counter past zero and
+// emit fires again; duplicate BLOCK_PROCESSED messages are deduplicated at
+// the callback delivery service (keyed by blockHash + callbackURL + type).
+func (s *SubtreeWorkerService) emitBlockProcessed(blockHash string) error {
 	if s.urlRegistry == nil {
-		return
+		return nil
 	}
 
 	urls, err := s.urlRegistry.GetAll()
 	if err != nil {
 		s.Logger.Error("failed to get callback URLs for BLOCK_PROCESSED", "error", err)
-		return
+		return fmt.Errorf("getting callback URLs for BLOCK_PROCESSED on block %s: %w", blockHash, err)
 	}
 	if len(urls) == 0 {
-		return
+		return nil
 	}
 
+	// Track the first error so the caller can re-drive the work item, while
+	// still attempting the remaining URLs (each callback target is
+	// independent — a hiccup on one shouldn't deny delivery to the others on
+	// this attempt). Matches publishSubtreeCallbacks's partial-success
+	// pattern from PR #77.
+	var firstErr error
 	for _, callbackURL := range urls {
 		msg := &kafka.CallbackTopicMessage{
 			CallbackURL: callbackURL,
 			Type:        kafka.CallbackBlockProcessed,
 			BlockHash:   blockHash,
 		}
-		data, err := msg.Encode()
-		if err != nil {
+		data, encErr := msg.Encode()
+		if encErr != nil {
 			s.Logger.Error("failed to encode BLOCK_PROCESSED message",
 				"callbackURL", callbackURL,
-				"error", err,
+				"error", encErr,
 			)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("encoding BLOCK_PROCESSED for %s: %w", callbackURL, encErr)
+			}
 			continue
 		}
-		if err := s.callbackProducer.PublishWithHashKey(callbackURL, data); err != nil {
+		if pubErr := s.callbackProducer.PublishWithHashKey(callbackURL, data); pubErr != nil {
 			s.Logger.Error("failed to publish BLOCK_PROCESSED callback",
 				"callbackURL", callbackURL,
-				"error", err,
+				"error", pubErr,
 			)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("publishing BLOCK_PROCESSED for %s: %w", callbackURL, pubErr)
+			}
 		}
 	}
 
-	s.Logger.Info("emitted BLOCK_PROCESSED callbacks",
-		"blockHash", blockHash,
-		"callbackURLs", len(urls),
-	)
+	if firstErr == nil {
+		s.Logger.Info("emitted BLOCK_PROCESSED callbacks",
+			"blockHash", blockHash,
+			"callbackURLs", len(urls),
+		)
+	}
+	return firstErr
 }

--- a/internal/block/subtree_worker_handle_message_test.go
+++ b/internal/block/subtree_worker_handle_message_test.go
@@ -28,11 +28,17 @@ import (
 // callbackFailingProducer is a sarama.SyncProducer that records every call and
 // can be configured to fail every send. Used to drive the publishSubtreeCallbacks
 // → handleTransientFailure path.
+//
+// failOnType, when non-empty, causes only sends whose payload decodes to a
+// CallbackTopicMessage with that Type to fail. This enables tests for the
+// F-014 emit-failure path (fail BLOCK_PROCESSED while letting STUMP through)
+// without affecting unrelated callback messages on the same producer.
 type callbackFailingProducer struct {
-	mu       sync.Mutex
-	messages []*sarama.ProducerMessage
-	failAll  bool
-	failErr  error
+	mu         sync.Mutex
+	messages   []*sarama.ProducerMessage
+	failAll    bool
+	failOnType kafka.CallbackType
+	failErr    error
 }
 
 func (f *callbackFailingProducer) SendMessage(msg *sarama.ProducerMessage) (int32, int64, error) {
@@ -40,6 +46,13 @@ func (f *callbackFailingProducer) SendMessage(msg *sarama.ProducerMessage) (int3
 	defer f.mu.Unlock()
 	if f.failAll {
 		return 0, 0, f.failErr
+	}
+	if f.failOnType != "" {
+		if b, ok := msg.Value.(sarama.ByteEncoder); ok {
+			if decoded, err := kafka.DecodeCallbackTopicMessage([]byte(b)); err == nil && decoded.Type == f.failOnType {
+				return 0, 0, f.failErr
+			}
+		}
 	}
 	f.messages = append(f.messages, msg)
 	return 0, int64(len(f.messages)), nil
@@ -73,6 +86,28 @@ func (f *callbackFailingProducer) sentCount() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return len(f.messages)
+}
+
+// sentCountOfType returns the number of successfully-sent messages whose
+// payload decodes to the given CallbackType.
+func (f *callbackFailingProducer) sentCountOfType(t kafka.CallbackType) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := 0
+	for _, msg := range f.messages {
+		b, ok := msg.Value.(sarama.ByteEncoder)
+		if !ok {
+			continue
+		}
+		decoded, err := kafka.DecodeCallbackTopicMessage([]byte(b))
+		if err != nil {
+			continue
+		}
+		if decoded.Type == t {
+			n++
+		}
+	}
+	return n
 }
 
 // stubStumpStore is a programmable StumpStore. By default Put returns a fixed
@@ -636,10 +671,282 @@ func TestHandleMessage_HappyPath_DecrementToZeroEmitsBlockProcessed(t *testing.T
 }
 
 // fakeURLRegistry satisfies store.CallbackURLRegistry for the count→0 emit test.
+// getAllErr, when non-nil, causes GetAll to fail — used to drive the F-014
+// "registry lookup error during emit" path.
 type fakeURLRegistry struct {
-	urls []string
+	urls       []string
+	getAllErr  error
 }
 
 func (f *fakeURLRegistry) Add(callbackURL string) error { return nil }
-func (f *fakeURLRegistry) GetAll() ([]string, error)    { return f.urls, nil }
+func (f *fakeURLRegistry) GetAll() ([]string, error) {
+	if f.getAllErr != nil {
+		return nil, f.getAllErr
+	}
+	return f.urls, nil
+}
+
+// --- F-014 BLOCK_PROCESSED publish-failure tests ---
+
+// TestEmitBlockProcessed_PublishFailureReturnsError verifies that when the
+// callback Kafka publish for BLOCK_PROCESSED fails, emitBlockProcessed
+// returns a non-nil error rather than silently swallowing it (F-014).
+func TestEmitBlockProcessed_PublishFailureReturnsError(t *testing.T) {
+	cbMock := &callbackFailingProducer{failAll: true, failErr: errors.New("kafka unavailable")}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	s := &SubtreeWorkerService{
+		urlRegistry: &fakeURLRegistry{urls: []string{
+			"http://cb.example.test/a",
+			"http://cb.example.test/b",
+		}},
+	}
+	s.InitBase("subtree-worker-test")
+	s.Logger = logger
+	s.callbackProducer = kafka.NewTestProducer(cbMock, "callback-test", logger)
+
+	err := s.emitBlockProcessed("blk-emit-fail")
+	if err == nil {
+		t.Fatalf("expected error from emitBlockProcessed when callback publish fails")
+	}
+}
+
+// TestEmitBlockProcessed_PartialFailureContinuesAndReturnsFirstError verifies
+// that when one URL's publish fails, the loop still attempts the remaining
+// URLs (best-effort) and returns the first error to the caller — matching
+// PR #77's publishSubtreeCallbacks pattern.
+func TestEmitBlockProcessed_PartialFailureContinuesAndReturnsFirstError(t *testing.T) {
+	cbMock := &callbackFailingProducer{
+		failOnType: kafka.CallbackBlockProcessed,
+		failErr:    errors.New("kafka unavailable"),
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	s := &SubtreeWorkerService{
+		urlRegistry: &fakeURLRegistry{urls: []string{
+			"http://cb.example.test/a",
+			"http://cb.example.test/b",
+			"http://cb.example.test/c",
+		}},
+	}
+	s.InitBase("subtree-worker-test")
+	s.Logger = logger
+	s.callbackProducer = kafka.NewTestProducer(cbMock, "callback-test", logger)
+
+	err := s.emitBlockProcessed("blk-partial")
+	if err == nil {
+		t.Fatalf("expected non-nil error when BLOCK_PROCESSED publishes fail")
+	}
+	// Every BLOCK_PROCESSED send was failed by the producer, so none were
+	// recorded — but the loop should have ATTEMPTED all URLs.
+	// We can't directly observe attempts without instrumenting failOnType, so
+	// instead verify that no successful BLOCK_PROCESSED was recorded.
+	if got := cbMock.sentCountOfType(kafka.CallbackBlockProcessed); got != 0 {
+		t.Errorf("expected zero successful BLOCK_PROCESSED sends, got %d", got)
+	}
+}
+
+// TestEmitBlockProcessed_HappyPath verifies the no-error path: every URL
+// receives one BLOCK_PROCESSED message and the function returns nil.
+func TestEmitBlockProcessed_HappyPath(t *testing.T) {
+	cbMock := &callbackFailingProducer{}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	s := &SubtreeWorkerService{
+		urlRegistry: &fakeURLRegistry{urls: []string{
+			"http://cb.example.test/a",
+			"http://cb.example.test/b",
+		}},
+	}
+	s.InitBase("subtree-worker-test")
+	s.Logger = logger
+	s.callbackProducer = kafka.NewTestProducer(cbMock, "callback-test", logger)
+
+	if err := s.emitBlockProcessed("blk-happy"); err != nil {
+		t.Fatalf("expected nil error on happy path, got: %v", err)
+	}
+	if got := cbMock.sentCountOfType(kafka.CallbackBlockProcessed); got != 2 {
+		t.Errorf("expected 2 BLOCK_PROCESSED messages, got %d", got)
+	}
+}
+
+// TestEmitBlockProcessed_RegistryFailureReturnsError verifies that a
+// registry-lookup failure surfaces as a non-nil return so the caller can
+// re-drive the work item rather than silently dropping BLOCK_PROCESSED.
+func TestEmitBlockProcessed_RegistryFailureReturnsError(t *testing.T) {
+	cbMock := &callbackFailingProducer{}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	s := &SubtreeWorkerService{
+		urlRegistry: &fakeURLRegistry{getAllErr: errors.New("registry down")},
+	}
+	s.InitBase("subtree-worker-test")
+	s.Logger = logger
+	s.callbackProducer = kafka.NewTestProducer(cbMock, "callback-test", logger)
+
+	if err := s.emitBlockProcessed("blk-registry-fail"); err == nil {
+		t.Fatalf("expected error when URL registry GetAll fails")
+	}
+	if got := cbMock.sentCount(); got != 0 {
+		t.Errorf("expected zero callback publishes when registry lookup fails, got %d", got)
+	}
+}
+
+// TestHandleMessage_BlockProcessedEmitFailure_RetriesAndDoesNotAck covers the
+// core F-014 case at the handler level: the LAST subtree's decrement-to-0
+// triggers emitBlockProcessed, the callback Kafka publish fails for the
+// BLOCK_PROCESSED message, and the work item is re-driven through the retry
+// pipeline (rather than silently ack'd with the BLOCK_PROCESSED notification
+// dropped on the floor).
+func TestHandleMessage_BlockProcessedEmitFailure_RetriesAndDoesNotAck(t *testing.T) {
+	// Producer fails BLOCK_PROCESSED but lets STUMP through. This isolates
+	// the F-014 emit-failure path from the F-012 STUMP-publish path.
+	cbMock := &callbackFailingProducer{
+		failOnType: kafka.CallbackBlockProcessed,
+		failErr:    errors.New("kafka unavailable"),
+	}
+	retryMock := &callbackFailingProducer{}
+	dlqMock := &callbackFailingProducer{}
+
+	const blockHash = "block-emit-fail"
+	counter := newCountingSubtreeCounter()
+	// Pre-seed at 1 so the single subtree drives the counter to 0 → emit fires.
+	_ = counter.Init(blockHash, 1)
+	counter.initCalls = 0
+
+	stumpStore := &stubStumpStore{}
+
+	subtreePayload := buildRawSubtreeBytes(t, 2)
+	server := rawSubtreeServer(subtreePayload)
+	defer server.Close()
+
+	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, 5)
+	svc.urlRegistry = &fakeURLRegistry{urls: []string{"http://cb.example.test/hook"}}
+
+	value := makeWorkMessageBytes(t, blockHash, "subtree-emit-fail", server.URL, 0)
+	if err := svc.handleMessage(context.Background(), &sarama.ConsumerMessage{Value: value}); err != nil {
+		// Below max attempts, handleTransientFailure re-publishes for retry
+		// and returns nil — the work item was redirected through the retry
+		// path rather than silently acked at the success branch.
+		t.Fatalf("handleMessage with BLOCK_PROCESSED emit failure: expected nil after retry republish, got: %v", err)
+	}
+
+	// Counter WAS decremented exactly once (emit happens after Decrement); on
+	// redelivery the counter goes negative and remaining<=0 fires emit again.
+	if got := counter.decrementCount(); got != 1 {
+		t.Errorf("expected counter Decrement called exactly once on emit-failure path, got %d", got)
+	}
+	// STUMP callback was published successfully BEFORE the BLOCK_PROCESSED emit failed.
+	if got := cbMock.sentCountOfType(kafka.CallbackStump); got != 1 {
+		t.Errorf("expected 1 STUMP callback publish before emit failure, got %d", got)
+	}
+	if got := cbMock.sentCountOfType(kafka.CallbackBlockProcessed); got != 0 {
+		t.Errorf("expected zero successful BLOCK_PROCESSED publishes (publish failed), got %d", got)
+	}
+	// Work item must have been re-published for retry.
+	if got := retryMock.sentCount(); got != 1 {
+		t.Errorf("expected exactly 1 retry publish on emit failure, got %d", got)
+	}
+	if got := dlqMock.sentCount(); got != 0 {
+		t.Errorf("expected zero DLQ publishes (below max attempts), got %d", got)
+	}
+}
+
+// TestHandleMessage_BlockProcessedEmitRetry_ReEmitsOnRedelivery verifies the
+// approach-A semantics: when a redelivered work item drives the counter
+// negative (because a previous attempt decremented to 0 but failed to emit),
+// emitBlockProcessed fires again. Receiver-side dedup at the delivery
+// service is responsible for collapsing the duplicate so the registered
+// endpoint sees BLOCK_PROCESSED at most once per (block, URL) pair.
+func TestHandleMessage_BlockProcessedEmitRetry_ReEmitsOnRedelivery(t *testing.T) {
+	cbMock := &callbackFailingProducer{}
+	retryMock := &callbackFailingProducer{}
+	dlqMock := &callbackFailingProducer{}
+
+	const blockHash = "block-emit-retry"
+	counter := newCountingSubtreeCounter()
+	// Pre-seed at 0 to simulate a redelivery: a previous attempt already
+	// decremented to 0 (and either succeeded-emit or failed-emit). The
+	// retry's decrement will drive the counter to -1, and remaining<=0 must
+	// still trigger emit so a previously-failed BLOCK_PROCESSED is retried.
+	_ = counter.Init(blockHash, 0)
+	counter.initCalls = 0
+
+	stumpStore := &stubStumpStore{}
+
+	subtreePayload := buildRawSubtreeBytes(t, 2)
+	server := rawSubtreeServer(subtreePayload)
+	defer server.Close()
+
+	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, 5)
+	svc.urlRegistry = &fakeURLRegistry{urls: []string{"http://cb.example.test/hook"}}
+
+	value := makeWorkMessageBytes(t, blockHash, "subtree-emit-retry", server.URL, 1)
+	if err := svc.handleMessage(context.Background(), &sarama.ConsumerMessage{Value: value}); err != nil {
+		t.Fatalf("handleMessage on redelivery: expected nil, got: %v", err)
+	}
+
+	if got := counter.decrementCount(); got != 1 {
+		t.Errorf("expected counter Decrement called exactly once on redelivery, got %d", got)
+	}
+	if got := counter.value(blockHash); got != -1 {
+		t.Errorf("expected counter to be -1 on redelivery decrement, got %d", got)
+	}
+	// BLOCK_PROCESSED MUST have been re-emitted: receiver-side dedup will
+	// collapse the duplicate at delivery time.
+	if got := cbMock.sentCountOfType(kafka.CallbackBlockProcessed); got != 1 {
+		t.Errorf("expected 1 BLOCK_PROCESSED re-emit on redelivery, got %d", got)
+	}
+	if got := retryMock.sentCount(); got != 0 {
+		t.Errorf("expected zero retry publishes when redelivery succeeds, got %d", got)
+	}
+	if got := dlqMock.sentCount(); got != 0 {
+		t.Errorf("expected zero DLQ publishes, got %d", got)
+	}
+}
+
+// TestHandleMessage_BlockProcessedEmitFailure_AtMaxAttempts_DLQPathReturnsError
+// covers the worst-case F-014 path: a STUMP-publish failure forces DLQ, and
+// the DLQ-path decrement-and-emit hits the F-014 emit failure too. The DLQ
+// publish has already happened, but the emit-failure is propagated so the
+// consumer redelivers — silently acking would leave the registered endpoint
+// without BLOCK_PROCESSED forever. This matches the F-013 DLQ-path
+// Decrement-failure semantics from PR #88: prefer a duplicate DLQ publish
+// over silently losing the BLOCK_PROCESSED notification.
+func TestHandleMessage_BlockProcessedEmitFailure_AtMaxAttempts_DLQPathReturnsError(t *testing.T) {
+	// Producer fails ALL callback publishes — STUMP fails (forcing DLQ) AND
+	// BLOCK_PROCESSED fails (forcing the F-014 path on the DLQ-decrement).
+	cbMock := &callbackFailingProducer{failAll: true, failErr: errors.New("kafka unavailable")}
+	retryMock := &callbackFailingProducer{}
+	dlqMock := &callbackFailingProducer{}
+
+	const blockHash = "block-emit-dlq"
+	counter := newCountingSubtreeCounter()
+	_ = counter.Init(blockHash, 1)
+	counter.initCalls = 0
+
+	stumpStore := &stubStumpStore{}
+
+	subtreePayload := buildRawSubtreeBytes(t, 2)
+	server := rawSubtreeServer(subtreePayload)
+	defer server.Close()
+
+	const maxAttempts = 3
+	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, maxAttempts)
+	svc.urlRegistry = &fakeURLRegistry{urls: []string{"http://cb.example.test/hook"}}
+
+	// AttemptCount = maxAttempts - 1 → next attempt is terminal → DLQ.
+	value := makeWorkMessageBytes(t, blockHash, "subtree-emit-dlq", server.URL, maxAttempts-1)
+	err := svc.handleMessage(context.Background(), &sarama.ConsumerMessage{Value: value})
+	if err == nil {
+		t.Fatalf("expected non-nil error so consumer redelivers when emit fails on DLQ path, got nil")
+	}
+
+	if got := dlqMock.sentCount(); got != 1 {
+		t.Errorf("expected exactly 1 DLQ publish at max attempts, got %d", got)
+	}
+	if got := retryMock.sentCount(); got != 0 {
+		t.Errorf("expected zero retry publishes at max attempts, got %d", got)
+	}
+	// Counter Decrement was attempted exactly once on the DLQ path.
+	if got := counter.decrementCount(); got != 1 {
+		t.Errorf("expected counter Decrement called once on DLQ path, got %d", got)
+	}
+}
 

--- a/internal/block/subtree_worker_test.go
+++ b/internal/block/subtree_worker_test.go
@@ -48,8 +48,10 @@ func TestSubtreeWorkerService_EmitBlockProcessed_NilRegistry(t *testing.T) {
 	svc.Logger = logger
 	svc.callbackProducer = newTestKafkaProducer(mock, "callback-test", logger)
 
-	// Should not panic with nil registry.
-	svc.emitBlockProcessed("blockhash-123")
+	// Should not panic, and should return nil since there's no registry.
+	if err := svc.emitBlockProcessed("blockhash-123"); err != nil {
+		t.Errorf("expected nil error with nil registry, got: %v", err)
+	}
 
 	if len(mock.messages) != 0 {
 		t.Errorf("expected no messages with nil registry, got %d", len(mock.messages))


### PR DESCRIPTION
## Summary
- `emitBlockProcessed` now returns an error and `decrementCounterAndMaybeEmit` propagates it. `handleMessage` routes the failure through `handleTransientFailure` so the Kafka consumer redelivers the work item on transient callback-topic outages instead of silently dropping the BLOCK_PROCESSED notification.
- **Approach A (redelivery-with-dedup):** counter is decremented before emit, so on redelivery the counter goes negative; `remaining<=0` still fires emit. The callback delivery service deduplicates by `(blockHash, callbackURL, BLOCK_PROCESSED)` (see `dedupKeyForMessage` in `internal/callback/delivery.go`), so the registered endpoint sees BLOCK_PROCESSED at most once per `(block, URL)` pair.
- Per-URL emit is best-effort (matches PR #77's `publishSubtreeCallbacks` pattern): on a partial failure, the loop continues so independent callback URLs still get the notification on this attempt; the first error is returned so the caller can re-drive the work item.
- Tests cover: emit happy path, emit publish-failure returns error, emit registry-failure returns error, partial-failure continues+returns first error, handler retry path on emit failure, handler re-emits on redelivery (counter going negative), and the DLQ-path-with-emit-failure case which propagates the error so the consumer redelivers (matches PR #88's F-013 DLQ-decrement-failure semantics — preferring duplicate DLQ publish over silent BLOCK_PROCESSED loss).

Closes #12

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/block/... -race`
- [x] `go test ./... -race` (full suite green)
- [x] `golangci-lint run ./internal/block/...` (only pre-existing errcheck issues in `subtree_processor_test.go` remain; not touched here)
- [ ] Reviewer to confirm dedup-on-redelivery is acceptable (the dedup TTL must outlast the work-item retry window — `Callback.DedupTTLSec` should be >= max-attempts × retry-backoff so a retry that happens after dedup TTL expiry doesn't re-deliver to the receiver)