### PR TITLE
fix(cache): validate slice lengths and keySize before indexing/dividing (#34, #35)

### DIFF
--- a/internal/cache/improved_cache.go
+++ b/internal/cache/improved_cache.go
@@ -351,6 +351,10 @@ func (c *ImprovedCache) Set(k, v []byte) error {
 // Returns:
 // - Error if the operation fails, particularly if keys length is not a multiple of keySize
 func (c *ImprovedCache) SetMultiKeysSingleValue(keys [][]byte, value []byte, keySize int) error {
+	if keySize <= 0 {
+		return fmt.Errorf("SetMultiKeysSingleValue: keySize must be > 0; got %d", keySize)
+	}
+
 	if len(keys)%keySize != 0 {
 		return fmt.Errorf("keys length must be a multiple of keySize; got %d; want %d", len(keys), keySize)
 	}
@@ -399,6 +403,10 @@ func (c *ImprovedCache) SetMultiKeysSingleValue(keys [][]byte, value []byte, key
 // Value: single value is sent for all keys.
 // Value bytes are appended to the end of the previous value bytes.
 func (c *ImprovedCache) SetMultiKeysSingleValueAppended(keys, value []byte, keySize int) error {
+	if keySize <= 0 {
+		return fmt.Errorf("SetMultiKeysSingleValueAppended: keySize must be > 0; got %d", keySize)
+	}
+
 	if len(keys)%keySize != 0 {
 		return fmt.Errorf("keys length must be a multiple of keySize; got %d; want %d", len(keys), keySize)
 	}
@@ -442,6 +450,10 @@ func (c *ImprovedCache) SetMultiKeysSingleValueAppended(keys, value []byte, keyS
 
 // SetMulti stores multiple (k, v) entries in the cache, for different values.
 func (c *ImprovedCache) SetMulti(keys, values [][]byte) error {
+	if len(keys) != len(values) {
+		return fmt.Errorf("SetMulti: keys/values length mismatch (%d != %d)", len(keys), len(values))
+	}
+
 	batchedKeys := make([][][]byte, BucketsCount)
 	batchedValues := make([][][]byte, BucketsCount)
 

--- a/internal/cache/improved_cache_test.go
+++ b/internal/cache/improved_cache_test.go
@@ -1,0 +1,105 @@
+package cache
+
+import (
+	"strings"
+	"testing"
+)
+
+// newTestImprovedCache creates a small ImprovedCache suitable for unit tests.
+func newTestImprovedCache(t *testing.T) *ImprovedCache {
+	t.Helper()
+
+	c, err := New(BucketsCount*int(ChunkSize), Unallocated)
+	if err != nil {
+		t.Fatalf("failed to create test cache: %v", err)
+	}
+
+	return c
+}
+
+func TestSetMulti_LengthMismatchReturnsError(t *testing.T) {
+	c := newTestImprovedCache(t)
+
+	keys := [][]byte{[]byte("a"), []byte("b"), []byte("c")}
+	values := [][]byte{[]byte("1"), []byte("2")}
+
+	err := c.SetMulti(keys, values)
+	if err == nil {
+		t.Fatal("expected error for mismatched keys/values lengths, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "SetMulti: keys/values length mismatch") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestSetMulti_EqualLengthsSucceeds(t *testing.T) {
+	c := newTestImprovedCache(t)
+
+	keys := [][]byte{[]byte("a"), []byte("b"), []byte("c")}
+	values := [][]byte{[]byte("1"), []byte("2"), []byte("3")}
+
+	if err := c.SetMulti(keys, values); err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+}
+
+func TestSetMulti_EmptySlicesSucceeds(t *testing.T) {
+	c := newTestImprovedCache(t)
+
+	if err := c.SetMulti(nil, nil); err != nil {
+		t.Fatalf("expected success for empty slices, got: %v", err)
+	}
+}
+
+func TestSetMultiKeysSingleValue_ZeroKeySizeReturnsError(t *testing.T) {
+	c := newTestImprovedCache(t)
+
+	err := c.SetMultiKeysSingleValue([][]byte{[]byte("ab")}, []byte("v"), 0)
+	if err == nil {
+		t.Fatal("expected error for keySize == 0, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "keySize must be > 0") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestSetMultiKeysSingleValue_NegativeKeySizeReturnsError(t *testing.T) {
+	c := newTestImprovedCache(t)
+
+	err := c.SetMultiKeysSingleValue([][]byte{[]byte("ab")}, []byte("v"), -1)
+	if err == nil {
+		t.Fatal("expected error for negative keySize, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "keySize must be > 0") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestSetMultiKeysSingleValueAppended_ZeroKeySizeReturnsError(t *testing.T) {
+	c := newTestImprovedCache(t)
+
+	err := c.SetMultiKeysSingleValueAppended([]byte("aabb"), []byte("v"), 0)
+	if err == nil {
+		t.Fatal("expected error for keySize == 0, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "keySize must be > 0") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestSetMultiKeysSingleValueAppended_NegativeKeySizeReturnsError(t *testing.T) {
+	c := newTestImprovedCache(t)
+
+	err := c.SetMultiKeysSingleValueAppended([]byte("aabb"), []byte("v"), -2)
+	if err == nil {
+		t.Fatal("expected error for negative keySize, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "keySize must be > 0") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- `SetMulti` now returns an error when `len(keys) != len(values)` instead of panicking when indexing `values[i]` past the end (#34).
- `SetMultiKeysSingleValue` and `SetMultiKeysSingleValueAppended` now validate `keySize > 0` before any modulo/division/stride operations, preventing integer divide-by-zero panics (#35).
- Adds focused unit tests in `internal/cache/improved_cache_test.go` covering each new validation predicate.

## Validation predicates
- `SetMulti`: `len(keys) != len(values)` -> `fmt.Errorf("SetMulti: keys/values length mismatch (%d != %d)", len(keys), len(values))`
- `SetMultiKeysSingleValue`: `keySize <= 0` -> `fmt.Errorf("SetMultiKeysSingleValue: keySize must be > 0; got %d", keySize)`
- `SetMultiKeysSingleValueAppended`: `keySize <= 0` -> `fmt.Errorf("SetMultiKeysSingleValueAppended: keySize must be > 0; got %d", keySize)`

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/cache/... -count=1 -race`

Closes #34
Closes #35