### PR TITLE
fix(store): propagate per-record failures from BatchUpdateTTL (#42)

### DIFF
--- a/internal/store/registration.go
+++ b/internal/store/registration.go
@@ -29,6 +29,11 @@ type aerospikeRegistration struct {
 	maxRetries          int
 	retryBaseMs         int
 	maxCallbacksPerTxID int
+	// updateTTLOne is the per-record TTL updater used by BatchUpdateTTL. It
+	// defaults to (*aerospikeRegistration).UpdateTTL and is overridable in
+	// tests so the aggregation behavior of BatchUpdateTTL can be exercised
+	// without a live Aerospike cluster.
+	updateTTLOne func(txid string, ttl time.Duration) error
 }
 
 // Compile-time check: aerospikeRegistration satisfies RegistrationStore.
@@ -45,7 +50,7 @@ func NewRegistrationStore(client *AerospikeClient, setName string, maxRetries, r
 	if maxCallbacksPerTxID < 0 {
 		maxCallbacksPerTxID = 0
 	}
-	return &aerospikeRegistration{
+	r := &aerospikeRegistration{
 		client:              client,
 		setName:             setName,
 		logger:              logger,
@@ -53,6 +58,8 @@ func NewRegistrationStore(client *AerospikeClient, setName string, maxRetries, r
 		retryBaseMs:         retryBaseMs,
 		maxCallbacksPerTxID: maxCallbacksPerTxID,
 	}
+	r.updateTTLOne = r.UpdateTTL
+	return r
 }
 
 // addCASMaxAttempts caps how many times Add will retry the optimistic
@@ -253,16 +260,30 @@ func (s *aerospikeRegistration) UpdateTTL(txid string, ttl time.Duration) error 
 	return nil
 }
 
-// BatchUpdateTTL updates TTL for multiple txids in batch.
+// BatchUpdateTTL updates TTL for multiple txids and reports per-record failures
+// as an aggregated error. Aerospike batch operations (and our per-record
+// fallback path) report results independently per item, so we iterate every
+// txid before returning rather than fail-fast on the first error: callers can
+// tell which records were touched successfully even when others failed. The
+// returned error is non-nil if and only if at least one per-record update
+// failed; individual failures are joined via errors.Join so callers can use
+// errors.Is/errors.As on each underlying error. Each failure is also logged at
+// WARN level (the most common cause is an Aerospike namespace with
+// nsup-period=0, which rejects TTL updates outright). F-043.
 func (s *aerospikeRegistration) BatchUpdateTTL(txids []string, ttl time.Duration) error {
 	if len(txids) == 0 {
 		return nil
 	}
 
+	var errs []error
 	for _, txid := range txids {
-		if err := s.UpdateTTL(txid, ttl); err != nil {
+		if err := s.updateTTLOne(txid, ttl); err != nil {
 			s.logger.Warn("failed to update TTL (check Aerospike nsup-period config)", "txid", txid, "error", err)
+			errs = append(errs, fmt.Errorf("txid %s: %w", txid, err))
 		}
 	}
-	return nil
+	if len(errs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("batch update TTL: %w", errors.Join(errs...))
 }

--- a/internal/store/registration_test.go
+++ b/internal/store/registration_test.go
@@ -1,0 +1,126 @@
+package store
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newBatchTTLTestStore returns an aerospikeRegistration whose updateTTLOne is
+// stubbed by fn. The Aerospike client is left nil because BatchUpdateTTL never
+// touches it once updateTTLOne is overridden — this lets us exercise the
+// aggregation logic without a live cluster.
+func newBatchTTLTestStore(fn func(txid string, ttl time.Duration) error) *aerospikeRegistration {
+	return &aerospikeRegistration{
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		updateTTLOne: fn,
+	}
+}
+
+func TestBatchUpdateTTL_EmptyReturnsNil(t *testing.T) {
+	called := 0
+	s := newBatchTTLTestStore(func(string, time.Duration) error {
+		called++
+		return nil
+	})
+	if err := s.BatchUpdateTTL(nil, time.Second); err != nil {
+		t.Fatalf("nil txids: unexpected err: %v", err)
+	}
+	if err := s.BatchUpdateTTL([]string{}, time.Second); err != nil {
+		t.Fatalf("empty txids: unexpected err: %v", err)
+	}
+	if called != 0 {
+		t.Fatalf("expected 0 per-record calls, got %d", called)
+	}
+}
+
+func TestBatchUpdateTTL_AllSucceedReturnsNil(t *testing.T) {
+	var seen []string
+	s := newBatchTTLTestStore(func(txid string, _ time.Duration) error {
+		seen = append(seen, txid)
+		return nil
+	})
+	if err := s.BatchUpdateTTL([]string{"a", "b", "c"}, time.Second); err != nil {
+		t.Fatalf("expected nil err on all-success, got %v", err)
+	}
+	if got := strings.Join(seen, ","); got != "a,b,c" {
+		t.Fatalf("expected per-record calls in order a,b,c; got %s", got)
+	}
+}
+
+func TestBatchUpdateTTL_DoesNotFailFast(t *testing.T) {
+	// Every per-record call fails. We must observe one call per txid (no
+	// short-circuit) and the returned error must aggregate every failure.
+	var calls []string
+	s := newBatchTTLTestStore(func(txid string, _ time.Duration) error {
+		calls = append(calls, txid)
+		return errors.New("boom-" + txid)
+	})
+
+	err := s.BatchUpdateTTL([]string{"a", "b", "c"}, time.Second)
+	if err == nil {
+		t.Fatal("expected non-nil error when every per-record op fails")
+	}
+	if got := strings.Join(calls, ","); got != "a,b,c" {
+		t.Fatalf("expected all 3 per-record calls (no fail-fast); got %s", got)
+	}
+	msg := err.Error()
+	for _, want := range []string{"boom-a", "boom-b", "boom-c"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("aggregated error missing %q: %s", want, msg)
+		}
+	}
+}
+
+func TestBatchUpdateTTL_PartialFailureAggregates(t *testing.T) {
+	// Only "b" fails; "a" and "c" succeed. We must still return non-nil and
+	// the error must mention "b" but not the successful txids.
+	sentinel := errors.New("sentinel-b-failed")
+	s := newBatchTTLTestStore(func(txid string, _ time.Duration) error {
+		if txid == "b" {
+			return sentinel
+		}
+		return nil
+	})
+
+	err := s.BatchUpdateTTL([]string{"a", "b", "c"}, time.Second)
+	if err == nil {
+		t.Fatal("expected non-nil error when one per-record op fails")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected errors.Is(err, sentinel) to be true; err=%v", err)
+	}
+	if !strings.Contains(err.Error(), "b") {
+		t.Fatalf("expected error to identify failing txid 'b'; err=%v", err)
+	}
+}
+
+func TestBatchUpdateTTL_WrapsViaErrorsJoin(t *testing.T) {
+	// Two distinct sentinels — both must remain reachable via errors.Is.
+	e1 := errors.New("e1")
+	e2 := errors.New("e2")
+	s := newBatchTTLTestStore(func(txid string, _ time.Duration) error {
+		switch txid {
+		case "x":
+			return e1
+		case "y":
+			return e2
+		default:
+			return nil
+		}
+	})
+
+	err := s.BatchUpdateTTL([]string{"x", "y", "z"}, time.Second)
+	if err == nil {
+		t.Fatal("expected aggregated error")
+	}
+	if !errors.Is(err, e1) {
+		t.Errorf("errors.Is(err, e1) = false; want true")
+	}
+	if !errors.Is(err, e2) {
+		t.Errorf("errors.Is(err, e2) = false; want true")
+	}
+}


### PR DESCRIPTION
## Summary
- Aerospike `BatchUpdateTTL` silently swallowed per-record failures: it logged each error but always returned `nil`, so callers had no way to detect that part (or all) of a batch had failed (F-043).
- Iterate every txid (no fail-fast) and aggregate per-record errors via `errors.Join`, returning a non-nil error iff at least one per-record update failed. Underlying errors remain reachable via `errors.Is` / `errors.As`.
- The SQL sibling at `internal/store/sql/registration.go` is structurally different — it issues a single `UPDATE ... WHERE txid IN (...)` whose error is already returned wholesale — so no fix is required there.
- Updated the doc comment to describe the new contract (no fail-fast, aggregated errors, why we still warn-log each failure).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/store/... -count=1 -race` (all pass)
- [x] New unit tests in `internal/store/registration_test.go` cover:
  - empty / nil input returns nil and makes zero per-record calls
  - all-success returns nil
  - all-fail: every txid is attempted (no fail-fast) and every cause appears in the aggregated error
  - partial failure: error is non-nil and identifies the failing txid; original error is reachable via `errors.Is`
  - `errors.Join` unwrap: multiple distinct sentinel errors are all reachable via `errors.Is` on the aggregate

Closes #42