### PR TITLE
fix(subtree): propagate seen-counter increment failures (#19)

### DIFF
--- a/internal/subtree/processor.go
+++ b/internal/subtree/processor.go
@@ -243,12 +243,16 @@ func (p *Processor) Health() service.HealthStatus {
 
 // handleMessage processes a single subtree announcement message from Kafka.
 //
-// On transient failure (DataHub/blob store/parse/registration lookup, or any
-// SEEN callback encode/publish failure) the message is re-published to the
-// subtree topic with AttemptCount+1 and nil is returned so the consumer
-// MarkMessage's and the partition advances. Once AttemptCount reaches
-// SubtreeConfig.MaxAttempts the message is routed to the subtree-dlq topic
-// instead of being re-driven again.
+// On transient failure (DataHub/blob store/parse/registration lookup, any
+// SEEN callback encode/publish failure, or a seen-counter increment failure)
+// the message is re-published to the subtree topic with AttemptCount+1 and
+// nil is returned so the consumer MarkMessage's and the partition advances.
+// Once AttemptCount reaches SubtreeConfig.MaxAttempts the message is routed
+// to the subtree-dlq topic instead of being re-driven again.
+//
+// The dedup cache is updated only on full success — any transient failure
+// path returns before p.dedupCache.Add, so a redelivery from the retry
+// pipeline is reprocessed rather than being silently skipped (F-057, F-058).
 //
 // The only errors returned upward are producer-level failures that prevent us
 // from either acking or requeueing — those still stall the partition so we
@@ -456,12 +460,22 @@ func (p *Processor) findRegisteredTxids(txids []string) (map[string][]string, er
 // emitBatchedSeenCallbacks emits batched SEEN_ON_NETWORK and SEEN_MULTIPLE_NODES callbacks.
 // Groups txids by callbackURL and publishes one message per callbackURL.
 //
-// Returns a non-nil error if any per-URL encode or publish fails. The loop
-// continues past a single per-URL failure so independent callback targets
-// still receive their best-effort delivery on this attempt (partial success),
-// but the first error encountered is returned to the caller so handleMessage
-// can re-drive the subtree message through handleTransientFailure rather than
-// silently acking and dropping SEEN notifications — see F-057.
+// Returns a non-nil error if any per-URL encode or publish fails, or if any
+// seenCounterStore.Increment call fails. The loop continues past a single
+// per-txid/per-URL failure so independent callback targets still receive
+// their best-effort delivery on this attempt (partial success), but the
+// first error encountered is returned to the caller so handleMessage can
+// re-drive the subtree message through handleTransientFailure rather than
+// silently acking and dropping SEEN notifications.
+//
+// F-057 made publish failures bubble up. F-058 extends the same contract to
+// seen-counter increment failures: previously, a transient
+// seenCounterStore.Increment error was logged and skipped while
+// handleMessage still added the subtree hash to the dedup cache, permanently
+// undercounting network observations and suppressing SEEN_MULTIPLE_NODES
+// callbacks for the affected txids. Returning the error keeps the dedup
+// cache untouched (handleMessage gates that add on success) and routes the
+// work through handleTransientFailure for redelivery.
 func (p *Processor) emitBatchedSeenCallbacks(registeredTxids map[string][]string, subtreeID string) error {
 	if len(registeredTxids) == 0 {
 		return nil
@@ -508,11 +522,23 @@ func (p *Processor) emitBatchedSeenCallbacks(registeredTxids map[string][]string
 	}
 
 	// 4.6: Increment seen counters and collect threshold-reached txids.
+	//
+	// A failure here MUST surface as an error (F-058). Pre-fix this path
+	// logged a warning and continued, while handleMessage still added the
+	// subtree hash to the dedup cache — permanently dropping
+	// SEEN_MULTIPLE_NODES callbacks for the affected txids on redelivery.
+	// Capture the first error and return it so handleMessage re-drives via
+	// handleTransientFailure (which leaves the dedup cache untouched), but
+	// keep iterating remaining txids so independent counters still get their
+	// best-effort increment + threshold callback on this attempt.
 	thresholdGroups := make(map[string][]string) // callbackURL → threshold-reached txids
 	for txid, callbackURLs := range registeredTxids {
 		result, err := p.seenCounterStore.Increment(txid, subtreeID)
 		if err != nil {
-			p.Logger.Warn("failed to increment seen counter", "txid", txid, "error", err)
+			p.Logger.Error("failed to increment seen counter", "txid", txid, "subtreeID", subtreeID, "error", err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("incrementing seen counter for %s: %w", txid, err)
+			}
 			continue
 		}
 		if result.ThresholdReached {

--- a/internal/subtree/processor_test.go
+++ b/internal/subtree/processor_test.go
@@ -1710,3 +1710,241 @@ func TestHandleMessage_CachedLookupFailure_RoutesToRetryAndSkipsDedup(t *testing
 		t.Errorf("expected 0 callback publishes after cached-lookup failure, got %d", got)
 	}
 }
+
+// --- F-058: Seen-counter increment failure propagation tests ---
+//
+// Pre-fix, when seenCounterStore.Increment returned a transient error the
+// emitBatchedSeenCallbacks loop logged a warning and continued, while
+// handleMessage still added the subtree's hash to the dedup cache. Any
+// redelivery was then silently skipped — permanently undercounting network
+// observations and suppressing SEEN_MULTIPLE_NODES callbacks for affected
+// txids. The fix returns the first error from emitBatchedSeenCallbacks so
+// handleMessage routes the work through handleTransientFailure (which
+// leaves the dedup cache untouched).
+
+// failingSeenCounter returns a configured error from every Increment call.
+// Used to drive the seen-counter failure path for F-058. Reuses the same
+// pattern as the existing mockSeenCounter / mockIdempotentSeenCounter fakes.
+type failingSeenCounter struct {
+	mu       sync.Mutex
+	err      error
+	failed   int
+	attempts []string // txids passed to Increment, in call order
+}
+
+func (f *failingSeenCounter) Increment(txid string, subtreeID string) (*store.IncrementResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.attempts = append(f.attempts, txid)
+	f.failed++
+	return nil, f.err
+}
+
+// TestEmitBatchedSeenCallbacks_IncrementFailureReturnsError verifies that a
+// seenCounterStore.Increment error surfaces to the caller — the F-058 fix.
+// The publish path for SEEN_ON_NETWORK still succeeds (Increment failure must
+// not suppress the per-txid SEEN_ON_NETWORK callback), but the function
+// returns a non-nil error so handleMessage redelivers.
+func TestEmitBatchedSeenCallbacks_IncrementFailureReturnsError(t *testing.T) {
+	regStore := &mockRegStore{registrations: map[string][]string{}}
+	sc := &failingSeenCounter{err: errors.New("aerospike counter outage")}
+	p, mockProd := newTestProcessor(t, regStore, sc)
+
+	registered := map[string][]string{
+		"tx1": {"http://url-A/cb"},
+		"tx2": {"http://url-B/cb"},
+	}
+
+	err := p.emitBatchedSeenCallbacks(registered, "subtree-counter-fail")
+	if err == nil {
+		t.Fatalf("expected non-nil error when seen-counter Increment fails")
+	}
+	if !strings.Contains(err.Error(), "incrementing seen counter") {
+		t.Errorf("expected error to wrap increment context, got: %v", err)
+	}
+
+	// Both txids should have been attempted (best-effort iteration past
+	// the first failure mirrors PR #81's per-URL partial-success contract).
+	if sc.failed != 2 {
+		t.Errorf("expected 2 Increment attempts (one per txid), got %d", sc.failed)
+	}
+
+	// SEEN_ON_NETWORK publishes for both URLs must still have happened —
+	// the increment failure must not suppress already-batched per-URL
+	// SEEN_ON_NETWORK delivery on this attempt.
+	msgs := mockProd.getMessages()
+	if len(msgs) != 2 {
+		t.Errorf("expected 2 SEEN_ON_NETWORK publishes despite increment failure, got %d", len(msgs))
+	}
+	for _, pm := range msgs {
+		cb := decodeCallbackMsg(t, pm)
+		if cb.Type != kafka.CallbackSeenOnNetwork {
+			t.Errorf("expected SEEN_ON_NETWORK only (no SEEN_MULTIPLE_NODES on failure), got %s", cb.Type)
+		}
+	}
+}
+
+// TestHandleMessage_SeenCounterIncrementFailure_RoutesToRetryAndSkipsDedup is
+// the end-to-end F-058 contract test: when seenCounterStore.Increment fails
+// for a registered txid, handleMessage must route the subtree message
+// through the retry pipeline AND must NOT add the subtree hash to the dedup
+// cache (otherwise redelivery is silently skipped and SEEN_MULTIPLE_NODES
+// callbacks are permanently lost).
+func TestHandleMessage_SeenCounterIncrementFailure_RoutesToRetryAndSkipsDedup(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	registeredTxid := "9602604163d73e2ab424bad28b1363694c397512dfa883ec1ee90cc92f847359"
+
+	regStore := &mockRegStore{
+		registrations: map[string][]string{
+			registeredTxid: {"http://callback.example.com/notify"},
+		},
+	}
+
+	rawBytes := hashFromHex(t, registeredTxid)
+	dataHubServer := startRawSubtreeServer(rawBytes)
+	defer dataHubServer.Close()
+
+	cbMock := &mockSyncProducer{}
+	retryMock := &mockSyncProducer{}
+	dlqMock := &mockSyncProducer{}
+	dedup := cache.NewDedupCache(100)
+	sc := &failingSeenCounter{err: errors.New("aerospike counter outage")}
+
+	p := &Processor{
+		cfg: &config.Config{
+			Subtree: config.SubtreeConfig{
+				MaxAttempts: 5,
+				StorageMode: "stream", // skip blob store
+			},
+		},
+		registrationStore: regStore,
+		seenCounterStore:  sc,
+		callbackProducer:  kafka.NewTestProducer(cbMock, "callback-test", logger),
+		retryProducer:     kafka.NewTestProducer(retryMock, "subtree-test", logger),
+		dlqProducer:       kafka.NewTestProducer(dlqMock, "subtree-dlq-test", logger),
+		dataHubClient:     datahub.NewClient(5, 0, logger),
+		dedupCache:        dedup,
+	}
+	p.InitBase("subtree-counter-fail-test")
+	p.Logger = logger
+
+	subtreeMsg := &kafka.SubtreeMessage{
+		Hash:         "subtree-counter-fail",
+		DataHubURL:   dataHubServer.URL,
+		AttemptCount: 0,
+	}
+	value, err := subtreeMsg.Encode()
+	if err != nil {
+		t.Fatalf("encode subtree msg: %v", err)
+	}
+
+	if err := p.handleMessage(t.Context(), &sarama.ConsumerMessage{Value: value}); err != nil {
+		t.Fatalf("handleMessage: expected nil error (retry path returns nil after re-publishing), got: %v", err)
+	}
+
+	// Critical: dedup cache MUST NOT contain this subtree's hash. If it did,
+	// the consumer's redelivery would be silently dropped and the
+	// SEEN_MULTIPLE_NODES callback for this txid would be permanently lost.
+	if dedup.Contains(subtreeMsg.Hash) {
+		t.Errorf("dedup cache must NOT contain %q after a seen-counter Increment failure", subtreeMsg.Hash)
+	}
+
+	// Retry producer received the re-published subtree message.
+	if got := len(retryMock.getMessages()); got != 1 {
+		t.Errorf("expected exactly 1 retry publish, got %d", got)
+	}
+	if got := len(dlqMock.getMessages()); got != 0 {
+		t.Errorf("expected zero DLQ publishes, got %d", got)
+	}
+	if got := p.messagesProcessed.Load(); got != 0 {
+		t.Errorf("expected messagesProcessed=0 after seen-counter failure, got %d", got)
+	}
+	if got := p.messagesRetried.Load(); got != 1 {
+		t.Errorf("expected messagesRetried=1 after seen-counter failure, got %d", got)
+	}
+
+	// Increment was attempted at least once for the registered txid.
+	if sc.failed < 1 {
+		t.Errorf("expected at least 1 Increment attempt, got %d", sc.failed)
+	}
+}
+
+// TestHandleMessage_SeenCounterSuccess_UpdatesDedup is the success companion
+// to TestHandleMessage_SeenCounterIncrementFailure: when Increment succeeds,
+// handleMessage returns nil, the dedup cache is updated, and the retry path
+// is NOT exercised.
+func TestHandleMessage_SeenCounterSuccess_UpdatesDedup(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	registeredTxid := "9602604163d73e2ab424bad28b1363694c397512dfa883ec1ee90cc92f847359"
+
+	regStore := &mockRegStore{
+		registrations: map[string][]string{
+			registeredTxid: {"http://callback.example.com/notify"},
+		},
+	}
+
+	rawBytes := hashFromHex(t, registeredTxid)
+	dataHubServer := startRawSubtreeServer(rawBytes)
+	defer dataHubServer.Close()
+
+	cbMock := &mockSyncProducer{}
+	retryMock := &mockSyncProducer{}
+	dlqMock := &mockSyncProducer{}
+	dedup := cache.NewDedupCache(100)
+
+	p := &Processor{
+		cfg: &config.Config{
+			Subtree: config.SubtreeConfig{
+				MaxAttempts: 5,
+				StorageMode: "stream",
+			},
+		},
+		registrationStore: regStore,
+		seenCounterStore:  &mockSeenCounter{}, // succeeds, ThresholdReached=false
+		callbackProducer:  kafka.NewTestProducer(cbMock, "callback-test", logger),
+		retryProducer:     kafka.NewTestProducer(retryMock, "subtree-test", logger),
+		dlqProducer:       kafka.NewTestProducer(dlqMock, "subtree-dlq-test", logger),
+		dataHubClient:     datahub.NewClient(5, 0, logger),
+		dedupCache:        dedup,
+	}
+	p.InitBase("subtree-counter-ok-test")
+	p.Logger = logger
+
+	subtreeMsg := &kafka.SubtreeMessage{
+		Hash:         "subtree-counter-ok",
+		DataHubURL:   dataHubServer.URL,
+		AttemptCount: 0,
+	}
+	value, err := subtreeMsg.Encode()
+	if err != nil {
+		t.Fatalf("encode subtree msg: %v", err)
+	}
+
+	if err := p.handleMessage(t.Context(), &sarama.ConsumerMessage{Value: value}); err != nil {
+		t.Fatalf("handleMessage: expected nil error on success path, got: %v", err)
+	}
+
+	if !dedup.Contains(subtreeMsg.Hash) {
+		t.Errorf("dedup cache MUST contain %q after a successful processing pass", subtreeMsg.Hash)
+	}
+
+	if got := len(retryMock.getMessages()); got != 0 {
+		t.Errorf("expected 0 retry publishes on success, got %d", got)
+	}
+	if got := len(dlqMock.getMessages()); got != 0 {
+		t.Errorf("expected 0 DLQ publishes on success, got %d", got)
+	}
+	if got := p.messagesProcessed.Load(); got != 1 {
+		t.Errorf("expected messagesProcessed=1 on success, got %d", got)
+	}
+	if got := p.messagesRetried.Load(); got != 0 {
+		t.Errorf("expected messagesRetried=0 on success, got %d", got)
+	}
+	// SEEN_ON_NETWORK should have been published (no SEEN_MULTIPLE_NODES
+	// since mockSeenCounter never fires the threshold).
+	if got := len(cbMock.getMessages()); got != 1 {
+		t.Errorf("expected 1 SEEN_ON_NETWORK callback publish, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary

- A failed `seenCounterStore.Increment` was logged and skipped while the subtree continued to be marked processed in the dedup cache, permanently dropping `SEEN_MULTIPLE_NODES` callbacks for affected txids on any redelivery (F-058).
- The error now bubbles up through `emitBatchedSeenCallbacks` (matching PR #81's per-URL `firstErr` pattern: keep iterating remaining txids for best-effort delivery, return the first error to the caller). `handleMessage` propagates through `handleTransientFailure`, which leaves the dedup cache untouched and routes to the retry/DLQ pipeline.
- `SEEN_ON_NETWORK` publishes for already-batched URLs are unaffected: the increment loop runs after publish, so independent callback targets still receive their best-effort delivery on this attempt while the work item is requeued for the threshold pass.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/subtree/... -count=1 -race` (passes; 3 pre-existing `errcheck` warnings on existing tests are unrelated)
- [x] New unit test: `TestEmitBatchedSeenCallbacks_IncrementFailureReturnsError` — Increment errors surface; `SEEN_ON_NETWORK` still emitted; both txids attempted (best-effort).
- [x] New end-to-end test: `TestHandleMessage_SeenCounterIncrementFailure_RoutesToRetryAndSkipsDedup` — retry producer publishes once; DLQ untouched; dedup cache does NOT contain the subtree hash; `messagesProcessed=0`, `messagesRetried=1`.
- [x] New success companion: `TestHandleMessage_SeenCounterSuccess_UpdatesDedup` — happy path returns nil, dedup cache updated, no retry, `SEEN_ON_NETWORK` emitted.

Closes #19.