### PR TITLE
fix(api): surface listener bind errors synchronously (#33)

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -3,8 +3,10 @@ package api
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"time"
 
@@ -95,12 +97,25 @@ func (s *Server) Init(cfg interface{}) error {
 	return nil
 }
 
+// Start binds the configured TCP listener and begins serving HTTP requests in
+// a background goroutine. The bind step is performed synchronously so that
+// failures such as "port already in use" or "permission denied" are returned
+// to the caller as an error instead of being swallowed asynchronously. Once
+// the listener is established, Serve runs in its own goroutine and any
+// post-startup errors (other than http.ErrServerClosed from a clean shutdown)
+// are logged.
 func (s *Server) Start(ctx context.Context) error {
+	addr := s.httpServer.Addr
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", addr, err)
+	}
+
 	s.SetStarted(true)
 	s.Logger.Info("starting API server", "port", s.cfg.Port)
 
 	go func() {
-		if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := s.httpServer.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			s.Logger.Error("HTTP server error", "error", err)
 		}
 	}()

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/bsv-blockchain/merkle-service/internal/config"
+)
+
+// TestStart_BindErrorIsReturnedSynchronously verifies that Start returns a
+// non-nil error when the configured port cannot be bound (e.g. it is already
+// in use). Prior to the fix for #33 the listen call happened inside a
+// goroutine and Start always returned nil, so callers had no way to detect
+// bind failures.
+func TestStart_BindErrorIsReturnedSynchronously(t *testing.T) {
+	// Occupy an ephemeral port first so we know it is unavailable.
+	occupier, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to occupy a port: %v", err)
+	}
+	defer occupier.Close()
+
+	port := occupier.Addr().(*net.TCPAddr).Port
+
+	srv := NewServer(config.APIConfig{Port: port}, nil, nil, nil, slog.Default())
+	if err := srv.Init(nil); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	// Force the bind to target the loopback address actually held by the
+	// occupier so that the conflict is deterministic across hosts whose
+	// default interface might differ from 127.0.0.1.
+	srv.httpServer.Addr = occupier.Addr().String()
+
+	err = srv.Start(context.Background())
+	if err == nil {
+		// If the goroutine somehow won, make sure the server is shut down.
+		_ = srv.Stop()
+		t.Fatalf("expected Start to return a bind error, got nil")
+	}
+	if !strings.Contains(err.Error(), "listen on") {
+		t.Fatalf("expected wrapped listen error, got %v", err)
+	}
+}
+
+// TestStart_SucceedsOnFreePort verifies the happy path: a free port binds
+// synchronously and Start returns nil. Stop should then cleanly shut down
+// the running goroutine.
+func TestStart_SucceedsOnFreePort(t *testing.T) {
+	srv := NewServer(config.APIConfig{Port: 0}, nil, nil, nil, slog.Default())
+	if err := srv.Init(nil); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	// Port 0 lets the kernel assign a free port.
+	srv.httpServer.Addr = "127.0.0.1:0"
+
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("Start returned unexpected error: %v", err)
+	}
+	if err := srv.Stop(); err != nil {
+		t.Fatalf("Stop returned unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- `Server.Start` launched `ListenAndServe` in a goroutine and unconditionally returned `nil`, so bind failures (port in use, permission denied, bad address) were only logged async and the supervisor treated the API as healthy.
- Bind the TCP listener synchronously with `net.Listen` and wrap the error; pass the live listener to `http.Server.Serve` in a goroutine for the request loop.
- Updated the `Start` doc comment to describe the new contract and added unit tests covering both the bind-failure and happy-path branches.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/api/... -count=1 -race`

Closes #33