### PR TITLE
fix(cache): do not cache negative registration lookups (#13)

### DIFF
--- a/internal/block/subtree_processor.go
+++ b/internal/block/subtree_processor.go
@@ -17,10 +17,13 @@ import (
 // RegCache is the registration deduplication cache abstraction used by
 // block-time subtree processing. Mirrors the shape used by the subtree-fetcher
 // so a future cross-process cache implementation can be substituted.
+//
+// Only positive lookups are cached. Negatives are not cached so that a
+// /watch registration arriving after an earlier "not registered"
+// observation is not masked until cache eviction (F-020).
 type RegCache interface {
 	FilterUncached(txids []string) (uncached []string, cachedRegistered []string)
 	SetMultiRegistered(txids []string) error
-	SetMultiNotRegistered(txids []string) error
 }
 
 // SubtreeResult holds the callback groups produced by processing a subtree.
@@ -212,23 +215,19 @@ func lookupRegistrations(
 		return nil, err
 	}
 
-	// Update cache with discoveries from the uncached portion only — we don't
-	// re-record cachedRegistered txids because they're already in the cache.
-	if regCache != nil && len(uncached) > 0 {
+	// Update cache with discoveries from the uncached portion. Only
+	// positive results are cached; negatives are intentionally not
+	// cached so a later /watch registration is not hidden by a stale
+	// negative entry (F-020).
+	if regCache != nil && len(uncached) > 0 && len(registered) > 0 {
 		foundTxids := make([]string, 0, len(registered))
-		notFoundTxids := make([]string, 0, len(uncached))
 		for _, txid := range uncached {
 			if _, found := registered[txid]; found {
 				foundTxids = append(foundTxids, txid)
-			} else {
-				notFoundTxids = append(notFoundTxids, txid)
 			}
 		}
 		if len(foundTxids) > 0 {
 			_ = regCache.SetMultiRegistered(foundTxids)
-		}
-		if len(notFoundTxids) > 0 {
-			_ = regCache.SetMultiNotRegistered(notFoundTxids)
 		}
 	}
 

--- a/internal/cache/registration_cache.go
+++ b/internal/cache/registration_cache.go
@@ -7,7 +7,23 @@ import (
 )
 
 // RegistrationCache wraps ImprovedCache for deduplicating registration lookups.
-// It caches whether a txid has been checked against Aerospike recently.
+//
+// Only positive results ("this txid is registered") are cached. Negative
+// results ("not registered") are intentionally NOT cached because the
+// registration store is mutated out-of-band by the API server's /watch
+// handler, which has no way to invalidate this in-process cache — and in
+// the microservices deployment topology (api-server, subtree-fetcher and
+// block-processor as separate processes) cannot reach the cache at all.
+//
+// Caching negatives previously caused F-020: a txid observed by the
+// subtree-fetcher before it was registered would be cached as
+// "not registered" with no TTL and remain hidden until the cache
+// wrapped around, suppressing callbacks for any later /watch.
+//
+// The performance loss vs caching negatives is bounded: every uncached
+// txid still flows through a single batched BatchGet against the
+// backing store. The hot positive-hit path (cachedRegistered in
+// FilterUncached) is unchanged.
 type RegistrationCache struct {
 	cache  *ImprovedCache
 	logger *slog.Logger
@@ -29,12 +45,12 @@ func NewRegistrationCache(maxMB int, logger *slog.Logger) (*RegistrationCache, e
 }
 
 // cacheValue represents a cached registration lookup result.
-// 0 = not registered, 1 = registered
+// Only `registered` is ever stored; see the package-level comment on
+// RegistrationCache for why negatives are not cached.
 type cacheValue byte
 
 const (
-	notRegistered cacheValue = 0
-	registered    cacheValue = 1
+	registered cacheValue = 1
 )
 
 // SetRegistered marks a txid as having been checked and found registered.
@@ -44,15 +60,6 @@ func (rc *RegistrationCache) SetRegistered(txid string) error {
 		return err
 	}
 	return rc.cache.Set(key, []byte{byte(registered)})
-}
-
-// SetNotRegistered marks a txid as having been checked and found not registered.
-func (rc *RegistrationCache) SetNotRegistered(txid string) error {
-	key, err := hex.DecodeString(txid)
-	if err != nil {
-		return err
-	}
-	return rc.cache.Set(key, []byte{byte(notRegistered)})
 }
 
 // SetMultiRegistered marks multiple txids as registered in batch.
@@ -73,27 +80,27 @@ func (rc *RegistrationCache) SetMultiRegistered(txids []string) error {
 	return rc.cache.SetMulti(keys, values)
 }
 
-// SetMultiNotRegistered marks multiple txids as not registered in batch.
-func (rc *RegistrationCache) SetMultiNotRegistered(txids []string) error {
-	keys := make([][]byte, 0, len(txids))
-	values := make([][]byte, 0, len(txids))
-	for _, txid := range txids {
-		key, err := hex.DecodeString(txid)
-		if err != nil {
-			continue
-		}
-		keys = append(keys, key)
-		values = append(values, []byte{byte(notRegistered)})
+// Invalidate removes any cached entry for txid. Safe to call for txids
+// that were never cached. Provided so an in-process /watch handler can
+// drop a stale entry as defence in depth — note that the canonical fix
+// for F-020 is "do not cache negatives", which this cache enforces by
+// construction (there is no SetNotRegistered).
+func (rc *RegistrationCache) Invalidate(txid string) error {
+	key, err := hex.DecodeString(txid)
+	if err != nil {
+		return err
 	}
-	if len(keys) == 0 {
-		return nil
-	}
-	return rc.cache.SetMulti(keys, values)
+	rc.cache.Del(key)
+	return nil
 }
 
 // GetCached checks if a txid lookup result is cached.
 // Returns (isRegistered, isCached).
-// If isCached is false, the caller should query Aerospike.
+//
+// Because negatives are never cached, isCached==true always implies
+// isRegistered==true. The two-value signature is preserved so callers
+// can reason about cache hits explicitly. If isCached is false, the
+// caller must query the backing store.
 func (rc *RegistrationCache) GetCached(txid string) (isRegistered bool, isCached bool) {
 	key, err := hex.DecodeString(txid)
 	if err != nil {
@@ -111,6 +118,9 @@ func (rc *RegistrationCache) GetCached(txid string) (isRegistered bool, isCached
 
 // FilterUncached takes a list of txids and returns only those NOT in the cache.
 // Also returns the cached results for those that ARE cached.
+//
+// Because negatives are never cached, every cached entry is positive,
+// and cachedRegistered will contain every txid that hits the cache.
 func (rc *RegistrationCache) FilterUncached(txids []string) (uncached []string, cachedRegistered []string) {
 	for _, txid := range txids {
 		isReg, isCached := rc.GetCached(txid)

--- a/internal/cache/registration_cache_test.go
+++ b/internal/cache/registration_cache_test.go
@@ -1,0 +1,196 @@
+package cache
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+)
+
+func newTestRegistrationCache(t *testing.T) *RegistrationCache {
+	t.Helper()
+	rc, err := NewRegistrationCache(1, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("NewRegistrationCache: %v", err)
+	}
+	return rc
+}
+
+// validHexTxid returns a 64-character hex string parseable by hex.DecodeString.
+func validHexTxid(c byte) string {
+	out := make([]byte, 64)
+	for i := range out {
+		out[i] = c
+	}
+	return string(out)
+}
+
+func TestRegistrationCache_PositivePersists(t *testing.T) {
+	rc := newTestRegistrationCache(t)
+	txid := validHexTxid('a')
+
+	if isReg, isCached := rc.GetCached(txid); isCached || isReg {
+		t.Fatalf("expected miss for fresh txid, got isReg=%v isCached=%v", isReg, isCached)
+	}
+
+	if err := rc.SetRegistered(txid); err != nil {
+		t.Fatalf("SetRegistered: %v", err)
+	}
+
+	isReg, isCached := rc.GetCached(txid)
+	if !isCached {
+		t.Fatal("expected positive cache hit after SetRegistered")
+	}
+	if !isReg {
+		t.Fatal("expected isRegistered=true for positively cached txid")
+	}
+}
+
+// TestRegistrationCache_NegativesAreNotCached is the F-020 regression test:
+// if a txid lookup returned "not registered" (e.g. observed by the
+// subtree-fetcher before /watch ever ran), the cache must NOT remember
+// that result. Otherwise a later registration would be hidden behind a
+// stale negative entry until cache wraparound.
+//
+// We exercise the property at the API surface: the cache exposes
+// SetRegistered / SetMultiRegistered / Invalidate but no SetNotRegistered.
+// A txid that has never been positively cached must remain a miss
+// regardless of how many times the caller has previously queried it.
+func TestRegistrationCache_NegativesAreNotCached(t *testing.T) {
+	rc := newTestRegistrationCache(t)
+	txid := validHexTxid('b')
+
+	// Many "not found" lookups must never plant a cached negative.
+	for i := 0; i < 100; i++ {
+		if _, isCached := rc.GetCached(txid); isCached {
+			t.Fatalf("unexpected cache hit for unregistered txid on lookup %d", i)
+		}
+	}
+
+	// Caller now registers the txid externally (e.g. POST /watch).
+	if err := rc.SetRegistered(txid); err != nil {
+		t.Fatalf("SetRegistered: %v", err)
+	}
+
+	// A subsequent lookup must observe the registration immediately —
+	// not a stale "not registered" entry.
+	isReg, isCached := rc.GetCached(txid)
+	if !isCached {
+		t.Fatal("F-020 regression: expected cache to reflect SetRegistered after prior misses")
+	}
+	if !isReg {
+		t.Fatal("F-020 regression: expected isRegistered=true after SetRegistered")
+	}
+}
+
+// TestRegistrationCache_LookupRegisterLookup simulates the exact flow
+// described in F-020: lookup-before-register → register → lookup-after-
+// register must return true.
+func TestRegistrationCache_LookupRegisterLookup(t *testing.T) {
+	rc := newTestRegistrationCache(t)
+	txid := validHexTxid('c')
+
+	// Step 1: subtree-fetcher observes txid in mempool, looks it up,
+	// finds nothing in registration store. Caller previously would
+	// have called SetNotRegistered here; that method is intentionally
+	// gone.
+	uncached, cached := rc.FilterUncached([]string{txid})
+	if len(uncached) != 1 || len(cached) != 0 {
+		t.Fatalf("expected 1 uncached / 0 cached, got %d / %d", len(uncached), len(cached))
+	}
+
+	// Step 2: user registers the txid via /watch.
+	if err := rc.SetRegistered(txid); err != nil {
+		t.Fatalf("SetRegistered: %v", err)
+	}
+
+	// Step 3: subtree-fetcher sees the txid again, this time in a
+	// later subtree. The cache must report it as positively cached.
+	uncached, cached = rc.FilterUncached([]string{txid})
+	if len(cached) != 1 || cached[0] != txid {
+		t.Fatalf("F-020 regression: expected txid in cachedRegistered, got uncached=%v cached=%v", uncached, cached)
+	}
+	if len(uncached) != 0 {
+		t.Fatalf("expected no uncached, got %v", uncached)
+	}
+}
+
+func TestRegistrationCache_SetMultiRegistered(t *testing.T) {
+	rc := newTestRegistrationCache(t)
+	txids := []string{validHexTxid('1'), validHexTxid('2'), validHexTxid('3')}
+
+	if err := rc.SetMultiRegistered(txids); err != nil {
+		t.Fatalf("SetMultiRegistered: %v", err)
+	}
+
+	for _, txid := range txids {
+		isReg, isCached := rc.GetCached(txid)
+		if !isCached || !isReg {
+			t.Errorf("expected %s to be positively cached, got isReg=%v isCached=%v", txid, isReg, isCached)
+		}
+	}
+}
+
+func TestRegistrationCache_InvalidateClearsEntry(t *testing.T) {
+	rc := newTestRegistrationCache(t)
+	txid := validHexTxid('d')
+
+	if err := rc.SetRegistered(txid); err != nil {
+		t.Fatalf("SetRegistered: %v", err)
+	}
+	if _, isCached := rc.GetCached(txid); !isCached {
+		t.Fatal("expected positive cache hit before Invalidate")
+	}
+
+	if err := rc.Invalidate(txid); err != nil {
+		t.Fatalf("Invalidate: %v", err)
+	}
+
+	if _, isCached := rc.GetCached(txid); isCached {
+		t.Fatal("expected miss after Invalidate")
+	}
+}
+
+func TestRegistrationCache_InvalidateUnknownTxidIsNoop(t *testing.T) {
+	rc := newTestRegistrationCache(t)
+	txid := validHexTxid('e')
+
+	// Invalidating a txid that was never cached must not error.
+	if err := rc.Invalidate(txid); err != nil {
+		t.Fatalf("Invalidate on missing key: %v", err)
+	}
+}
+
+func TestRegistrationCache_InvalidHexTxidIsRejected(t *testing.T) {
+	rc := newTestRegistrationCache(t)
+
+	if err := rc.SetRegistered("not-hex"); err == nil {
+		t.Error("SetRegistered should reject non-hex txid")
+	}
+	if err := rc.Invalidate("not-hex"); err == nil {
+		t.Error("Invalidate should reject non-hex txid")
+	}
+
+	// GetCached returns isCached=false for an invalid txid rather than
+	// erroring — preserve that contract.
+	if isReg, isCached := rc.GetCached("not-hex"); isReg || isCached {
+		t.Errorf("expected miss for invalid txid, got isReg=%v isCached=%v", isReg, isCached)
+	}
+}
+
+func TestRegistrationCache_FilterUncachedSegregatesPositivesAndUnknowns(t *testing.T) {
+	rc := newTestRegistrationCache(t)
+	txReg := validHexTxid('a')
+	txUnknown := validHexTxid('b')
+
+	if err := rc.SetRegistered(txReg); err != nil {
+		t.Fatalf("SetRegistered: %v", err)
+	}
+
+	uncached, cachedRegistered := rc.FilterUncached([]string{txReg, txUnknown})
+	if len(uncached) != 1 || uncached[0] != txUnknown {
+		t.Errorf("expected uncached=[%s], got %v", txUnknown, uncached)
+	}
+	if len(cachedRegistered) != 1 || cachedRegistered[0] != txReg {
+		t.Errorf("expected cachedRegistered=[%s], got %v", txReg, cachedRegistered)
+	}
+}

--- a/internal/subtree/processor.go
+++ b/internal/subtree/processor.go
@@ -27,10 +27,13 @@ type SeenCounter interface {
 }
 
 // RegCache abstracts the registration deduplication cache for testability.
+//
+// The cache only stores positive results. Negative ("not registered")
+// lookups are intentionally not cached so that a /watch arriving after
+// an early negative lookup is not hidden until cache eviction (F-020).
 type RegCache interface {
 	FilterUncached(txids []string) (uncached []string, cachedRegistered []string)
 	SetMultiRegistered(txids []string) error
-	SetMultiNotRegistered(txids []string) error
 }
 
 // Processor consumes subtree announcement messages from Kafka, fetches full
@@ -403,22 +406,18 @@ func (p *Processor) findRegisteredTxids(txids []string) (map[string][]string, er
 		}
 	}
 
-	// 4.4: Update cache with results.
-	if p.regCache != nil {
+	// 4.4: Update cache with positive results only. Negatives are NOT
+	// cached: a txid observed before its /watch registration must remain
+	// looked up against the backing store on subsequent passes (F-020).
+	if p.regCache != nil && len(registeredFromStore) > 0 {
 		foundTxids := make([]string, 0, len(registeredFromStore))
-		notFoundTxids := make([]string, 0, len(uncached)-len(registeredFromStore))
 		for _, txid := range uncached {
 			if _, found := registeredFromStore[txid]; found {
 				foundTxids = append(foundTxids, txid)
-			} else {
-				notFoundTxids = append(notFoundTxids, txid)
 			}
 		}
 		if len(foundTxids) > 0 {
 			_ = p.regCache.SetMultiRegistered(foundTxids)
-		}
-		if len(notFoundTxids) > 0 {
-			_ = p.regCache.SetMultiNotRegistered(notFoundTxids)
 		}
 	}
 

--- a/internal/subtree/processor_test.go
+++ b/internal/subtree/processor_test.go
@@ -62,9 +62,12 @@ func (m *mockSeenCounter) Increment(txid string, subtreeID string) (*store.Incre
 }
 
 type mockRegCache struct {
-	cached map[string]bool // txid -> isRegistered
-	setReg []string        // txids passed to SetMultiRegistered
-	setNot []string        // txids passed to SetMultiNotRegistered
+	// cached tracks positive cache entries only. A txid present in this
+	// map is treated as "cached and registered". Negative results are
+	// not cached (see RegistrationCache documentation / F-020), so we
+	// no longer carry an isRegistered bool per entry.
+	cached map[string]bool
+	setReg []string // txids passed to SetMultiRegistered
 }
 
 func (m *mockRegCache) FilterUncached(txids []string) (uncached []string, cachedRegistered []string) {
@@ -81,11 +84,6 @@ func (m *mockRegCache) FilterUncached(txids []string) (uncached []string, cached
 
 func (m *mockRegCache) SetMultiRegistered(txids []string) error {
 	m.setReg = append(m.setReg, txids...)
-	return nil
-}
-
-func (m *mockRegCache) SetMultiNotRegistered(txids []string) error {
-	m.setNot = append(m.setNot, txids...)
 	return nil
 }
 
@@ -241,9 +239,14 @@ func TestFindRegisteredTxids_NoCache(t *testing.T) {
 }
 
 // TestFindRegisteredTxids_WithCache tests the cache + store interaction.
+//
+// Negatives are not cached (F-020), so a txid that the cache has
+// "no positive entry" for is treated as uncached and re-queried against
+// the backing store every pass. Only positive cache entries short-
+// circuit the registration lookup.
 func TestFindRegisteredTxids_WithCache(t *testing.T) {
 	cachedRegTxid := "aaaa000000000000000000000000000000000000000000000000000000000001"
-	cachedNotRegTxid := "bbbb000000000000000000000000000000000000000000000000000000000002"
+	uncachedTxidA := "bbbb000000000000000000000000000000000000000000000000000000000002"
 	uncachedRegTxid := "cccc000000000000000000000000000000000000000000000000000000000003"
 	uncachedNotRegTxid := "dddd000000000000000000000000000000000000000000000000000000000004"
 
@@ -256,9 +259,8 @@ func TestFindRegisteredTxids_WithCache(t *testing.T) {
 
 	cache := &mockRegCache{
 		cached: map[string]bool{
-			cachedRegTxid:    true,  // cached as registered
-			cachedNotRegTxid: false, // cached as NOT registered
-			// uncached txids not in map
+			cachedRegTxid: true, // cached as registered (positive)
+			// every other txid is uncached — negatives are never cached
 		},
 	}
 
@@ -267,7 +269,7 @@ func TestFindRegisteredTxids_WithCache(t *testing.T) {
 		regCache:          cache,
 	}
 
-	txids := []string{cachedRegTxid, cachedNotRegTxid, uncachedRegTxid, uncachedNotRegTxid}
+	txids := []string{cachedRegTxid, uncachedTxidA, uncachedRegTxid, uncachedNotRegTxid}
 	result, err := p.findRegisteredTxids(txids)
 	if err != nil {
 		t.Fatalf("findRegisteredTxids: %v", err)
@@ -290,24 +292,25 @@ func TestFindRegisteredTxids_WithCache(t *testing.T) {
 		t.Fatalf("expected 2 BatchGet calls, got %d", len(regStore.batchGetCalls))
 	}
 	batchTxids := regStore.batchGetCalls[0]
-	if len(batchTxids) != 2 {
-		t.Errorf("expected 2 uncached txids in first BatchGet, got %d", len(batchTxids))
+	if len(batchTxids) != 3 {
+		t.Errorf("expected 3 uncached txids in first BatchGet, got %d: %v", len(batchTxids), batchTxids)
 	}
 	cachedBatchTxids := regStore.batchGetCalls[1]
 	if len(cachedBatchTxids) != 1 || cachedBatchTxids[0] != cachedRegTxid {
 		t.Errorf("expected cached-registered txid in second BatchGet, got %v", cachedBatchTxids)
 	}
 
-	// Cache should be updated: uncachedRegTxid → registered, uncachedNotRegTxid → not registered
+	// Cache should record exactly one positive update (uncachedRegTxid).
+	// The two not-found txids must NOT produce any cache writes — that is
+	// the F-020 fix.
 	if len(cache.setReg) != 1 || cache.setReg[0] != uncachedRegTxid {
 		t.Errorf("expected SetMultiRegistered([%s]), got %v", uncachedRegTxid, cache.setReg)
 	}
-	if len(cache.setNot) != 1 || cache.setNot[0] != uncachedNotRegTxid {
-		t.Errorf("expected SetMultiNotRegistered([%s]), got %v", uncachedNotRegTxid, cache.setNot)
-	}
 }
 
-// TestFindRegisteredTxids_AllCached tests when all txids are cached.
+// TestFindRegisteredTxids_AllCached tests when all txids hit positive
+// cache entries (no uncached lookups). Since negatives are not cached
+// (F-020), "fully cached" means every input has a positive entry.
 func TestFindRegisteredTxids_AllCached(t *testing.T) {
 	txid1 := "1111000000000000000000000000000000000000000000000000000000000001"
 	txid2 := "2222000000000000000000000000000000000000000000000000000000000002"
@@ -315,13 +318,14 @@ func TestFindRegisteredTxids_AllCached(t *testing.T) {
 	regStore := &mockRegStore{
 		registrations: map[string][]string{
 			txid1: {"http://cb.example.com"},
+			txid2: {"http://cb2.example.com"},
 		},
 	}
 
 	cache := &mockRegCache{
 		cached: map[string]bool{
 			txid1: true,
-			txid2: false,
+			txid2: true,
 		},
 	}
 
@@ -335,11 +339,14 @@ func TestFindRegisteredTxids_AllCached(t *testing.T) {
 		t.Fatalf("findRegisteredTxids: %v", err)
 	}
 
-	if len(result) != 1 {
-		t.Fatalf("expected 1 registered txid, got %d", len(result))
+	if len(result) != 2 {
+		t.Fatalf("expected 2 registered txids, got %d", len(result))
 	}
 	if _, ok := result[txid1]; !ok {
 		t.Errorf("expected %s in result", txid1)
+	}
+	if _, ok := result[txid2]; !ok {
+		t.Errorf("expected %s in result", txid2)
 	}
 
 	// One BatchGet call for cached-registered txids' URLs (no call for uncached since all cached).
@@ -541,7 +548,8 @@ func TestFindRegisteredTxids_LargeSubtree(t *testing.T) {
 }
 
 // TestFindRegisteredTxids_CacheUpdatedCorrectly verifies the cache is properly
-// populated after a store lookup.
+// populated after a store lookup. Only positive results should be cached;
+// not-registered txids must not produce cache writes (F-020).
 func TestFindRegisteredTxids_CacheUpdatedCorrectly(t *testing.T) {
 	txidReg := "aaaa000000000000000000000000000000000000000000000000000000000001"
 	txidNot1 := "bbbb000000000000000000000000000000000000000000000000000000000002"
@@ -567,19 +575,9 @@ func TestFindRegisteredTxids_CacheUpdatedCorrectly(t *testing.T) {
 		t.Fatalf("findRegisteredTxids: %v", err)
 	}
 
-	// Verify cache was updated
+	// Verify cache was updated with the single positive result only.
 	if len(cache.setReg) != 1 || cache.setReg[0] != txidReg {
 		t.Errorf("expected registered cache update for %s, got %v", txidReg, cache.setReg)
-	}
-	if len(cache.setNot) != 2 {
-		t.Errorf("expected 2 not-registered cache updates, got %d: %v", len(cache.setNot), cache.setNot)
-	}
-	notSet := make(map[string]bool)
-	for _, txid := range cache.setNot {
-		notSet[txid] = true
-	}
-	if !notSet[txidNot1] || !notSet[txidNot2] {
-		t.Errorf("missing expected not-registered txids in cache: %v", cache.setNot)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Drops negative ("not registered") entries from `RegistrationCache` so a txid observed before `/watch` is no longer hidden until cache wraparound (F-020 / issue #13).
- Removes `SetNotRegistered` / `SetMultiNotRegistered` from the cache and from the `RegCache` interfaces in `internal/subtree` and `internal/block`; their callers no longer record not-found txids.
- Adds an `Invalidate(txid)` method as defence-in-depth for in-process callers that want to drop a stale entry.
- Adds regression tests covering the lookup-before-register -> register -> lookup-after-register flow plus the broader cache contract.

## Why option 2 (don't cache negatives) instead of invalidate-on-Add
The api-server, subtree-fetcher and block-processor run as separate processes in the microservices deployment (see `cmd/{api-server,subtree-fetcher,block-processor}`). An `Invalidate` call from `/watch` cannot reach an in-process cache held by another process, so invalidation alone would not fix the cross-process variant of F-020. Not caching negatives at all is the only correct fix that works for both monolithic (`cmd/merkle-service`) and microservices deployments. Performance impact is bounded: every uncached txid still flows through a single batched `BatchGet`; the hot positive-hit path is unchanged.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/cache/... ./internal/store/... ./internal/api/... -count=1 -race`
- [x] `go test ./internal/subtree/... ./internal/block/... -count=1 -race`
- [x] `go test ./... -count=1 -race` (full suite green)
- [x] New regression tests in `internal/cache/registration_cache_test.go` (notably `TestRegistrationCache_LookupRegisterLookup` and `TestRegistrationCache_NegativesAreNotCached`) cover F-020.

Closes #13.