### PR TITLE
fix(datahub): SSRF guards for DataHub URL fetches (#22)

### DIFF
--- a/internal/block/processor.go
+++ b/internal/block/processor.go
@@ -57,11 +57,12 @@ func NewProcessor(
 }
 
 func (p *Processor) Init(cfg interface{}) error {
-	p.dataHubClient = datahub.NewClientWithCaps(
+	p.dataHubClient = datahub.NewClientWithSSRFGuard(
 		p.datahubCfg.TimeoutSec,
 		p.datahubCfg.MaxRetries,
 		p.datahubCfg.MaxBlockBytes,
 		p.datahubCfg.MaxSubtreeBytes,
+		p.datahubCfg.AllowPrivateIPs,
 		p.Logger,
 	)
 

--- a/internal/block/subtree_worker.go
+++ b/internal/block/subtree_worker.go
@@ -76,11 +76,12 @@ func NewSubtreeWorkerService(
 }
 
 func (s *SubtreeWorkerService) Init(_ interface{}) error {
-	s.dataHubClient = datahub.NewClientWithCaps(
+	s.dataHubClient = datahub.NewClientWithSSRFGuard(
 		s.datahubCfg.TimeoutSec,
 		s.datahubCfg.MaxRetries,
 		s.datahubCfg.MaxBlockBytes,
 		s.datahubCfg.MaxSubtreeBytes,
+		s.datahubCfg.AllowPrivateIPs,
 		s.Logger,
 	)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -267,6 +267,18 @@ type DataHubConfig struct {
 	// Operators with a smaller subtree size limit should tune this down.
 	// A value <= 0 selects the default.
 	MaxSubtreeBytes int64 `yaml:"maxSubtreeBytes" mapstructure:"maxsubtreebytes"`
+
+	// AllowPrivateIPs disables the SSRF guard that normally rejects
+	// DataHub URLs (or dial addresses) pointing at loopback,
+	// link-local, or RFC1918 destinations. Default false. Because the
+	// dataHubURL flows from peer-controlled P2P announcements, by
+	// default a forged announcement cannot turn the block/subtree
+	// processors into an SSRF primitive against cluster-internal
+	// services or cloud metadata endpoints. Operators running an
+	// in-cluster Teranode peer (testing, sidecar topologies) can set
+	// this to true. The guard against 0.0.0.0/multicast destinations
+	// remains in force regardless. See finding F-028.
+	AllowPrivateIPs bool `yaml:"allowPrivateIPs" mapstructure:"allowprivateips"`
 }
 
 // registerDefaults sets all default values in the Viper instance.
@@ -377,6 +389,8 @@ func registerDefaults(v *viper.Viper) {
 	// 1 GiB — accommodates Teranode subtrees up to ~33.5M txids; operators
 	// running with smaller per-subtree limits should tune this down.
 	v.SetDefault("datahub.maxsubtreebytes", int64(1*1024*1024*1024))
+	// SSRF guard default: deny private/loopback/link-local destinations.
+	v.SetDefault("datahub.allowprivateips", false)
 
 	// Registry
 	v.SetDefault("registry.maxcallbackspertxid", 10)
@@ -494,6 +508,7 @@ func bindEnvVars(v *viper.Viper) {
 		"datahub.maxretries":      "DATAHUB_MAX_RETRIES",
 		"datahub.maxblockbytes":   "DATAHUB_MAX_BLOCK_BYTES",
 		"datahub.maxsubtreebytes": "DATAHUB_MAX_SUBTREE_BYTES",
+		"datahub.allowprivateips": "DATAHUB_ALLOW_PRIVATE_IPS",
 
 		// Registry
 		"registry.maxcallbackspertxid": "REGISTRY_MAX_CALLBACKS_PER_TXID",

--- a/internal/datahub/client.go
+++ b/internal/datahub/client.go
@@ -2,15 +2,19 @@ package datahub
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"math"
+	"net"
 	"net/http"
+	"syscall"
 	"time"
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	subtreepkg "github.com/bsv-blockchain/go-subtree"
+	"github.com/bsv-blockchain/merkle-service/internal/ssrfguard"
 	"github.com/bsv-blockchain/teranode/model"
 )
 
@@ -44,6 +48,14 @@ const (
 // Response bodies are read through an io.LimitReader and Content-Length is
 // checked before reading, so a hostile or malfunctioning DataHub cannot
 // exhaust process memory by returning an unbounded response.
+//
+// Because dataHubURL is sourced from peer-controlled P2P announcements, the
+// client also gates outbound requests through the shared ssrfguard predicate
+// at two layers: a URL/DNS check at request time and a Dialer.Control hook at
+// connect time. A malicious peer cannot redirect block/subtree fetches at
+// loopback, link-local, RFC1918 or cloud-metadata IPs unless the operator
+// has explicitly opted in via DataHubConfig.AllowPrivateIPs. See finding
+// F-028.
 type Client struct {
 	httpClient *http.Client
 	maxRetries int
@@ -54,20 +66,41 @@ type Client struct {
 	maxBlockBytes   int64
 	maxSubtreeBytes int64
 	maxGenericBytes int64
+
+	// allowPrivateIPs disables the SSRF predicate's private/loopback
+	// /link-local check. The unspecified/multicast checks remain in
+	// force regardless. Mirrors CallbackConfig.AllowPrivateIPs.
+	allowPrivateIPs bool
 }
 
 // NewClient creates a new DataHub client with the default per-endpoint
-// response body caps. Use NewClientWithCaps to override the caps from
-// configuration.
+// response body caps. The SSRF guard is enabled with allowPrivateIPs=true
+// for parity with this constructor's historical test-friendly behaviour
+// (httptest binds to 127.0.0.1). Production code MUST use
+// NewClientWithSSRFGuard so private destinations are blocked by default.
 func NewClient(timeoutSec int, maxRetries int, logger *slog.Logger) *Client {
-	return NewClientWithCaps(timeoutSec, maxRetries, 0, 0, logger)
+	return NewClientWithSSRFGuard(timeoutSec, maxRetries, 0, 0, true, logger)
 }
 
 // NewClientWithCaps creates a new DataHub client with explicit per-endpoint
 // response body caps. A cap of 0 selects the corresponding Default* value.
 // Negative caps are clamped to 0 (i.e. fall back to the default) to avoid
-// silently disabling the protection.
+// silently disabling the protection. The SSRF guard is enabled but with
+// allowPrivateIPs=true so existing tests using httptest (127.0.0.1) keep
+// working. Production code paths should call NewClientWithSSRFGuard with
+// the operator's AllowPrivateIPs setting.
 func NewClientWithCaps(timeoutSec int, maxRetries int, maxBlockBytes int64, maxSubtreeBytes int64, logger *slog.Logger) *Client {
+	return NewClientWithSSRFGuard(timeoutSec, maxRetries, maxBlockBytes, maxSubtreeBytes, true, logger)
+}
+
+// NewClientWithSSRFGuard creates a new DataHub client with explicit
+// per-endpoint response body caps and an SSRF predicate applied at both
+// request time (URL/DNS validation) and dial time (Dialer.Control). A cap
+// of 0 selects the corresponding Default*; negative caps are clamped to
+// 0. allowPrivateIPs=false (the production default) blocks
+// loopback/link-local/RFC1918/cloud-metadata destinations even if a
+// peer-supplied dataHubURL points there. Mitigates F-028.
+func NewClientWithSSRFGuard(timeoutSec int, maxRetries int, maxBlockBytes int64, maxSubtreeBytes int64, allowPrivateIPs bool, logger *slog.Logger) *Client {
 	if maxBlockBytes <= 0 {
 		maxBlockBytes = DefaultMaxBlockBytes
 	}
@@ -75,14 +108,41 @@ func NewClientWithCaps(timeoutSec int, maxRetries int, maxBlockBytes int64, maxS
 		maxSubtreeBytes = DefaultMaxSubtreeBytes
 	}
 	return &Client{
-		httpClient: &http.Client{
-			Timeout: time.Duration(timeoutSec) * time.Second,
-		},
+		httpClient:      newSSRFAwareHTTPClient(timeoutSec, allowPrivateIPs),
 		maxRetries:      maxRetries,
 		logger:          logger,
 		maxBlockBytes:   maxBlockBytes,
 		maxSubtreeBytes: maxSubtreeBytes,
 		maxGenericBytes: DefaultMaxGenericBytes,
+		allowPrivateIPs: allowPrivateIPs,
+	}
+}
+
+// newSSRFAwareHTTPClient builds the underlying http.Client used by the
+// DataHub client. A net.Dialer.Control hook calls
+// ssrfguard.CheckDialAddress on every TCP dial so a peer that bypasses
+// the request-time URL check (e.g. via DNS rebinding) is still rejected
+// at connection time. The Control hook receives the resolved
+// "ip:port" address from Go's resolver — there is no opportunity for a
+// hostname to be substituted between resolution and dial.
+func newSSRFAwareHTTPClient(timeoutSec int, allowPrivateIPs bool) *http.Client {
+	transport := &http.Transport{
+		IdleConnTimeout:    90 * time.Second,
+		DisableCompression: false,
+		DialContext: (&net.Dialer{
+			Timeout:   10 * time.Second,
+			KeepAlive: 30 * time.Second,
+			Control: func(network, address string, _ syscall.RawConn) error {
+				if network != "tcp" && network != "tcp4" && network != "tcp6" {
+					return nil
+				}
+				return ssrfguard.CheckDialAddress(address, allowPrivateIPs)
+			},
+		}).DialContext,
+	}
+	return &http.Client{
+		Timeout:   time.Duration(timeoutSec) * time.Second,
+		Transport: transport,
 	}
 }
 
@@ -105,7 +165,13 @@ type BlockMetadata struct {
 }
 
 // FetchSubtreeRaw fetches raw binary subtree data from a DataHub endpoint.
+// dataHubURL is treated as untrusted (it flows from peer-controlled P2P
+// announcements) and is validated against the SSRF predicate before any
+// network I/O happens.
 func (c *Client) FetchSubtreeRaw(ctx context.Context, dataHubURL string, hash string) ([]byte, error) {
+	if err := c.validateDataHubURL(dataHubURL); err != nil {
+		return nil, err
+	}
 	url := fmt.Sprintf("%s/subtree/%s", dataHubURL, hash)
 	return c.doGetWithRetry(ctx, url, c.maxSubtreeBytes)
 }
@@ -183,7 +249,13 @@ func ParseBinaryBlockMetadata(data []byte) (*BlockMetadata, error) {
 }
 
 // FetchBlockMetadata fetches block metadata (binary) from a DataHub endpoint.
+// dataHubURL is treated as untrusted (it flows from peer-controlled P2P
+// announcements) and is validated against the SSRF predicate before any
+// network I/O happens.
 func (c *Client) FetchBlockMetadata(ctx context.Context, dataHubURL string, hash string) (*BlockMetadata, error) {
+	if err := c.validateDataHubURL(dataHubURL); err != nil {
+		return nil, err
+	}
 	url := fmt.Sprintf("%s/block/%s", dataHubURL, hash)
 	data, err := c.doGetWithRetry(ctx, url, c.maxBlockBytes)
 	if err != nil {
@@ -196,6 +268,30 @@ func (c *Client) FetchBlockMetadata(ctx context.Context, dataHubURL string, hash
 	}
 
 	return meta, nil
+}
+
+// validateDataHubURL applies the shared SSRF predicate to a peer-supplied
+// DataHub base URL. It runs at request time (so the offending URL never
+// reaches Go's HTTP client) and is reinforced by the Dialer.Control hook
+// installed on the client transport. Errors are wrapped so callers can
+// distinguish SSRF rejection from transport failures.
+func (c *Client) validateDataHubURL(rawURL string) error {
+	if err := ssrfguard.ValidateURL(rawURL, c.allowPrivateIPs, nil); err != nil {
+		c.logger.Warn("rejecting DataHub URL by SSRF policy",
+			"url", rawURL,
+			"allowPrivateIPs", c.allowPrivateIPs,
+			"error", err,
+		)
+		switch {
+		case errors.Is(err, ssrfguard.ErrBlockedAddress):
+			return fmt.Errorf("DataHub URL rejected by SSRF policy: %w", err)
+		case errors.Is(err, ssrfguard.ErrInvalidURL):
+			return fmt.Errorf("invalid DataHub URL: %w", err)
+		default:
+			return fmt.Errorf("DataHub URL validation failed: %w", err)
+		}
+	}
+	return nil
 }
 
 // readCapped reads up to maxBytes from r and returns an error if the body is

--- a/internal/datahub/client_ssrf_test.go
+++ b/internal/datahub/client_ssrf_test.go
@@ -1,0 +1,149 @@
+package datahub
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bsv-blockchain/merkle-service/internal/ssrfguard"
+)
+
+// TestFetchSubtreeRaw_RejectsLoopbackURL verifies that a peer-supplied
+// DataHub URL pointing at 127.0.0.1 is rejected at request-time
+// validation, before any network I/O happens. This is the first layer of
+// the SSRF defence: an attacker cannot turn a forged P2P announcement
+// into a GET against a service listening on the loopback interface.
+func TestFetchSubtreeRaw_RejectsLoopbackURL(t *testing.T) {
+	client := NewClientWithSSRFGuard(5, 0, 0, 0, false, testLogger())
+
+	_, err := client.FetchSubtreeRaw(context.Background(), "http://127.0.0.1:9999", "abc")
+	if err == nil {
+		t.Fatal("expected SSRF rejection for loopback URL, got nil")
+	}
+	if !errors.Is(err, ssrfguard.ErrBlockedAddress) {
+		t.Fatalf("expected ErrBlockedAddress, got: %v", err)
+	}
+}
+
+// TestFetchBlockMetadata_RejectsPrivateIPURL verifies the same
+// protection on the block-metadata path: a peer-supplied URL pointing
+// at an RFC1918 IP must be refused.
+func TestFetchBlockMetadata_RejectsPrivateIPURL(t *testing.T) {
+	client := NewClientWithSSRFGuard(5, 0, 0, 0, false, testLogger())
+
+	_, err := client.FetchBlockMetadata(context.Background(), "http://10.0.0.5:8080", "blockhash")
+	if err == nil {
+		t.Fatal("expected SSRF rejection for RFC1918 URL, got nil")
+	}
+	if !errors.Is(err, ssrfguard.ErrBlockedAddress) {
+		t.Fatalf("expected ErrBlockedAddress, got: %v", err)
+	}
+}
+
+// TestFetchSubtreeRaw_RejectsCloudMetadataHost verifies the cloud
+// metadata hostname denylist is enforced: even if a peer sends
+// "metadata.google.internal" the request never leaves the process.
+func TestFetchSubtreeRaw_RejectsCloudMetadataHost(t *testing.T) {
+	client := NewClientWithSSRFGuard(5, 0, 0, 0, false, testLogger())
+
+	// 169.254.169.254 is on the metadata-hostname denylist regardless
+	// of allowPrivateIPs.
+	_, err := client.FetchSubtreeRaw(context.Background(), "http://169.254.169.254/latest/meta-data", "abc")
+	if err == nil {
+		t.Fatal("expected SSRF rejection for cloud metadata IP, got nil")
+	}
+	if !errors.Is(err, ssrfguard.ErrBlockedAddress) {
+		t.Fatalf("expected ErrBlockedAddress, got: %v", err)
+	}
+}
+
+// TestFetchSubtreeRaw_RejectsBadScheme verifies that non-http(s)
+// schemes (file://, gopher://, etc.) are rejected as invalid before
+// any I/O happens.
+func TestFetchSubtreeRaw_RejectsBadScheme(t *testing.T) {
+	client := NewClientWithSSRFGuard(5, 0, 0, 0, false, testLogger())
+
+	_, err := client.FetchSubtreeRaw(context.Background(), "file:///etc/passwd", "abc")
+	if err == nil {
+		t.Fatal("expected rejection for file:// URL, got nil")
+	}
+	if !errors.Is(err, ssrfguard.ErrInvalidURL) {
+		t.Fatalf("expected ErrInvalidURL, got: %v", err)
+	}
+}
+
+// TestFetchSubtreeRaw_DialBlocksLoopback verifies the dial-time SSRF
+// guard. We craft a request that survives ValidateURL (using
+// allowPrivateIPs=true at construction would defeat the test, so we
+// instead aim a public-looking hostname at a loopback port via
+// httptest, matching the DNS-rebinding scenario). Here we shortcut by
+// using a literal IP after asserting validation; if the dial-time guard
+// is removed, the connection succeeds and the test fails.
+//
+// The httptest server binds to 127.0.0.1; to exercise the dial hook
+// rather than the URL hook, we directly invoke the lower-level
+// doGetWithRetry so the test demonstrates the second-layer protection.
+func TestFetchSubtreeRaw_DialBlocksLoopback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("server should not have been reached: %s %s", r.Method, r.URL)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewClientWithSSRFGuard(2, 0, 0, 0, false, testLogger())
+
+	// doGetWithRetry skips the URL-level ssrfguard.ValidateURL, so a
+	// successful block here can only come from the Dialer.Control hook.
+	_, err := client.doGetWithRetry(context.Background(), srv.URL+"/subtree/abc", DefaultMaxSubtreeBytes)
+	if err == nil {
+		t.Fatal("expected dial-time SSRF block, got nil")
+	}
+	if !strings.Contains(err.Error(), "blocked") &&
+		!strings.Contains(err.Error(), "refusing to dial") {
+		t.Fatalf("expected SSRF dial-block error, got: %v", err)
+	}
+}
+
+// TestFetchSubtreeRaw_AllowPrivateIPsOptIn verifies the operator
+// escape-hatch: with AllowPrivateIPs=true the client successfully
+// fetches from an httptest server on 127.0.0.1.
+func TestFetchSubtreeRaw_AllowPrivateIPsOptIn(t *testing.T) {
+	subtreeBytes := buildRawSubtreeBytes(2)
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(subtreeBytes)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewClientWithSSRFGuard(5, 0, 0, 0, true, testLogger())
+
+	body, err := client.FetchSubtreeRaw(context.Background(), srv.URL, "abc")
+	if err != nil {
+		t.Fatalf("expected success with allowPrivateIPs=true, got %v", err)
+	}
+	if !hit {
+		t.Fatal("server handler was not reached")
+	}
+	if len(body) != len(subtreeBytes) {
+		t.Fatalf("expected body length %d, got %d", len(subtreeBytes), len(body))
+	}
+}
+
+// TestFetchBlockMetadata_RejectsEmptyURL verifies that an empty
+// dataHubURL (e.g. a peer that omitted the field) is rejected as an
+// invalid URL rather than crashing or making a malformed request.
+func TestFetchBlockMetadata_RejectsEmptyURL(t *testing.T) {
+	client := NewClientWithSSRFGuard(5, 0, 0, 0, false, testLogger())
+
+	_, err := client.FetchBlockMetadata(context.Background(), "", "blockhash")
+	if err == nil {
+		t.Fatal("expected rejection for empty URL, got nil")
+	}
+	if !errors.Is(err, ssrfguard.ErrInvalidURL) {
+		t.Fatalf("expected ErrInvalidURL, got: %v", err)
+	}
+}

--- a/internal/subtree/processor.go
+++ b/internal/subtree/processor.go
@@ -74,12 +74,15 @@ func NewProcessor(
 func (p *Processor) Init(_ interface{}) error {
 	p.InitBase("subtree-fetcher")
 
-	// Initialize DataHub client.
-	p.dataHubClient = datahub.NewClientWithCaps(
+	// Initialize DataHub client. SSRF guard rejects peer-supplied URLs
+	// that point at private/loopback/link-local destinations unless the
+	// operator opts in via DataHub.AllowPrivateIPs (F-028).
+	p.dataHubClient = datahub.NewClientWithSSRFGuard(
 		p.cfg.DataHub.TimeoutSec,
 		p.cfg.DataHub.MaxRetries,
 		p.cfg.DataHub.MaxBlockBytes,
 		p.cfg.DataHub.MaxSubtreeBytes,
+		p.cfg.DataHub.AllowPrivateIPs,
 		p.Logger,
 	)
 


### PR DESCRIPTION
## Summary

- `dataHubURL` flows from peer-controlled P2P announcements (`teranode.SubtreeMessage` / `BlockMessage`) into Kafka and finally into `internal/datahub.Client.FetchSubtreeRaw` / `FetchBlockMetadata`. A forged announcement could previously trigger server-side GETs against arbitrary internal services, RFC1918 hosts, or cloud metadata endpoints (e.g. `http://169.254.169.254/...`).
- This PR applies the same two-layer mitigation already used for callback delivery (PR #85): the shared `internal/ssrfguard` predicate validates every peer-supplied DataHub URL at request time and a `Dialer.Control` hook rejects private/loopback/link-local destinations at connect time, defeating DNS rebinding.
- Adds `DataHubConfig.AllowPrivateIPs` (default `false`, env `DATAHUB_ALLOW_PRIVATE_IPS`) as the operator escape hatch — mirroring `CallbackConfig.AllowPrivateIPs`. The unspecified/multicast/cloud-metadata-hostname checks remain on regardless. Closes F-028, closes #22.

## Trace

- `internal/p2p/client.go:323-365` — peer-supplied `msg.DataHubURL` copied verbatim into `kafka.SubtreeMessage` / `kafka.BlockMessage`.
- `internal/block/processor.go:158`, `internal/subtree/processor.go:279`, `internal/block/subtree_worker.go:269` — that URL is dereferenced into the DataHub client without any host validation prior to this PR.
- `internal/datahub/client.go` — now calls `ssrfguard.ValidateURL` at the top of `FetchSubtreeRaw` / `FetchBlockMetadata` and installs `ssrfguard.CheckDialAddress` on the HTTP client transport.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/datahub/... -count=1 -race` passes (incl. 7 new SSRF tests)
- [x] `go test ./... -count=1 -race` passes across all packages
- [x] New tests cover: loopback URL rejection, RFC1918 URL rejection, cloud-metadata IP rejection, bad-scheme rejection (`file://`), empty URL rejection, dial-time `127.0.0.1` block via `httptest.NewServer`, and `AllowPrivateIPs=true` opt-in success path
- [x] `golangci-lint run ./internal/datahub/...` reports only pre-existing errcheck issues unrelated to this change