### PR TITLE
fix(service): use atomic Bool for started state (#28)

### DIFF
--- a/internal/service/base.go
+++ b/internal/service/base.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 )
 
@@ -14,7 +15,7 @@ type BaseService struct {
 	Logger  *slog.Logger
 	ctx     context.Context
 	cancel  context.CancelFunc
-	started bool
+	started atomic.Bool
 }
 
 // NewLogger creates a JSON slog.Logger at the given level writing to stdout.
@@ -32,7 +33,7 @@ func (b *BaseService) InitBase(name string) {
 		b.Logger = NewLogger(slog.LevelInfo).With("service", name)
 	}
 	b.ctx, b.cancel = context.WithCancel(context.Background())
-	b.started = false
+	b.started.Store(false)
 }
 
 // Context returns the service's context.
@@ -49,12 +50,12 @@ func (b *BaseService) Cancel() {
 
 // IsStarted returns whether the service has been started.
 func (b *BaseService) IsStarted() bool {
-	return b.started
+	return b.started.Load()
 }
 
 // SetStarted sets the started state of the service.
 func (b *BaseService) SetStarted(started bool) {
-	b.started = started
+	b.started.Store(started)
 }
 
 // WaitForShutdown blocks until a SIGTERM or SIGINT signal is received,


### PR DESCRIPTION
## Summary
- Replaces the unsynchronized `started bool` field on `BaseService` with `sync/atomic.Bool` to eliminate the data race between concurrent health-check readers and `SetStarted` writers (F-034).
- Updates `IsStarted()` / `SetStarted()` / `InitBase()` to use atomic `Load`/`Store`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1 -race`

Closes #28