### PR TITLE
fix(kafka): start new consumer groups at OffsetOldest (#15)

### DIFF
--- a/internal/kafka/consumer.go
+++ b/internal/kafka/consumer.go
@@ -12,6 +12,21 @@ import (
 // MessageHandler is called for each consumed message.
 type MessageHandler func(ctx context.Context, msg *sarama.ConsumerMessage) error
 
+// newConsumerConfig returns the sarama configuration used by every consumer
+// group created by this package. It is extracted so unit tests can verify the
+// invariants we care about (notably the F-031 initial-offset policy) without
+// having to stand up a real Kafka broker.
+func newConsumerConfig() *sarama.Config {
+	config := sarama.NewConfig()
+	config.Consumer.Group.Rebalance.GroupStrategies = []sarama.BalanceStrategy{sarama.NewBalanceStrategyRoundRobin()}
+	// F-031: start new consumer groups at the OLDEST available offset so a
+	// group with no committed offsets (renamed group, lost offsets, fresh
+	// environment) still processes the durable backlog instead of silently
+	// jumping to the topic head and dropping queued work.
+	config.Consumer.Offsets.Initial = sarama.OffsetOldest
+	return config
+}
+
 // Consumer wraps a Sarama consumer group.
 type Consumer struct {
 	group   sarama.ConsumerGroup
@@ -24,10 +39,18 @@ type Consumer struct {
 }
 
 // NewConsumer creates a new Kafka consumer group wrapper.
+//
+// Initial offset policy (F-031): a consumer group with no committed offsets
+// starts at sarama.OffsetOldest so it processes every message already queued
+// on the topic. The previous default of sarama.OffsetNewest silently skipped
+// work whenever a group was renamed, its committed offsets were lost, or the
+// service was deployed into a fresh environment with topics that already had
+// durable backlogs (subtree, subtree-worker, block, callback). For the work
+// topics this service consumes, replaying from the earliest available offset
+// is always correct: the handlers are idempotent and the backlog must be
+// processed, never dropped.
 func NewConsumer(brokers []string, groupID string, topics []string, handler MessageHandler, logger *slog.Logger) (*Consumer, error) {
-	config := sarama.NewConfig()
-	config.Consumer.Group.Rebalance.GroupStrategies = []sarama.BalanceStrategy{sarama.NewBalanceStrategyRoundRobin()}
-	config.Consumer.Offsets.Initial = sarama.OffsetNewest
+	config := newConsumerConfig()
 
 	group, err := sarama.NewConsumerGroup(brokers, groupID, config)
 	if err != nil {

--- a/internal/kafka/consumer_test.go
+++ b/internal/kafka/consumer_test.go
@@ -198,6 +198,24 @@ func TestConsumeClaim_FirstMessageError(t *testing.T) {
 	}
 }
 
+// TestNewConsumerConfig_InitialOffsetOldest is the regression test for F-031.
+// Consumer groups with no committed offsets must start at the OLDEST available
+// offset so renaming a group, recovering lost offsets, or deploying into a
+// fresh environment with a non-empty topic still processes the durable
+// backlog instead of silently skipping it.
+func TestNewConsumerConfig_InitialOffsetOldest(t *testing.T) {
+	cfg := newConsumerConfig()
+	if cfg == nil {
+		t.Fatal("newConsumerConfig returned nil")
+	}
+	if got, want := cfg.Consumer.Offsets.Initial, sarama.OffsetOldest; got != want {
+		t.Errorf("Consumer.Offsets.Initial = %d, want %d (sarama.OffsetOldest); a new consumer group must replay the backlog, not jump to the topic head", got, want)
+	}
+	if got := cfg.Consumer.Offsets.Initial; got == sarama.OffsetNewest {
+		t.Errorf("Consumer.Offsets.Initial must not be sarama.OffsetNewest (F-031): new groups would silently skip queued work")
+	}
+}
+
 // TestConsumeClaim_ContextCancelled verifies the loop exits cleanly when the
 // session context is cancelled mid-flight (Stop / rebalance path).
 func TestConsumeClaim_ContextCancelled(t *testing.T) {


### PR DESCRIPTION
## Summary
- Switch the sarama consumer initial-offset default from `OffsetNewest` to `OffsetOldest` so a group with no committed offsets replays the durable backlog instead of silently jumping to the topic head (F-031).
- Extract the sarama config into `newConsumerConfig` so the offset-policy invariant is unit-testable without a live broker.
- Add `TestNewConsumerConfig_InitialOffsetOldest` pinning the new behaviour and explicitly rejecting `OffsetNewest`.

## Why
A renamed consumer group, lost committed offsets, or a fresh deploy into an environment with a non-empty topic would cause the consumer to skip every already-queued message. The work topics this service consumes (`subtree`, `subtree-worker`, `block`, `callback`) have idempotent handlers and must process the backlog, not drop it.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/kafka/... -count=1 -race`
- [x] New unit test `TestNewConsumerConfig_InitialOffsetOldest` asserts `cfg.Consumer.Offsets.Initial == sarama.OffsetOldest`.

Closes #15