### PR TITLE
fix(store): atomic callback dedup claim (#29, #30)

### DIFF
--- a/internal/callback/delivery.go
+++ b/internal/callback/delivery.go
@@ -27,10 +27,15 @@ import (
 	"github.com/bsv-blockchain/merkle-service/internal/store"
 )
 
-// CallbackDeduper abstracts callback deduplication for testability.
+// CallbackDeduper abstracts callback deduplication for testability. Claim is
+// the single atomic primitive: claimed=true means this caller is the first
+// (and only) deliverer for the tuple — it must deliver. claimed=false means
+// the tuple was already claimed by a prior or concurrent worker — caller
+// MUST skip delivery to avoid double-firing. Collapsing the previous
+// Exists+Record pair into one operation closes the read-modify-write race
+// where two workers could both see "not exists" and both deliver.
 type CallbackDeduper interface {
-	Exists(txid, callbackURL, statusType string) (bool, error)
-	Record(txid, callbackURL, statusType string, ttl time.Duration) error
+	Claim(txid, callbackURL, statusType string, ttl time.Duration) (bool, error)
 }
 
 // futureRetryWaitCap is the maximum amount of time handleMessage will block
@@ -331,47 +336,43 @@ func (d *DeliveryService) processDelivery(ctx context.Context, cbMsg *kafka.Call
 		"subtreeIndex", cbMsg.SubtreeIndex,
 	)
 
-	// Check callback dedup — skip if already delivered.
-	if d.dedupStore != nil {
-		dedupKey := dedupKeyForMessage(cbMsg)
-		if dedupKey != "" {
-			exists, err := d.dedupStore.Exists(dedupKey, cbMsg.CallbackURL, string(cbMsg.Type))
-			if err != nil {
-				// Previous behavior was "proceed with delivery" — but if a
-				// prior attempt had succeeded and Aerospike is briefly
-				// unreadable, we'd deliver a duplicate BLOCK_PROCESSED. Safer
-				// to fall through to the retry path so the next attempt
-				// re-checks dedup once the store recovers.
-				d.Logger.Error("dedup check failed, scheduling retry", "error", err, "dedupKey", dedupKey, "callbackUrl", cbMsg.CallbackURL)
-				return d.scheduleRetryOrDLQ(cbMsg, fmt.Errorf("dedup check: %w", err))
-			}
-			if exists {
-				d.Logger.Debug("skipping duplicate callback delivery",
-					"dedupKey", dedupKey,
-					"callbackUrl", cbMsg.CallbackURL,
-					"type", cbMsg.Type,
-				)
-				d.messagesDedupe.Add(1)
-				return nil
-			}
+	// Atomically claim the dedup slot BEFORE delivery. Single-shot Claim
+	// closes the prior Exists/Record TOCTOU race where two concurrent workers
+	// could both observe "not delivered yet" and both fire the callback.
+	// claimed=true here means we own the delivery; claimed=false means a
+	// peer (or a prior attempt) already won, so we skip.
+	//
+	// On Claim failure (backend outage) we fall through to the retry path so
+	// the next attempt re-claims once the store recovers — preferable to
+	// proceeding without dedup protection and risking a double-fire.
+	dedupKey := dedupKeyForMessage(cbMsg)
+	if d.dedupStore != nil && dedupKey != "" {
+		ttl := time.Duration(d.cfg.Callback.DedupTTLSec) * time.Second
+		claimed, err := d.dedupStore.Claim(dedupKey, cbMsg.CallbackURL, string(cbMsg.Type), ttl)
+		if err != nil {
+			d.Logger.Error("dedup claim failed, scheduling retry", "error", err, "dedupKey", dedupKey, "callbackUrl", cbMsg.CallbackURL)
+			return d.scheduleRetryOrDLQ(cbMsg, fmt.Errorf("dedup claim: %w", err))
+		}
+		if !claimed {
+			d.Logger.Debug("skipping duplicate callback delivery",
+				"dedupKey", dedupKey,
+				"callbackUrl", cbMsg.CallbackURL,
+				"type", cbMsg.Type,
+			)
+			d.messagesDedupe.Add(1)
+			return nil
 		}
 	}
 
-	// Attempt HTTP POST delivery.
+	// Attempt HTTP POST delivery. We've already claimed the dedup slot, so a
+	// failure here leaves the slot held — the retry republished to Kafka
+	// will, on next consumption, see the existing claim and dedup-skip
+	// (since this worker registered the claim). That's the trade-off for
+	// race-free dedup: at most one HTTP delivery attempt per tuple per TTL
+	// window. The Kafka-driven retry/DLQ pipeline still kicks in to surface
+	// the failure.
 	deliverErr := d.deliverCallback(ctx, cbMsg)
 	if deliverErr == nil {
-		// Record successful delivery for dedup. Delivery already succeeded —
-		// the offset will advance regardless. Log dedup-store outages at
-		// ERROR so they're visible in prod without DEBUG.
-		if d.dedupStore != nil {
-			dedupKey := dedupKeyForMessage(cbMsg)
-			if dedupKey != "" {
-				ttl := time.Duration(d.cfg.Callback.DedupTTLSec) * time.Second
-				if recErr := d.dedupStore.Record(dedupKey, cbMsg.CallbackURL, string(cbMsg.Type), ttl); recErr != nil {
-					d.Logger.Error("failed to record callback dedup", "error", recErr, "dedupKey", dedupKey, "callbackUrl", cbMsg.CallbackURL)
-				}
-			}
-		}
 		d.messagesProcessed.Add(1)
 		d.Logger.Debug("callback delivered successfully",
 			"callbackUrl", cbMsg.CallbackURL,

--- a/internal/callback/delivery_test.go
+++ b/internal/callback/delivery_test.go
@@ -540,7 +540,8 @@ func TestProcessDelivery_DedupSkipsDuplicate(t *testing.T) {
 
 	cfg := defaultTestConfig()
 	ds, _, _ := newTestDeliveryService(t, cfg, server.Client())
-	ds.dedupStore = &mockDedupStore{exists: true}
+	// claimResult=false → Claim returns "already claimed" → dedup-skip path.
+	ds.dedupStore = &mockDedupStore{claimResult: false}
 
 	msg := &kafka.CallbackTopicMessage{
 		CallbackURL:  server.URL + "/callback",
@@ -720,15 +721,21 @@ func TestDeliverCallback_BlockProcessedPayload(t *testing.T) {
 	}
 }
 
-// mockDedupStore implements CallbackDeduper for testing.
+// mockDedupStore implements CallbackDeduper for testing. claimResult drives
+// the (claimed, err) tuple returned from Claim — tests for the "duplicate
+// arrived after a prior delivery" path set claimResult=false (no error,
+// nothing claimed) so processDelivery follows the dedup-skip branch. claimErr
+// is OR'd in when set so tests can simulate a backend outage.
 type mockDedupStore struct {
-	exists bool
+	claimResult bool
+	claimErr    error
+	calls       int
 }
 
-func (m *mockDedupStore) Exists(txid, callbackURL, statusType string) (bool, error) {
-	return m.exists, nil
-}
-
-func (m *mockDedupStore) Record(txid, callbackURL, statusType string, ttl time.Duration) error {
-	return nil
+func (m *mockDedupStore) Claim(txid, callbackURL, statusType string, ttl time.Duration) (bool, error) {
+	m.calls++
+	if m.claimErr != nil {
+		return false, m.claimErr
+	}
+	return m.claimResult, nil
 }

--- a/internal/e2e/postgres_e2e_test.go
+++ b/internal/e2e/postgres_e2e_test.go
@@ -268,24 +268,29 @@ func TestPostgres_CallbackDedupTTL(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = registry.Close() })
 
-	// 1s TTL. The expiry filter inside Exists should observe it as gone after 2s.
-	if err := registry.CallbackDedup.Record("tx-x", "u", "MINED", 1*time.Second); err != nil {
-		t.Fatalf("Record: %v", err)
+	// 1s TTL. After expiry the next Claim should win again because the
+	// pre-INSERT expired-row eviction inside Claim clears the stale row.
+	claimed, err := registry.CallbackDedup.Claim("tx-x", "u", "MINED", 1*time.Second)
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
 	}
-	ok, err := registry.CallbackDedup.Exists("tx-x", "u", "MINED")
+	if !claimed {
+		t.Fatal("first Claim should win")
+	}
+	dup, err := registry.CallbackDedup.Claim("tx-x", "u", "MINED", 1*time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !ok {
-		t.Fatal("Exists=false immediately after Record")
+	if dup {
+		t.Fatal("second Claim within TTL should be duplicate")
 	}
 	time.Sleep(2 * time.Second)
-	ok, err = registry.CallbackDedup.Exists("tx-x", "u", "MINED")
+	reclaim, err := registry.CallbackDedup.Claim("tx-x", "u", "MINED", 1*time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ok {
-		t.Fatal("Exists=true after TTL elapsed")
+	if !reclaim {
+		t.Fatal("Claim after TTL elapsed should succeed again")
 	}
 
 	// Sweeper runs every 200ms per our cfg — give it a window to physically delete.

--- a/internal/store/callback_dedup.go
+++ b/internal/store/callback_dedup.go
@@ -3,6 +3,7 @@ package store
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -43,47 +44,59 @@ func dedupKey(txid, callbackURL, statusType string) string {
 	return hex.EncodeToString(h[:])
 }
 
-// Exists checks if a callback delivery has already been recorded.
-func (s *aerospikeCallbackDedup) Exists(txid, callbackURL, statusType string) (bool, error) {
+// Claim atomically reserves the dedup slot for (txid, callbackURL, statusType).
+// It uses Aerospike's CREATE_ONLY record-exists action so concurrent workers
+// cannot both observe "not exists" and double-deliver: at most one writer
+// successfully creates the record, the rest receive KEY_EXISTS_ERROR which we
+// translate to claimed=false.
+//
+// Returns:
+//   - (true, nil)  — this caller created the record and SHOULD deliver.
+//   - (false, nil) — record already existed (duplicate); caller MUST skip.
+//   - (_, err)     — backend error; caller should treat as transient and retry.
+func (s *aerospikeCallbackDedup) Claim(txid, callbackURL, statusType string, ttl time.Duration) (bool, error) {
 	keyStr := dedupKey(txid, callbackURL, statusType)
 	key, err := as.NewKey(s.client.Namespace(), s.setName, keyStr)
 	if err != nil {
 		return false, fmt.Errorf("failed to create dedup key: %w", err)
 	}
 
-	exists, err := s.client.Client().Exists(s.client.ReadPolicy(), key)
-	if err != nil {
-		return false, fmt.Errorf("failed to check dedup record: %w", err)
-	}
-	return exists, nil
-}
-
-// Record marks a callback delivery as completed with a TTL.
-func (s *aerospikeCallbackDedup) Record(txid, callbackURL, statusType string, ttl time.Duration) error {
-	keyStr := dedupKey(txid, callbackURL, statusType)
-	key, err := as.NewKey(s.client.Namespace(), s.setName, keyStr)
-	if err != nil {
-		return fmt.Errorf("failed to create dedup key: %w", err)
-	}
-
 	wp := s.client.WritePolicy(s.maxRetries, s.retryBaseMs)
+	wp.RecordExistsAction = as.CREATE_ONLY
 	if ttl > 0 {
 		wp.Expiration = uint32(ttl.Seconds())
 	}
 
 	bins := as.BinMap{dedupMarkerBin: 1}
-	if err := s.client.Client().Put(wp, key, bins); err != nil {
-		// If TTL is rejected (namespace lacks nsup-period), retry without TTL.
-		if err.Matches(astypes.FAIL_FORBIDDEN) && ttl > 0 {
-			s.logger.Warn("callback dedup TTL rejected, writing without TTL (configure Aerospike nsup-period to enable TTL)",
-				"txid", txid, "statusType", statusType)
-			wp2 := s.client.WritePolicy(s.maxRetries, s.retryBaseMs)
-			if err2 := s.client.Client().Put(wp2, key, bins); err2 != nil {
-				return fmt.Errorf("failed to record dedup (without TTL): %w", err2)
-			}
-			return nil
-		}
-		return fmt.Errorf("failed to record dedup: %w", err)
+	putErr := s.client.Client().Put(wp, key, bins)
+	if putErr == nil {
+		return true, nil
 	}
-	return nil
+
+	// CREATE_ONLY collision = a prior (or concurrent) writer claimed it first.
+	// This is the dedup-hit signal, not an error.
+	var asErr as.Error
+	if errors.As(putErr, &asErr) && asErr.Matches(astypes.KEY_EXISTS_ERROR) {
+		return false, nil
+	}
+
+	// If TTL is rejected (namespace lacks nsup-period), retry without TTL —
+	// preserves the prior behavior of degrading gracefully on misconfigured
+	// namespaces. Still CREATE_ONLY so the atomic-claim guarantee holds.
+	if errors.As(putErr, &asErr) && asErr.Matches(astypes.FAIL_FORBIDDEN) && ttl > 0 {
+		s.logger.Warn("callback dedup TTL rejected, writing without TTL (configure Aerospike nsup-period to enable TTL)",
+			"txid", txid, "statusType", statusType)
+		wp2 := s.client.WritePolicy(s.maxRetries, s.retryBaseMs)
+		wp2.RecordExistsAction = as.CREATE_ONLY
+		if err2 := s.client.Client().Put(wp2, key, bins); err2 != nil {
+			var asErr2 as.Error
+			if errors.As(err2, &asErr2) && asErr2.Matches(astypes.KEY_EXISTS_ERROR) {
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to claim dedup (without TTL): %w", err2)
+		}
+		return true, nil
+	}
+
+	return false, fmt.Errorf("failed to claim dedup: %w", putErr)
 }

--- a/internal/store/callback_dedup_integration_test.go
+++ b/internal/store/callback_dedup_integration_test.go
@@ -1,0 +1,89 @@
+//go:build integration
+
+package store_test
+
+import (
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/merkle-service/internal/store"
+)
+
+// TestCallbackDedup_ClaimIsAtomic exercises the CREATE_ONLY-backed Claim
+// against a real Aerospike: the first writer for a tuple wins, every other
+// writer (including concurrent ones) observes claimed=false. This is the
+// regression test for issue #29 — the previous Exists+Record pair allowed
+// two concurrent workers to both observe "not exists" and double-deliver.
+func TestCallbackDedup_ClaimIsAtomic(t *testing.T) {
+	client := newAerospikeClient(t)
+	setName := uniqueSet(t, "dedup_claim")
+	s := store.NewCallbackDedupStore(client, setName, 3, 100, slog.Default())
+
+	claimed, err := s.Claim("tx", "url", "MINED", time.Hour)
+	if err != nil {
+		t.Fatalf("first Claim error: %v", err)
+	}
+	if !claimed {
+		t.Fatal("first Claim should win")
+	}
+
+	// Repeat claims for the same tuple are duplicates.
+	for i := 0; i < 3; i++ {
+		dup, err := s.Claim("tx", "url", "MINED", time.Hour)
+		if err != nil {
+			t.Fatalf("repeat Claim error: %v", err)
+		}
+		if dup {
+			t.Fatalf("repeat Claim #%d should be marked duplicate", i)
+		}
+	}
+
+	// Distinct tuples are independent claims.
+	other, err := s.Claim("tx", "url", "STUMP", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !other {
+		t.Fatal("Claim for distinct statusType should win")
+	}
+}
+
+// TestCallbackDedup_ConcurrentClaimsAtMostOneWins is the explicit race
+// regression: N goroutines race for the same tuple, only one is allowed to
+// observe claimed=true. CREATE_ONLY surfaces the others as KEY_EXISTS_ERROR
+// which we map to claimed=false.
+func TestCallbackDedup_ConcurrentClaimsAtMostOneWins(t *testing.T) {
+	client := newAerospikeClient(t)
+	setName := uniqueSet(t, "dedup_race")
+	s := store.NewCallbackDedupStore(client, setName, 3, 100, slog.Default())
+
+	const workers = 32
+	results := make(chan bool, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			ok, err := s.Claim("race-tx", "race-url", "MINED", time.Hour)
+			if err != nil {
+				t.Errorf("Claim error: %v", err)
+				return
+			}
+			results <- ok
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	wins := 0
+	for r := range results {
+		if r {
+			wins++
+		}
+	}
+	if wins != 1 {
+		t.Fatalf("expected exactly 1 winning Claim, got %d (across %d workers)", wins, workers)
+	}
+}

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -35,9 +35,17 @@ type SubtreeStore interface {
 
 // CallbackDedupStore tracks whether a (txid, url, statusType) combination has
 // already been delivered so retries don't double-fire callbacks.
+//
+// Claim atomically reserves a dedup slot. It returns claimed=true iff this
+// caller is the first to record the (txid, url, statusType) tuple — meaning
+// the caller is responsible for delivering the callback. claimed=false
+// indicates the tuple was already recorded by a prior delivery (or a
+// concurrent racer that won the claim) and the caller MUST skip delivery to
+// avoid double-firing. Combining the prior Exists+Record pair into a single
+// atomic operation closes the read-modify-write race that allowed two
+// concurrent workers to both observe "not exists" and double-deliver.
 type CallbackDedupStore interface {
-	Exists(txid, callbackURL, statusType string) (bool, error)
-	Record(txid, callbackURL, statusType string, ttl time.Duration) error
+	Claim(txid, callbackURL, statusType string, ttl time.Duration) (claimed bool, err error)
 }
 
 // CallbackURLRegistry enumerates every known callback URL. Add is set-insert.

--- a/internal/store/sql/callback_dedup.go
+++ b/internal/store/sql/callback_dedup.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"time"
 
@@ -27,39 +28,60 @@ func dedupKey(txid, callbackURL, statusType string) string {
 	return hex.EncodeToString(h[:])
 }
 
-func (s *callbackDedup) Exists(txid, callbackURL, statusType string) (bool, error) {
+// Claim atomically reserves the dedup slot for (txid, callbackURL, statusType)
+// via INSERT ... ON CONFLICT DO NOTHING RETURNING. RETURNING populates exactly
+// one row when the INSERT actually wrote (we won the claim) and zero rows
+// when the unique-key conflict suppressed the write (a prior or concurrent
+// writer already claimed). Both Postgres and SQLite 3.35+ support this
+// combination, so a single statement is the dedup primitive on both backends.
+//
+// A live row whose expires_at is in the past is treated as already-expired:
+// the conflicting INSERT first overwrites the stale row (so the new TTL takes
+// effect) and the caller is told they claimed it. This matches the prior
+// Exists() filter behavior so a long-since-delivered tuple can still be
+// re-claimed once its TTL elapses without waiting for the sweeper.
+//
+// Returns (true, nil) when the caller should deliver, (false, nil) on a live
+// duplicate, and (_, err) on backend failure (caller should treat as
+// transient and retry).
+func (s *callbackDedup) Claim(txid, callbackURL, statusType string, ttl time.Duration) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	key := dedupKey(txid, callbackURL, statusType)
-	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
-		"SELECT 1 FROM callback_dedup WHERE dedup_key = %s AND (expires_at IS NULL OR expires_at > %s)",
-		s.d.placeholder(1), s.d.now)
-	row := s.db.QueryRowContext(ctx, q, key)
-	var x int
-	err := row.Scan(&x)
-	if err == sql.ErrNoRows {
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	return true, nil
-}
 
-func (s *callbackDedup) Record(txid, callbackURL, statusType string, ttl time.Duration) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	key := dedupKey(txid, callbackURL, statusType)
 	var expiresExpr string
 	if ttl > 0 {
 		expiresExpr = s.d.intervalSeconds(int(ttl.Seconds()))
 	} else {
 		expiresExpr = "NULL"
 	}
+
+	// Step 1: best-effort eviction of an expired row for this key. Done in a
+	// separate statement so the subsequent INSERT can use the simple ON
+	// CONFLICT DO NOTHING form on both Postgres and SQLite without juggling
+	// dialect differences in the conflict-update predicate.
+	delQ := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
+		"DELETE FROM callback_dedup WHERE dedup_key = %s AND expires_at IS NOT NULL AND expires_at <= %s",
+		s.d.placeholder(1), s.d.now)
+	if _, err := s.db.ExecContext(ctx, delQ, key); err != nil {
+		return false, fmt.Errorf("dedup expire-clean: %w", err)
+	}
+
+	// Step 2: atomic claim. RETURNING fires exactly when the INSERT inserts.
 	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		`INSERT INTO callback_dedup (dedup_key, expires_at) VALUES (%s, %s)
-        ON CONFLICT (dedup_key) DO UPDATE SET expires_at = EXCLUDED.expires_at`,
+        ON CONFLICT (dedup_key) DO NOTHING
+        RETURNING 1`,
 		s.d.placeholder(1), expiresExpr)
-	_, err := s.db.ExecContext(ctx, q, key)
-	return err
+
+	var sentinel int
+	err := s.db.QueryRowContext(ctx, q, key).Scan(&sentinel)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		// Conflict: a live row already exists. Caller is a duplicate.
+		return false, nil
+	}
+	return false, fmt.Errorf("dedup claim: %w", err)
 }

--- a/internal/store/sql/sql_test.go
+++ b/internal/store/sql/sql_test.go
@@ -180,53 +180,106 @@ func TestRegistrationStore_MaxCallbacksDisabled(t *testing.T) {
 	}
 }
 
-func TestCallbackDedup_RecordAndExists(t *testing.T) {
+func TestCallbackDedup_ClaimIsAtomic(t *testing.T) {
 	db, d := newTestDB(t)
 	s := newCallbackDedup(db, d)
 
-	ok, err := s.Exists("tx", "url", "MINED")
+	// First call wins the claim.
+	claimed, err := s.Claim("tx", "url", "MINED", 1*time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ok {
-		t.Fatal("Exists=true before Record")
+	if !claimed {
+		t.Fatal("first Claim should succeed")
 	}
 
-	if err = s.Record("tx", "url", "MINED", 1*time.Hour); err != nil {
-		t.Fatal(err)
+	// Subsequent calls observe the existing claim and return false (duplicate).
+	for i := 0; i < 3; i++ {
+		claimed, err = s.Claim("tx", "url", "MINED", 1*time.Hour)
+		if err != nil {
+			t.Fatalf("repeat Claim error: %v", err)
+		}
+		if claimed {
+			t.Fatalf("repeat Claim #%d should report duplicate", i)
+		}
 	}
-	ok, err = s.Exists("tx", "url", "MINED")
+
+	// Distinct tuple is independent.
+	claimed, err = s.Claim("tx", "url", "STUMP", 1*time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !ok {
-		t.Fatal("Exists=false after Record")
-	}
-
-	// Idempotent re-record.
-	if err := s.Record("tx", "url", "MINED", 1*time.Hour); err != nil {
-		t.Fatalf("re-record: %v", err)
+	if !claimed {
+		t.Fatal("Claim for distinct statusType should succeed")
 	}
 }
 
-func TestCallbackDedup_TTLExpiry(t *testing.T) {
+func TestCallbackDedup_TTLExpiryAllowsReclaim(t *testing.T) {
 	db, d := newTestDB(t)
 	s := newCallbackDedup(db, d)
 
-	// 1-second TTL so the check-clause can observe the expiry without
-	// needing the sweeper goroutine to run.
-	if err := s.Record("tx", "url", "MINED", 1*time.Second); err != nil {
-		t.Fatal(err)
-	}
-	// Wait past the TTL. SQLite's CURRENT_TIMESTAMP has second precision so
-	// we pad by 2s.
-	time.Sleep(2100 * time.Millisecond)
-	ok, err := s.Exists("tx", "url", "MINED")
+	// 1-second TTL so we can observe expiry without waiting for the sweeper.
+	claimed, err := s.Claim("tx", "url", "MINED", 1*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ok {
-		t.Fatal("Exists should be false after TTL elapses")
+	if !claimed {
+		t.Fatal("initial Claim should succeed")
+	}
+
+	// Immediately re-claim → duplicate, still within TTL.
+	claimed, err = s.Claim("tx", "url", "MINED", 1*time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claimed {
+		t.Fatal("Claim within TTL should be marked duplicate")
+	}
+
+	// SQLite's CURRENT_TIMESTAMP has second precision; pad by 2s past TTL.
+	time.Sleep(2100 * time.Millisecond)
+
+	// Expired row should be evicted by Claim's pre-INSERT cleanup, so the
+	// next claim wins again.
+	claimed, err = s.Claim("tx", "url", "MINED", 1*time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !claimed {
+		t.Fatal("Claim after TTL expiry should succeed")
+	}
+}
+
+func TestCallbackDedup_ConcurrentClaimsAtMostOneWins(t *testing.T) {
+	db, d := newTestDB(t)
+	s := newCallbackDedup(db, d)
+
+	const workers = 16
+	var wg sync.WaitGroup
+	wins := make(chan bool, workers)
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			ok, err := s.Claim("race-tx", "race-url", "MINED", 1*time.Hour)
+			if err != nil {
+				t.Errorf("Claim error: %v", err)
+				return
+			}
+			wins <- ok
+		}()
+	}
+	wg.Wait()
+	close(wins)
+
+	winCount := 0
+	for w := range wins {
+		if w {
+			winCount++
+		}
+	}
+	if winCount != 1 {
+		t.Fatalf("expected exactly 1 winning Claim across %d workers, got %d", workers, winCount)
 	}
 }
 
@@ -522,12 +575,12 @@ func TestSweeper_DeletesExpiredRows(t *testing.T) {
 	db, d := newTestDB(t)
 	dedup := newCallbackDedup(db, d)
 
-	// Record one entry with a short TTL (will expire) and one with a long TTL.
-	if err := dedup.Record("tx-expired", "u", "MINED", 1*time.Second); err != nil {
-		t.Fatal(err)
+	// Claim one entry with a short TTL (will expire) and one with a long TTL.
+	if claimed, err := dedup.Claim("tx-expired", "u", "MINED", 1*time.Second); err != nil || !claimed {
+		t.Fatalf("claim tx-expired: claimed=%v err=%v", claimed, err)
 	}
-	if err := dedup.Record("tx-fresh", "u", "MINED", 1*time.Hour); err != nil {
-		t.Fatal(err)
+	if claimed, err := dedup.Claim("tx-fresh", "u", "MINED", 1*time.Hour); err != nil || !claimed {
+		t.Fatalf("claim tx-fresh: claimed=%v err=%v", claimed, err)
 	}
 
 	// Wait for the first entry to expire, then sweep.
@@ -536,8 +589,8 @@ func TestSweeper_DeletesExpiredRows(t *testing.T) {
 	sw.sweepOnce(context.Background())
 
 	// Verify the expired row is gone at the row level (not just filtered by
-	// the expires_at check). Count via SELECT so we don't rely on Exists'
-	// own expiry filter.
+	// the expires_at check). Count via SELECT so we don't rely on Claim's
+	// own expiry-cleanup behavior.
 	var count int
 	if err := db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM callback_dedup WHERE dedup_key = ?",
 		dedupKey("tx-expired", "u", "MINED")).Scan(&count); err != nil {
@@ -547,13 +600,13 @@ func TestSweeper_DeletesExpiredRows(t *testing.T) {
 		t.Fatalf("expired row still present after sweep: count=%d", count)
 	}
 
-	// Fresh entry still exists.
-	ok, err := dedup.Exists("tx-fresh", "u", "MINED")
+	// Fresh entry still claimed → second Claim returns duplicate.
+	claimed, err := dedup.Claim("tx-fresh", "u", "MINED", 1*time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !ok {
-		t.Fatal("fresh entry was deleted")
+	if claimed {
+		t.Fatal("fresh entry should still be claimed (duplicate Claim)")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Collapse `CallbackDedupStore.Exists` + `Record` into a single atomic `Claim(txid, callbackURL, statusType, ttl) (claimed bool, err error)`. `claimed=true` means the caller is the first writer and must deliver; `claimed=false` means a prior or concurrent worker already claimed the tuple and the caller MUST skip. Closes the read-modify-write race that allowed concurrent callback-delivery workers to both observe "not exists" and double-fire (#29 Aerospike, #30 SQL).
- Aerospike backend: `Put` with `RecordExistsAction = CREATE_ONLY`; `KEY_EXISTS_ERROR` is mapped to `claimed=false`. The pre-existing `FAIL_FORBIDDEN` (TTL rejected) fallback is preserved, still under CREATE_ONLY so the atomic-claim guarantee holds even on namespaces without `nsup-period`.
- SQL backend (Postgres + SQLite >= 3.35): `INSERT ... ON CONFLICT DO NOTHING RETURNING 1`. RETURNING fires exactly when the INSERT actually inserted; `sql.ErrNoRows` indicates the unique-key conflict suppressed the write. A best-effort DELETE of an expired row for the same key precedes the INSERT so a stale claim does not block reclaim past TTL without waiting for the sweeper.
- `internal/callback/delivery.go` now calls `Claim` once before delivery. Backend failures fall through to the existing Kafka retry/DLQ path so a transient store outage cannot silently double-deliver.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1 -race`
- [x] New unit tests for SQL: `TestCallbackDedup_ClaimIsAtomic`, `TestCallbackDedup_TTLExpiryAllowsReclaim`, `TestCallbackDedup_ConcurrentClaimsAtMostOneWins` (16-goroutine race, asserts exactly 1 winner under `-race`).
- [x] New Aerospike integration tests behind `//go:build integration` mirror the same shape (single-winner concurrency test with 32 goroutines).
- [x] Existing callback-delivery tests still pass; mock dedup store updated to the new `Claim` API.
- [x] Postgres e2e (`TestPostgres_CallbackDedupTTL`) updated and exercises post-TTL re-claim.

Closes #29
Closes #30