### PR TITLE
fix(store/file_blob): reject path-traversal blob keys (#24)

### DIFF
--- a/internal/store/file_blob.go
+++ b/internal/store/file_blob.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -77,11 +78,18 @@ func schemeOf(rawURL string) string {
 
 // FileBlobStore implements BlobStore using the local filesystem.
 type FileBlobStore struct {
-	dir    string
-	mu     sync.RWMutex
-	dah    map[string]uint64 // delete-at-height per key
-	height uint64
+	dir     string
+	rootAbs string // absolute, cleaned form of dir for traversal checks
+	mu      sync.RWMutex
+	dah     map[string]uint64 // delete-at-height per key
+	height  uint64
 }
+
+// ErrBlobKeyEscapesRoot is returned when a blob key resolves to a filesystem
+// path outside the configured root directory. F-038 (issue #24): an
+// attacker-controlled subtree/STUMP key could otherwise read, write, or
+// delete files anywhere the service has filesystem permission.
+var ErrBlobKeyEscapesRoot = errors.New("blob key escapes root directory")
 
 // NewFileBlobStore creates a new file-based blob store rooted at dir.
 // The directory is created if it doesn't exist.
@@ -89,14 +97,66 @@ func NewFileBlobStore(dir string) (*FileBlobStore, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("creating blob store directory %s: %w", dir, err)
 	}
+	rootAbs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolving blob store directory %s: %w", dir, err)
+	}
 	return &FileBlobStore{
-		dir: dir,
-		dah: make(map[string]uint64),
+		dir:     dir,
+		rootAbs: rootAbs,
+		dah:     make(map[string]uint64),
 	}, nil
 }
 
-func (f *FileBlobStore) path(key string) string {
-	return filepath.Join(f.dir, key)
+// resolvePath validates key and returns the absolute path it maps to inside
+// f.dir. F-038: keys arrive from network-facing producers (subtree hashes,
+// STUMP refs) so we must reject any shape that could escape f.dir before
+// calling into the filesystem.
+//
+// The validation is layered:
+//  1. Reject the obviously-malicious shapes at entry — empty, absolute,
+//     leading slash, OS-specific separators (Windows '\\'), and any segment
+//     equal to ".." — so the error message names the offending key without
+//     leaking the resolved root.
+//  2. Re-check after filepath.Clean+Join via filepath.Rel so we also catch
+//     anything sneakier that happens to clean to a sibling directory (for
+//     example via OS-specific path quirks or future refactors that change
+//     how keys are composed).
+func (f *FileBlobStore) resolvePath(key string) (string, error) {
+	if key == "" {
+		return "", fmt.Errorf("%w: empty key", ErrBlobKeyEscapesRoot)
+	}
+	if filepath.IsAbs(key) || strings.HasPrefix(key, "/") {
+		return "", fmt.Errorf("%w: %q is absolute", ErrBlobKeyEscapesRoot, key)
+	}
+	// Reject Windows-style separators on every platform: blob keys are
+	// produced by content addressing (sha256 hex) plus optional "<bucket>/"
+	// prefixes, so a backslash is always anomalous and might bypass
+	// filepath.Clean on non-Windows hosts.
+	if strings.ContainsRune(key, '\\') {
+		return "", fmt.Errorf("%w: %q contains backslash", ErrBlobKeyEscapesRoot, key)
+	}
+	// Walk segments and reject any "..". Splitting by "/" works for the
+	// forward-slash-namespaced keys this store accepts; the IsAbs check
+	// above already rejects anything starting at root.
+	for _, seg := range strings.Split(key, "/") {
+		if seg == ".." {
+			return "", fmt.Errorf("%w: %q contains parent segment", ErrBlobKeyEscapesRoot, key)
+		}
+	}
+
+	cleaned := filepath.Clean(key)
+	joined := filepath.Join(f.dir, cleaned)
+
+	abs, err := filepath.Abs(joined)
+	if err != nil {
+		return "", fmt.Errorf("resolving blob path %q: %w", key, err)
+	}
+	rel, err := filepath.Rel(f.rootAbs, abs)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("%w: %q", ErrBlobKeyEscapesRoot, key)
+	}
+	return abs, nil
 }
 
 func (f *FileBlobStore) Set(key string, data []byte, opts ...BlobOption) error {
@@ -105,11 +165,14 @@ func (f *FileBlobStore) Set(key string, data []byte, opts ...BlobOption) error {
 		opt(o)
 	}
 
-	path := f.path(key)
+	path, err := f.resolvePath(key)
+	if err != nil {
+		return err
+	}
 	// Keys may contain path separators (e.g. "stump/<sha256>") to namespace
 	// different blob categories. os.WriteFile does not create parents, so
 	// ensure the containing directory exists before writing.
-	if parent := filepath.Dir(path); parent != "" && parent != f.dir {
+	if parent := filepath.Dir(path); parent != "" && parent != f.rootAbs {
 		if err := os.MkdirAll(parent, 0o755); err != nil {
 			return fmt.Errorf("creating blob parent dir %s: %w", parent, err)
 		}
@@ -136,7 +199,11 @@ func (f *FileBlobStore) SetFromReader(key string, r io.Reader, size int64, opts 
 }
 
 func (f *FileBlobStore) Get(key string) ([]byte, error) {
-	data, err := os.ReadFile(f.path(key))
+	path, err := f.resolvePath(key)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("%w: %s", ErrBlobNotFound, key)
@@ -155,11 +222,16 @@ func (f *FileBlobStore) GetIoReader(key string) (io.ReadCloser, error) {
 }
 
 func (f *FileBlobStore) Del(key string) error {
+	path, err := f.resolvePath(key)
+	if err != nil {
+		return err
+	}
+
 	f.mu.Lock()
 	delete(f.dah, key)
 	f.mu.Unlock()
 
-	err := os.Remove(f.path(key))
+	err = os.Remove(path)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("deleting blob %s: %w", key, err)
 	}
@@ -171,10 +243,14 @@ func (f *FileBlobStore) SetCurrentBlockHeight(height uint64) {
 	defer f.mu.Unlock()
 	f.height = height
 
-	// Prune entries whose DAH has been reached.
+	// Prune entries whose DAH has been reached. Keys in f.dah were already
+	// validated by Set, but re-validate defensively so a future bug that
+	// writes to f.dah outside Set can't trigger a traversal during pruning.
 	for key, dah := range f.dah {
 		if height >= dah {
-			_ = os.Remove(f.path(key))
+			if path, err := f.resolvePath(key); err == nil {
+				_ = os.Remove(path)
+			}
 			delete(f.dah, key)
 		}
 	}

--- a/internal/store/file_blob_test.go
+++ b/internal/store/file_blob_test.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"bytes"
+	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -139,6 +141,133 @@ func TestNewBlobStoreFromURL(t *testing.T) {
 		}
 		if strings.Contains(err.Error(), "shouldnotleak") {
 			t.Errorf("error %q leaked the trailing portion of the input", err.Error())
+		}
+	})
+}
+
+// TestFileBlobStore_RejectsPathTraversalKeys pins F-038 (issue #24): blob keys
+// must not be able to read, write, or delete files outside the configured
+// root directory. Each operation (Set, Get, GetIoReader, Del) is checked
+// against the same set of attacker-controlled keys to ensure the validation
+// runs at every entry point — a one-sided fix that only guards Set would
+// still leak filesystem reads/deletes.
+func TestFileBlobStore_RejectsPathTraversalKeys(t *testing.T) {
+	root := t.TempDir()
+	bs, err := NewFileBlobStore(root)
+	if err != nil {
+		t.Fatalf("NewFileBlobStore: %v", err)
+	}
+
+	// Pre-create a sentinel file outside the root that, if traversal worked,
+	// the store would happily read or delete. The test asserts the file is
+	// untouched after every malicious operation.
+	outside := t.TempDir()
+	sentinelPath := filepath.Join(outside, "secret")
+	sentinelData := []byte("DO NOT TOUCH")
+	if err := os.WriteFile(sentinelPath, sentinelData, 0o600); err != nil {
+		t.Fatalf("seeding sentinel: %v", err)
+	}
+
+	traversalCases := []struct {
+		name string
+		key  string
+	}{
+		{"parent traversal", "../../etc/passwd"},
+		{"absolute path", "/etc/passwd"},
+		{"nested traversal escapes", "foo/../../../bar"},
+		{"relative escape via outside root", "../" + filepath.Base(outside) + "/secret"},
+		{"empty key", ""},
+		{"backslash-prefixed absolute", "\\etc\\passwd"},
+		{"single dot-dot", ".."},
+	}
+
+	for _, tc := range traversalCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if err := bs.Set(tc.key, []byte("pwn")); err == nil {
+				t.Errorf("Set(%q) accepted; want rejection", tc.key)
+			} else if !errors.Is(err, ErrBlobKeyEscapesRoot) {
+				t.Errorf("Set(%q) error = %v; want ErrBlobKeyEscapesRoot", tc.key, err)
+			}
+			if _, err := bs.Get(tc.key); err == nil {
+				t.Errorf("Get(%q) accepted; want rejection", tc.key)
+			} else if !errors.Is(err, ErrBlobKeyEscapesRoot) {
+				t.Errorf("Get(%q) error = %v; want ErrBlobKeyEscapesRoot", tc.key, err)
+			}
+			if _, err := bs.GetIoReader(tc.key); err == nil {
+				t.Errorf("GetIoReader(%q) accepted; want rejection", tc.key)
+			} else if !errors.Is(err, ErrBlobKeyEscapesRoot) {
+				t.Errorf("GetIoReader(%q) error = %v; want ErrBlobKeyEscapesRoot", tc.key, err)
+			}
+			if err := bs.Del(tc.key); err == nil {
+				t.Errorf("Del(%q) accepted; want rejection", tc.key)
+			} else if !errors.Is(err, ErrBlobKeyEscapesRoot) {
+				t.Errorf("Del(%q) error = %v; want ErrBlobKeyEscapesRoot", tc.key, err)
+			}
+		})
+	}
+
+	// The sentinel must still exist with original contents — a single
+	// traversal that snuck through would either delete it or rewrite it.
+	got, err := os.ReadFile(sentinelPath)
+	if err != nil {
+		t.Fatalf("sentinel disappeared: %v", err)
+	}
+	if !bytes.Equal(got, sentinelData) {
+		t.Fatalf("sentinel rewritten: got %q want %q", got, sentinelData)
+	}
+}
+
+// TestFileBlobStore_AcceptsValidKeys keeps the legitimate key shapes — bare
+// hex hashes and slash-namespaced "<bucket>/<hash>" keys — working after the
+// traversal guard. A regression here would silently break STUMP storage,
+// which uses "stump/<sha256>" via stumpKeyPrefix.
+func TestFileBlobStore_AcceptsValidKeys(t *testing.T) {
+	dir := t.TempDir()
+	bs, err := NewFileBlobStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileBlobStore: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		key  string
+	}{
+		{"hex hash", "abc123def4567890abcdef1234567890abcdef1234567890abcdef1234567890"},
+		{"slash-namespaced (stump)", "stump/3292be80a8cd32bc53582b666a1f13564259281a256a6b40aae0bc83c4d50a4d"},
+		{"bucket/hash", "bucket/abc123"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			payload := []byte("payload-" + tc.name)
+			if err := bs.Set(tc.key, payload); err != nil {
+				t.Fatalf("Set(%q): %v", tc.key, err)
+			}
+			got, err := bs.Get(tc.key)
+			if err != nil {
+				t.Fatalf("Get(%q): %v", tc.key, err)
+			}
+			if !bytes.Equal(got, payload) {
+				t.Errorf("round-trip mismatch for %q: got %q want %q", tc.key, got, payload)
+			}
+			if err := bs.Del(tc.key); err != nil {
+				t.Errorf("Del(%q): %v", tc.key, err)
+			}
+		})
+	}
+
+	// Boundary case: "foo/bar/../baz" cleans to "foo/baz" which stays inside
+	// f.dir, so a Rel-only check would let it through. We reject it anyway
+	// because no legitimate producer (subtree hashes, STUMP refs) ever emits
+	// ".." segments — accepting them would only matter to someone trying to
+	// probe the validator. Document the rejection so a future refactor can't
+	// loosen this without weighing the trade-off.
+	t.Run("interior dot-dot segment rejected even though it stays in root", func(t *testing.T) {
+		err := bs.Set("foo/bar/../baz", []byte("x"))
+		if err == nil || !errors.Is(err, ErrBlobKeyEscapesRoot) {
+			t.Errorf("Set(\"foo/bar/../baz\") = %v; want ErrBlobKeyEscapesRoot", err)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- F-038 (issue #24): `FileBlobStore.Set/Get/GetIoReader/Del` joined arbitrary keys onto `f.dir`, so a `..` or absolute key could read, write, or delete files anywhere the service had filesystem permission.
- Adds a `resolvePath` validator that rejects empty keys, absolute paths, backslashes, and any `..` segment up front, then re-checks the cleaned `filepath.Join` is rooted under the absolute root via `filepath.Rel`.
- All four entry points (plus the DAH pruner in `SetCurrentBlockHeight`) now route through the validator before touching the filesystem.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/store/... -count=1 -race`
- [x] New `TestFileBlobStore_RejectsPathTraversalKeys` covers `../../etc/passwd`, `/etc/passwd`, `foo/../../../bar`, sibling-dir escape via outside root, empty key, `\\etc\\passwd`, and bare `..` against `Set`/`Get`/`GetIoReader`/`Del`, with a sentinel file outside the root that must remain untouched.
- [x] New `TestFileBlobStore_AcceptsValidKeys` round-trips bare hex hashes, `stump/<sha256>`, and `bucket/abc123` to confirm the legitimate key shapes still work; a boundary subtest pins the rejection of `foo/bar/../baz` (cleans inside root but still rejected as defense in depth).

Closes #24.