### PR TITLE
fix(store/sql): take a write lock during subtree counter decrement (#31)

### DIFF
--- a/internal/store/sql/sql_test.go
+++ b/internal/store/sql/sql_test.go
@@ -480,6 +480,86 @@ func TestSubtreeCounter_ConcurrentDecrement(t *testing.T) {
 	}
 }
 
+// TestSubtreeCounter_ConcurrentDecrementMultiConn is the F-052 regression
+// test. The previous implementation opened the SQLite transaction with the
+// default deferred isolation, so two connections could both run the
+// SELECT before either ran the UPDATE — each saw the same `remaining`
+// value and wrote back the same decremented value, silently losing a
+// decrement. The fix opens the txn with sql.LevelSerializable, which
+// modernc.org/sqlite implements as BEGIN IMMEDIATE: the second connection
+// blocks at BEGIN until the first commits, so the read+write pair is
+// serialized.
+//
+// To actually exercise the race we configure the pool with multiple
+// connections (the shared newTestDB helper pins MaxOpenConns to 1 and
+// trivially serializes everything through the single conn).
+func TestSubtreeCounter_ConcurrentDecrementMultiConn(t *testing.T) {
+	tmp := t.TempDir() + "/subtree_race.db"
+	db, err := sql.Open("sqlite", "file:"+tmp+"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(8)
+	t.Cleanup(func() { _ = db.Close() })
+
+	d := sqliteDialect()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	if err := runMigrations(context.Background(), db, d, logger); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+
+	s := newSubtreeCounter(db, d, 600)
+	const initial = 64
+	if err := s.Init("blk", initial); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	results := make([]int, initial)
+	start := make(chan struct{})
+	for i := 0; i < initial; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			v, err := s.Decrement("blk")
+			if err != nil {
+				t.Errorf("Decrement: %v", err)
+				return
+			}
+			results[i] = v
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	// Every result in [0, initial-1] must appear exactly once. Pre-fix this
+	// would fail with duplicates and missing values when two goroutines
+	// raced through the SELECT-then-UPDATE.
+	seen := map[int]bool{}
+	for _, r := range results {
+		if seen[r] {
+			t.Fatalf("F-052 regression: duplicate Decrement result %d (lost a decrement)", r)
+		}
+		seen[r] = true
+	}
+	for want := 0; want < initial; want++ {
+		if !seen[want] {
+			t.Fatalf("F-052 regression: missing Decrement result %d", want)
+		}
+	}
+
+	// Final stored value must be 0, not some larger value left behind by
+	// clobbered writes.
+	var remaining int
+	if err := db.QueryRowContext(context.Background(), "SELECT remaining FROM subtree_counters WHERE block_hash = ?", "blk").Scan(&remaining); err != nil {
+		t.Fatal(err)
+	}
+	if remaining != 0 {
+		t.Fatalf("final remaining = %d, want 0", remaining)
+	}
+}
+
 func TestCallbackAccumulator_RoundTrip(t *testing.T) {
 	db, d := newTestDB(t)
 	s := newCallbackAccumulator(db, d, 600)

--- a/internal/store/sql/subtree_counter.go
+++ b/internal/store/sql/subtree_counter.go
@@ -34,9 +34,28 @@ func (s *subtreeCounter) Init(blockHash string, count int) error {
 }
 
 // Decrement atomically decrements the remaining count and returns the new
-// value. Uses UPDATE … RETURNING on PostgreSQL; on SQLite we fall back to a
-// transaction with explicit read-then-write under BEGIN IMMEDIATE, which
-// serializes writers.
+// value.
+//
+// Concurrency: a naive read-modify-write under SQLite's default deferred
+// transaction (or PostgreSQL's READ COMMITTED) lets two callers both observe
+// the same `remaining` value and write back the same decremented value,
+// silently losing a decrement (F-052). To prevent that we acquire a write
+// lock on the counter row before reading it:
+//
+//   - On PostgreSQL we use a single-statement UPDATE ... RETURNING. The
+//     UPDATE takes a row-level write lock and returns the post-decrement
+//     value atomically — equivalent to the SELECT ... FOR UPDATE pattern
+//     used by callback_accumulator.go (PR #75).
+//   - On SQLite we explicitly issue `BEGIN IMMEDIATE` on a pinned
+//     connection. The default `BeginTx` issues `BEGIN` (deferred), which
+//     only takes the write lock on the first write — leaving a window
+//     between the SELECT and the UPDATE in which a second connection can
+//     read the same value. `BEGIN IMMEDIATE` takes the database write
+//     lock at BEGIN time, so concurrent Decrement callers serialize on
+//     the lock. We can't use database/sql's TxOptions.Isolation here
+//     because modernc.org/sqlite ignores it unless the connection was
+//     opened with the `_txlock=immediate` URL parameter, and the rest of
+//     the codebase opens connections without it.
 func (s *subtreeCounter) Decrement(blockHash string) (int, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -52,26 +71,41 @@ func (s *subtreeCounter) Decrement(blockHash string) (int, error) {
 		return remaining, nil
 	}
 
-	// SQLite path.
-	tx, err := s.db.BeginTx(ctx, nil)
+	// SQLite path. Pin a connection, open the transaction with `BEGIN
+	// IMMEDIATE` (write lock acquired at BEGIN time), and manage commit /
+	// rollback explicitly. database/sql.BeginTx would issue plain `BEGIN`,
+	// which is deferred and reintroduces the read-modify-write race.
+	conn, err := s.db.Conn(ctx)
 	if err != nil {
 		return 0, err
 	}
-	defer func() { _ = tx.Rollback() }()
+	defer func() { _ = conn.Close() }()
+
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return 0, fmt.Errorf("begin immediate: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}()
+
 	var remaining int
 	qSel := fmt.Sprintf("SELECT remaining FROM subtree_counters WHERE block_hash = %s", s.d.placeholder(1)) //nolint:gosec // placeholder from internal function
-	if err := tx.QueryRowContext(ctx, qSel, blockHash).Scan(&remaining); err != nil {
+	if err := conn.QueryRowContext(ctx, qSel, blockHash).Scan(&remaining); err != nil {
 		return 0, err
 	}
 	remaining--
 	qUp := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		"UPDATE subtree_counters SET remaining = %s WHERE block_hash = %s",
 		s.d.placeholder(1), s.d.placeholder(2))
-	if _, err := tx.ExecContext(ctx, qUp, remaining, blockHash); err != nil {
+	if _, err := conn.ExecContext(ctx, qUp, remaining, blockHash); err != nil {
 		return 0, err
 	}
-	if err := tx.Commit(); err != nil {
-		return 0, err
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return 0, fmt.Errorf("commit: %w", err)
 	}
+	committed = true
 	return remaining, nil
 }


### PR DESCRIPTION
## Summary
- The SQLite `Decrement` path opened a default deferred transaction despite a comment promising `BEGIN IMMEDIATE`, so two concurrent callers could both observe the same `remaining` value and clobber each other's update — silently losing a decrement (F-052).
- Switch the SQLite path to an explicit `BEGIN IMMEDIATE` on a pinned connection so the write lock is taken before the read, matching the parent-row lock pattern in `callback_accumulator.go` (PR #75). modernc.org/sqlite ignores `sql.TxOptions.Isolation` unless the DSN sets `_txlock=immediate`, so the raw `BEGIN IMMEDIATE` is the reliable path.
- The PostgreSQL path already used a single-statement `UPDATE ... RETURNING` (which atomically takes the row-level write lock and returns the post-decrement value), so it needs no change.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/store/sql/... -count=1 -race`
- [x] New regression test `TestSubtreeCounter_ConcurrentDecrementMultiConn` opens the pool with `MaxOpenConns=8` so goroutines actually contend (the existing helper pins to 1 conn and trivially serializes), then asserts every decrement value in `[0, N-1]` appears exactly once and the final stored counter is 0.

Closes #31