### PR TITLE
fix(cmd/watch): validate --concurrency flag (#32)

### DIFF
--- a/cmd/watch/main.go
+++ b/cmd/watch/main.go
@@ -87,6 +87,15 @@ func main() {
 		os.Exit(2)
 	}
 
+	// Validate --concurrency: must be >= 1. A zero value would create an
+	// unbuffered semaphore that never lets goroutines proceed (wg.Wait hangs);
+	// a negative value would panic inside make().
+	if err := validateConcurrency(flagConcurrency); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		usage()
+		os.Exit(2)
+	}
+
 	client := &http.Client{Timeout: flagTimeout}
 	ctx := context.Background()
 
@@ -159,6 +168,17 @@ func runBulk(ctx context.Context, client *http.Client) {
 	if succeeded < len(txids) {
 		os.Exit(1)
 	}
+}
+
+// validateConcurrency returns an error if n is not a usable concurrency
+// value. The semaphore in runBulk is sized from this value; a zero value
+// produces an unbuffered channel that deadlocks wg.Wait, and a negative
+// value panics inside make().
+func validateConcurrency(n int) error {
+	if n < 1 {
+		return fmt.Errorf("--concurrency must be >= 1")
+	}
+	return nil
 }
 
 // validateTxid returns an error if s is not a 64-character hex string.

--- a/cmd/watch/main_test.go
+++ b/cmd/watch/main_test.go
@@ -9,6 +9,39 @@ import (
 	"testing"
 )
 
+// --- validateConcurrency ---
+
+func TestValidateConcurrency_Valid(t *testing.T) {
+	for _, n := range []int{1, 2, 10, 1000} {
+		if err := validateConcurrency(n); err != nil {
+			t.Errorf("validateConcurrency(%d) unexpected error: %v", n, err)
+		}
+	}
+}
+
+func TestValidateConcurrency_Zero(t *testing.T) {
+	err := validateConcurrency(0)
+	if err == nil {
+		t.Fatal("expected error for concurrency=0 (would deadlock on unbuffered semaphore)")
+	}
+	if !strings.Contains(err.Error(), "--concurrency must be >= 1") {
+		t.Errorf("error message should mention '--concurrency must be >= 1', got: %v", err)
+	}
+}
+
+func TestValidateConcurrency_Negative(t *testing.T) {
+	for _, n := range []int{-1, -10, -1 << 20} {
+		err := validateConcurrency(n)
+		if err == nil {
+			t.Errorf("expected error for concurrency=%d (would panic make()), got nil", n)
+			continue
+		}
+		if !strings.Contains(err.Error(), "--concurrency must be >= 1") {
+			t.Errorf("error message should mention '--concurrency must be >= 1', got: %v", err)
+		}
+	}
+}
+
 // --- validateTxid ---
 
 func TestValidateTxid_Valid(t *testing.T) {


### PR DESCRIPTION
## Summary
- Reject `--concurrency < 1` early in `cmd/watch` with a clear error message and exit code 2.
- A value of `0` previously created an unbuffered semaphore (`make(chan struct{}, 0)`) that no goroutine could ever send into, so `wg.Wait()` hung forever. Negative values would panic inside `make`.
- Added `validateConcurrency` helper plus unit tests covering valid, zero, and negative inputs.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./cmd/watch/... -count=1 -race`

Closes #32