### PR TITLE
fix(kafka): validate required fields after decode (#41)

### DIFF
--- a/internal/block/handle_message_test.go
+++ b/internal/block/handle_message_test.go
@@ -173,7 +173,7 @@ func TestHandleMessage_HappyPath_AllPublished(t *testing.T) {
 	server := newDataHubServerWithSubtrees(t, 3)
 	defer server.Close()
 
-	const blockHash = "block-happy"
+	blockHash := testHashFromLabel("block-happy")
 	msg := &sarama.ConsumerMessage{
 		Value: newBlockMessageBytes(t, blockHash, server.URL),
 	}
@@ -210,7 +210,7 @@ func TestHandleMessage_PublishFailureMidLoop_StopsAndReturnsError(t *testing.T) 
 	server := newDataHubServerWithSubtrees(t, 4)
 	defer server.Close()
 
-	const blockHash = "block-publish-fail"
+	blockHash := testHashFromLabel("block-publish-fail")
 	msg := &sarama.ConsumerMessage{
 		Value: newBlockMessageBytes(t, blockHash, server.URL),
 	}
@@ -252,7 +252,7 @@ func TestHandleMessage_PublishFailureFirstMessage_NoMessagesLeak(t *testing.T) {
 	server := newDataHubServerWithSubtrees(t, 3)
 	defer server.Close()
 
-	const blockHash = "block-publish-fail-first"
+	blockHash := testHashFromLabel("block-publish-fail-first")
 	msg := &sarama.ConsumerMessage{
 		Value: newBlockMessageBytes(t, blockHash, server.URL),
 	}
@@ -282,7 +282,7 @@ func TestHandleMessage_RetryAfterPublishFailure_Republishes(t *testing.T) {
 	server := newDataHubServerWithSubtrees(t, 3)
 	defer server.Close()
 
-	const blockHash = "block-retry"
+	blockHash := testHashFromLabel("block-retry")
 	msg := &sarama.ConsumerMessage{
 		Value: newBlockMessageBytes(t, blockHash, server.URL),
 	}
@@ -325,7 +325,7 @@ func TestHandleMessage_CounterInitFailure_NoPublishNoDedup(t *testing.T) {
 	server := newDataHubServerWithSubtrees(t, 2)
 	defer server.Close()
 
-	const blockHash = "block-counter-fail"
+	blockHash := testHashFromLabel("block-counter-fail")
 	msg := &sarama.ConsumerMessage{
 		Value: newBlockMessageBytes(t, blockHash, server.URL),
 	}
@@ -351,7 +351,7 @@ func TestHandleMessage_NoSubtrees_DedupAdded(t *testing.T) {
 	server := newDataHubServerWithSubtrees(t, 0)
 	defer server.Close()
 
-	const blockHash = "block-empty"
+	blockHash := testHashFromLabel("block-empty")
 	msg := &sarama.ConsumerMessage{
 		Value: newBlockMessageBytes(t, blockHash, server.URL),
 	}

--- a/internal/block/processor.go
+++ b/internal/block/processor.go
@@ -141,8 +141,19 @@ func (p *Processor) Health() service.HealthStatus {
 func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessage) error {
 	blockMsg, err := kafka.DecodeBlockMessage(msg.Value)
 	if err != nil {
-		p.Logger.Error("failed to decode block message", "error", err)
-		return err
+		// Malformed bytes (or a message that fails post-decode validation, e.g.
+		// missing/invalid hash or DataHub URL) cannot be recovered by re-driving
+		// — log and ack so the partition can advance. F-032 makes the decoder
+		// return ErrInvalidMessage for poison-pill payloads instead of letting
+		// them flow into HTTP fetches and downstream stores. Matches the same
+		// drop-on-decode-error pattern used by the subtree-fetcher and
+		// subtree-worker consumers.
+		p.Logger.Error("failed to decode block message, dropping",
+			"offset", msg.Offset,
+			"partition", msg.Partition,
+			"error", err,
+		)
+		return nil
 	}
 
 	p.Logger.Info("processing block announcement",

--- a/internal/block/processor_test.go
+++ b/internal/block/processor_test.go
@@ -74,13 +74,13 @@ func TestBlockProcessedMessage_CorrectFields(t *testing.T) {
 	msg := &kafka.CallbackTopicMessage{
 		CallbackURL: "http://example.com/cb",
 		Type:        kafka.CallbackBlockProcessed,
-		BlockHash:   "blockhash-field-test",
+		BlockHash:   "00000000000000000000000000000000000000000000000000000000bf1e1d77",
 	}
 
 	if msg.Type != kafka.CallbackBlockProcessed {
 		t.Errorf("expected CallbackBlockProcessed, got %s", msg.Type)
 	}
-	if msg.BlockHash != "blockhash-field-test" {
+	if msg.BlockHash != "00000000000000000000000000000000000000000000000000000000bf1e1d77" {
 		t.Errorf("expected blockhash-field-test, got %s", msg.BlockHash)
 	}
 	if msg.TxID != "" {
@@ -102,8 +102,8 @@ func TestBlockProcessedMessage_CorrectFields(t *testing.T) {
 	if decoded.Type != kafka.CallbackBlockProcessed {
 		t.Errorf("decoded type: expected BLOCK_PROCESSED, got %s", decoded.Type)
 	}
-	if decoded.BlockHash != "blockhash-field-test" {
-		t.Errorf("decoded blockHash: expected blockhash-field-test, got %s", decoded.BlockHash)
+	if decoded.BlockHash != "00000000000000000000000000000000000000000000000000000000bf1e1d77" {
+		t.Errorf("decoded blockHash mismatch, got %s", decoded.BlockHash)
 	}
 	if decoded.CallbackURL != "http://example.com/cb" {
 		t.Errorf("decoded callbackURL: expected http://example.com/cb, got %s", decoded.CallbackURL)
@@ -118,10 +118,10 @@ func TestSubtreeWorkMessage_Published(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	workProducer := kafka.NewTestProducer(workMock, "subtree-work-test", logger)
 
-	subtreeHashes := []string{"subtree-a", "subtree-b", "subtree-c"}
+	subtreeHashes := []string{"00000000000000000000000000000000000000000000000000000000000000aa", "00000000000000000000000000000000000000000000000000000000000000bb", "00000000000000000000000000000000000000000000000000000000000000cc"}
 	for i, stHash := range subtreeHashes {
 		workMsg := &kafka.SubtreeWorkMessage{
-			BlockHash:    "block-123",
+			BlockHash:    "0000000000000000000000000000000000000000000000000000000000000123",
 			BlockHeight:  850000,
 			SubtreeHash:  stHash,
 			SubtreeIndex: i,
@@ -142,7 +142,7 @@ func TestSubtreeWorkMessage_Published(t *testing.T) {
 
 	for i, pm := range workMock.messages {
 		msg := decodeSubtreeWork(t, pm)
-		if msg.BlockHash != "block-123" {
+		if msg.BlockHash != "0000000000000000000000000000000000000000000000000000000000000123" {
 			t.Errorf("message %d: expected blockHash 'block-123', got %s", i, msg.BlockHash)
 		}
 		if msg.SubtreeHash != subtreeHashes[i] {

--- a/internal/block/subtree_processor_test.go
+++ b/internal/block/subtree_processor_test.go
@@ -2,6 +2,8 @@ package block
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"io"
 	"log/slog"
 	"net/http"
@@ -22,6 +24,15 @@ import (
 
 func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// testHashFromLabel deterministically converts a human-readable test label
+// into a 64-char hex hash that satisfies the F-032 decoder validator. Tests
+// that previously used opaque placeholder strings (e.g. "block-happy") are
+// kept readable while still emitting messages the kafka decoder will accept.
+func testHashFromLabel(label string) string {
+	sum := sha256.Sum256([]byte(label))
+	return hex.EncodeToString(sum[:])
 }
 
 // buildRawSubtreeBytes creates raw DataHub-format subtree data (concatenated 32-byte hashes).
@@ -301,7 +312,7 @@ func TestStumpCallbackMessageEncoding(t *testing.T) {
 		CallbackURL:  "http://example.com/callback",
 		Type:         kafka.CallbackStump,
 		TxID:         "txid1",
-		BlockHash:    "blockhash123",
+		BlockHash:    "00000000000000000000000000000000000000000000000000000000b10cca12",
 		SubtreeIndex: 3,
 		StumpRef:     "deadbeef",
 	}
@@ -325,7 +336,7 @@ func TestStumpCallbackMessageEncoding(t *testing.T) {
 	if decoded.TxID != "txid1" {
 		t.Errorf("expected txid1, got %s", decoded.TxID)
 	}
-	if decoded.BlockHash != "blockhash123" {
+	if decoded.BlockHash != "00000000000000000000000000000000000000000000000000000000b10cca12" {
 		t.Errorf("unexpected block hash: %s", decoded.BlockHash)
 	}
 	if decoded.SubtreeIndex != 3 {

--- a/internal/block/subtree_worker_handle_message_test.go
+++ b/internal/block/subtree_worker_handle_message_test.go
@@ -249,7 +249,9 @@ func newWorkerForHandleMessage(
 }
 
 // makeWorkMessageBytes builds a SubtreeWorkMessage targeting the given DataHub
-// URL and returns the encoded bytes ready to feed into handleMessage.
+// URL and returns the encoded bytes ready to feed into handleMessage. The
+// hash arguments must be valid 64-char hex (use testHashFromLabel to derive
+// stable hashes from human-readable labels).
 func makeWorkMessageBytes(t *testing.T, blockHash, subtreeHash, dataHubURL string, attempt int) []byte {
 	t.Helper()
 	msg := &kafka.SubtreeWorkMessage{
@@ -374,8 +376,8 @@ func TestHandleMessage_CallbackPublishFailure_RetriesAndDoesNotDecrement(t *test
 	server := rawSubtreeServer(subtreePayload)
 	defer server.Close()
 
-	const blockHash = "block-cb-fail"
-	const subtreeHash = "subtree-cb-fail"
+	blockHash := testHashFromLabel("block-cb-fail")
+	subtreeHash := testHashFromLabel("subtree-cb-fail")
 
 	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, 5)
 
@@ -411,8 +413,10 @@ func TestHandleMessage_CallbackPublishFailure_AtMaxAttempts_DLQAndDecrement(t *t
 	retryMock := &callbackFailingProducer{}
 	dlqMock := &callbackFailingProducer{}
 
+	blockHash := testHashFromLabel("block-dlq")
+	subtreeHash := testHashFromLabel("subtree-dlq")
 	counter := newCountingSubtreeCounter()
-	_ = counter.Init("block-dlq", 1)
+	_ = counter.Init(blockHash, 1)
 	// Reset init bookkeeping after pre-seed so test assertions only count
 	// what handleMessage drives.
 	counter.initCalls = 0
@@ -427,7 +431,7 @@ func TestHandleMessage_CallbackPublishFailure_AtMaxAttempts_DLQAndDecrement(t *t
 	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, maxAttempts)
 
 	// AttemptCount = maxAttempts - 1 → next attempt is terminal → DLQ.
-	value := makeWorkMessageBytes(t, "block-dlq", "subtree-dlq", server.URL, maxAttempts-1)
+	value := makeWorkMessageBytes(t, blockHash, subtreeHash, server.URL, maxAttempts-1)
 	err := svc.handleMessage(context.Background(), &sarama.ConsumerMessage{Value: value})
 	if err != nil {
 		t.Fatalf("handleMessage at max attempts: expected nil error after DLQ publish, got: %v", err)
@@ -454,8 +458,10 @@ func TestHandleMessage_HappyPath_DecrementsExactlyOnce(t *testing.T) {
 	retryMock := &callbackFailingProducer{}
 	dlqMock := &callbackFailingProducer{}
 
+	blockHash := testHashFromLabel("block-happy")
+	subtreeHash := testHashFromLabel("subtree-happy")
 	counter := newCountingSubtreeCounter()
-	_ = counter.Init("block-happy", 1)
+	_ = counter.Init(blockHash, 1)
 	counter.initCalls = 0
 
 	stumpStore := &stubStumpStore{}
@@ -466,7 +472,7 @@ func TestHandleMessage_HappyPath_DecrementsExactlyOnce(t *testing.T) {
 
 	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, 5)
 
-	value := makeWorkMessageBytes(t, "block-happy", "subtree-happy", server.URL, 0)
+	value := makeWorkMessageBytes(t, blockHash, subtreeHash, server.URL, 0)
 	if err := svc.handleMessage(context.Background(), &sarama.ConsumerMessage{Value: value}); err != nil {
 		t.Fatalf("handleMessage happy path: expected nil error, got: %v", err)
 	}
@@ -502,7 +508,7 @@ func TestHandleMessage_StumpStoreFailure_RetriesAndDoesNotDecrement(t *testing.T
 
 	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, 5)
 
-	value := makeWorkMessageBytes(t, "block-blob-fail", "subtree-blob-fail", server.URL, 0)
+	value := makeWorkMessageBytes(t, testHashFromLabel("block-blob-fail"), testHashFromLabel("subtree-blob-fail"), server.URL, 0)
 	if err := svc.handleMessage(context.Background(), &sarama.ConsumerMessage{Value: value}); err != nil {
 		t.Fatalf("handleMessage stump-store failure: expected nil error (retry path), got: %v", err)
 	}
@@ -531,7 +537,7 @@ func TestHandleMessage_DecrementFailureOnSuccessPath_RetriesAndPreservesCount(t 
 	retryMock := &callbackFailingProducer{}
 	dlqMock := &callbackFailingProducer{}
 
-	const blockHash = "block-dec-fail"
+	blockHash := testHashFromLabel("block-dec-fail")
 	counter := newCountingSubtreeCounter()
 	_ = counter.Init(blockHash, 3)
 	counter.initCalls = 0
@@ -545,7 +551,7 @@ func TestHandleMessage_DecrementFailureOnSuccessPath_RetriesAndPreservesCount(t 
 
 	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, 5)
 
-	value := makeWorkMessageBytes(t, blockHash, "subtree-dec-fail", server.URL, 0)
+	value := makeWorkMessageBytes(t, blockHash, testHashFromLabel("subtree-dec-fail"), server.URL, 0)
 	err := svc.handleMessage(context.Background(), &sarama.ConsumerMessage{Value: value})
 	if err != nil {
 		// Below max attempts, handleTransientFailure re-publishes for retry
@@ -589,7 +595,7 @@ func TestHandleMessage_DecrementFailureOnDLQPath_ReturnsError(t *testing.T) {
 	retryMock := &callbackFailingProducer{}
 	dlqMock := &callbackFailingProducer{}
 
-	const blockHash = "block-dlq-dec-fail"
+	blockHash := testHashFromLabel("block-dlq-dec-fail")
 	counter := newCountingSubtreeCounter()
 	_ = counter.Init(blockHash, 1)
 	counter.initCalls = 0
@@ -604,7 +610,7 @@ func TestHandleMessage_DecrementFailureOnDLQPath_ReturnsError(t *testing.T) {
 	const maxAttempts = 3
 	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, maxAttempts)
 
-	value := makeWorkMessageBytes(t, blockHash, "subtree-dlq-dec-fail", server.URL, maxAttempts-1)
+	value := makeWorkMessageBytes(t, blockHash, testHashFromLabel("subtree-dlq-dec-fail"), server.URL, maxAttempts-1)
 	err := svc.handleMessage(context.Background(), &sarama.ConsumerMessage{Value: value})
 	if err == nil {
 		t.Fatalf("expected non-nil error when Decrement fails on DLQ path so consumer redelivers, got nil")
@@ -638,7 +644,7 @@ func TestHandleMessage_HappyPath_DecrementToZeroEmitsBlockProcessed(t *testing.T
 	retryMock := &callbackFailingProducer{}
 	dlqMock := &callbackFailingProducer{}
 
-	const blockHash = "block-zero-emit"
+	blockHash := testHashFromLabel("block-zero-emit")
 	counter := newCountingSubtreeCounter()
 	// Pre-seed counter at 1 so the single subtree work item drives it to 0.
 	_ = counter.Init(blockHash, 1)
@@ -654,7 +660,7 @@ func TestHandleMessage_HappyPath_DecrementToZeroEmitsBlockProcessed(t *testing.T
 	// Wire up urlRegistry so emitBlockProcessed has somewhere to publish.
 	svc.urlRegistry = &fakeURLRegistry{urls: []string{"http://cb.example.test/hook"}}
 
-	value := makeWorkMessageBytes(t, blockHash, "subtree-zero-emit", server.URL, 0)
+	value := makeWorkMessageBytes(t, blockHash, testHashFromLabel("subtree-zero-emit"), server.URL, 0)
 	if err := svc.handleMessage(context.Background(), &sarama.ConsumerMessage{Value: value}); err != nil {
 		t.Fatalf("handleMessage happy path: expected nil error, got: %v", err)
 	}
@@ -705,7 +711,7 @@ func TestEmitBlockProcessed_PublishFailureReturnsError(t *testing.T) {
 	s.Logger = logger
 	s.callbackProducer = kafka.NewTestProducer(cbMock, "callback-test", logger)
 
-	err := s.emitBlockProcessed("blk-emit-fail")
+	err := s.emitBlockProcessed(testHashFromLabel("blk-emit-fail"))
 	if err == nil {
 		t.Fatalf("expected error from emitBlockProcessed when callback publish fails")
 	}
@@ -732,7 +738,7 @@ func TestEmitBlockProcessed_PartialFailureContinuesAndReturnsFirstError(t *testi
 	s.Logger = logger
 	s.callbackProducer = kafka.NewTestProducer(cbMock, "callback-test", logger)
 
-	err := s.emitBlockProcessed("blk-partial")
+	err := s.emitBlockProcessed(testHashFromLabel("blk-partial"))
 	if err == nil {
 		t.Fatalf("expected non-nil error when BLOCK_PROCESSED publishes fail")
 	}
@@ -760,7 +766,7 @@ func TestEmitBlockProcessed_HappyPath(t *testing.T) {
 	s.Logger = logger
 	s.callbackProducer = kafka.NewTestProducer(cbMock, "callback-test", logger)
 
-	if err := s.emitBlockProcessed("blk-happy"); err != nil {
+	if err := s.emitBlockProcessed(testHashFromLabel("blk-happy")); err != nil {
 		t.Fatalf("expected nil error on happy path, got: %v", err)
 	}
 	if got := cbMock.sentCountOfType(kafka.CallbackBlockProcessed); got != 2 {
@@ -781,7 +787,7 @@ func TestEmitBlockProcessed_RegistryFailureReturnsError(t *testing.T) {
 	s.Logger = logger
 	s.callbackProducer = kafka.NewTestProducer(cbMock, "callback-test", logger)
 
-	if err := s.emitBlockProcessed("blk-registry-fail"); err == nil {
+	if err := s.emitBlockProcessed(testHashFromLabel("blk-registry-fail")); err == nil {
 		t.Fatalf("expected error when URL registry GetAll fails")
 	}
 	if got := cbMock.sentCount(); got != 0 {
@@ -805,7 +811,7 @@ func TestHandleMessage_BlockProcessedEmitFailure_RetriesAndDoesNotAck(t *testing
 	retryMock := &callbackFailingProducer{}
 	dlqMock := &callbackFailingProducer{}
 
-	const blockHash = "block-emit-fail"
+	blockHash := testHashFromLabel("block-emit-fail")
 	counter := newCountingSubtreeCounter()
 	// Pre-seed at 1 so the single subtree drives the counter to 0 → emit fires.
 	_ = counter.Init(blockHash, 1)
@@ -820,7 +826,7 @@ func TestHandleMessage_BlockProcessedEmitFailure_RetriesAndDoesNotAck(t *testing
 	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, 5)
 	svc.urlRegistry = &fakeURLRegistry{urls: []string{"http://cb.example.test/hook"}}
 
-	value := makeWorkMessageBytes(t, blockHash, "subtree-emit-fail", server.URL, 0)
+	value := makeWorkMessageBytes(t, blockHash, testHashFromLabel("subtree-emit-fail"), server.URL, 0)
 	if err := svc.handleMessage(context.Background(), &sarama.ConsumerMessage{Value: value}); err != nil {
 		// Below max attempts, handleTransientFailure re-publishes for retry
 		// and returns nil — the work item was redirected through the retry
@@ -860,7 +866,7 @@ func TestHandleMessage_BlockProcessedEmitRetry_ReEmitsOnRedelivery(t *testing.T)
 	retryMock := &callbackFailingProducer{}
 	dlqMock := &callbackFailingProducer{}
 
-	const blockHash = "block-emit-retry"
+	blockHash := testHashFromLabel("block-emit-retry")
 	counter := newCountingSubtreeCounter()
 	// Pre-seed at 0 to simulate a redelivery: a previous attempt already
 	// decremented to 0 (and either succeeded-emit or failed-emit). The
@@ -878,7 +884,7 @@ func TestHandleMessage_BlockProcessedEmitRetry_ReEmitsOnRedelivery(t *testing.T)
 	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, 5)
 	svc.urlRegistry = &fakeURLRegistry{urls: []string{"http://cb.example.test/hook"}}
 
-	value := makeWorkMessageBytes(t, blockHash, "subtree-emit-retry", server.URL, 1)
+	value := makeWorkMessageBytes(t, blockHash, testHashFromLabel("subtree-emit-retry"), server.URL, 1)
 	if err := svc.handleMessage(context.Background(), &sarama.ConsumerMessage{Value: value}); err != nil {
 		t.Fatalf("handleMessage on redelivery: expected nil, got: %v", err)
 	}
@@ -917,7 +923,7 @@ func TestHandleMessage_BlockProcessedEmitFailure_AtMaxAttempts_DLQPathReturnsErr
 	retryMock := &callbackFailingProducer{}
 	dlqMock := &callbackFailingProducer{}
 
-	const blockHash = "block-emit-dlq"
+	blockHash := testHashFromLabel("block-emit-dlq")
 	counter := newCountingSubtreeCounter()
 	_ = counter.Init(blockHash, 1)
 	counter.initCalls = 0
@@ -933,7 +939,7 @@ func TestHandleMessage_BlockProcessedEmitFailure_AtMaxAttempts_DLQPathReturnsErr
 	svc.urlRegistry = &fakeURLRegistry{urls: []string{"http://cb.example.test/hook"}}
 
 	// AttemptCount = maxAttempts - 1 → next attempt is terminal → DLQ.
-	value := makeWorkMessageBytes(t, blockHash, "subtree-emit-dlq", server.URL, maxAttempts-1)
+	value := makeWorkMessageBytes(t, blockHash, testHashFromLabel("subtree-emit-dlq"), server.URL, maxAttempts-1)
 	err := svc.handleMessage(context.Background(), &sarama.ConsumerMessage{Value: value})
 	if err == nil {
 		t.Fatalf("expected non-nil error so consumer redelivers when emit fails on DLQ path, got nil")

--- a/internal/callback/delivery_handle_message_test.go
+++ b/internal/callback/delivery_handle_message_test.go
@@ -86,11 +86,10 @@ func TestHandleMessage_HTTPFailureWithRetriesAvailable_RepublishesBeforeAck(t *t
 	ds, retryMock, dlqMock := newTestDeliveryService(t, cfg, server.Client())
 
 	msg := &kafka.CallbackTopicMessage{
-		CallbackURL:  server.URL + "/cb",
-		Type:         kafka.CallbackStump,
-		BlockHash:    "blockhash",
-		SubtreeIndex: 1,
-		RetryCount:   0,
+		CallbackURL: server.URL + "/cb",
+		Type:        kafka.CallbackSeenOnNetwork,
+		TxID:        "tx-retry",
+		RetryCount:  0,
 	}
 
 	if err := ds.handleMessage(context.Background(), encodeConsumerMessage(t, msg)); err != nil {
@@ -333,7 +332,7 @@ func TestHandleMessage_PermanentErrorRoutesToDLQBeforeAck(t *testing.T) {
 	msg := &kafka.CallbackTopicMessage{
 		CallbackURL:  server.URL + "/cb",
 		Type:         kafka.CallbackStump,
-		BlockHash:    "blk-perm",
+		BlockHash:    "00000000000000000000000000000000000000000000000000000000b1bcfee0",
 		SubtreeIndex: 2,
 		StumpRef:     "ref-never-stored",
 	}
@@ -380,7 +379,7 @@ func TestHandleMessage_StumpOrderingViaSamePartitionSerialization(t *testing.T) 
 	ds, _, _, stumpStore := newTestDeliveryServiceWithStumps(t, cfg, server.Client())
 
 	url := server.URL + "/cb"
-	blk := "block-seq"
+	blk := "0000000000000000000000000000000000000000000000000000000050a1b15e"
 	mustPut := func(b []byte) string {
 		ref, err := stumpStore.Put(b, 0)
 		if err != nil {

--- a/internal/callback/delivery_test.go
+++ b/internal/callback/delivery_test.go
@@ -177,7 +177,7 @@ func TestDeliverCallback_StumpSuccess(t *testing.T) {
 	msg := &kafka.CallbackTopicMessage{
 		CallbackURL:  server.URL + "/callback",
 		Type:         kafka.CallbackStump,
-		BlockHash:    "blockhash456",
+		BlockHash:    "00000000000000000000000000000000000000000000000000000000b10c0456",
 		SubtreeIndex: 3,
 		StumpRef:     stumpRef,
 	}
@@ -201,7 +201,7 @@ func TestDeliverCallback_StumpSuccess(t *testing.T) {
 	if payload.Type != "STUMP" {
 		t.Errorf("expected type 'STUMP', got %q", payload.Type)
 	}
-	if payload.BlockHash != "blockhash456" {
+	if payload.BlockHash != "00000000000000000000000000000000000000000000000000000000b10c0456" {
 		t.Errorf("expected blockHash 'blockhash456', got %q", payload.BlockHash)
 	}
 	if payload.SubtreeIndex != 3 {
@@ -281,7 +281,7 @@ func TestDeliverCallback_Non2xxReturnsError(t *testing.T) {
 			msg := &kafka.CallbackTopicMessage{
 				CallbackURL:  server.URL + "/callback",
 				Type:         kafka.CallbackStump,
-				BlockHash:    "blockhash",
+				BlockHash:    "00000000000000000000000000000000000000000000000000000000b10c0aa1",
 				SubtreeIndex: 1,
 			}
 
@@ -309,7 +309,7 @@ func TestDeliverCallback_2xxStatusesSucceed(t *testing.T) {
 			msg := &kafka.CallbackTopicMessage{
 				CallbackURL:  server.URL + "/callback",
 				Type:         kafka.CallbackStump,
-				BlockHash:    "blockhash",
+				BlockHash:    "00000000000000000000000000000000000000000000000000000000b10c0aa1",
 				SubtreeIndex: 1,
 			}
 
@@ -336,11 +336,10 @@ func TestProcessDelivery_RetriesViaKafkaRepublish(t *testing.T) {
 	ds, retryMock, _ := newTestDeliveryService(t, cfg, server.Client())
 
 	msg := &kafka.CallbackTopicMessage{
-		CallbackURL:  server.URL + "/callback",
-		Type:         kafka.CallbackStump,
-		BlockHash:    "blockhash",
-		SubtreeIndex: 1,
-		RetryCount:   0,
+		CallbackURL: server.URL + "/callback",
+		Type:        kafka.CallbackSeenOnNetwork,
+		TxID:        "tx-retry",
+		RetryCount:  0,
 	}
 
 	if err := ds.processDelivery(context.Background(), msg); err != nil {
@@ -380,7 +379,7 @@ func TestProcessDelivery_RetryRepublishFailureSurfacesError(t *testing.T) {
 	msg := &kafka.CallbackTopicMessage{
 		CallbackURL:  server.URL + "/callback",
 		Type:         kafka.CallbackStump,
-		BlockHash:    "blockhash",
+		BlockHash:    "00000000000000000000000000000000000000000000000000000000b10c0aa1",
 		SubtreeIndex: 1,
 	}
 
@@ -409,7 +408,7 @@ func TestProcessDelivery_PublishesToDLQAfterMaxRetries(t *testing.T) {
 	msg := &kafka.CallbackTopicMessage{
 		CallbackURL:  server.URL + "/callback",
 		Type:         kafka.CallbackStump,
-		BlockHash:    "blockhash",
+		BlockHash:    "00000000000000000000000000000000000000000000000000000000b10c0aa1",
 		SubtreeIndex: 1,
 		RetryCount:   3, // Already at max retries.
 	}
@@ -450,7 +449,7 @@ func TestProcessDelivery_DLQPublishFailureSurfacesError(t *testing.T) {
 	msg := &kafka.CallbackTopicMessage{
 		CallbackURL:  server.URL + "/callback",
 		Type:         kafka.CallbackStump,
-		BlockHash:    "blockhash",
+		BlockHash:    "00000000000000000000000000000000000000000000000000000000b10c0aa1",
 		SubtreeIndex: 1,
 	}
 
@@ -484,7 +483,7 @@ func TestProcessDelivery_MissingStumpBlobGoesStraightToDLQ(t *testing.T) {
 	msg := &kafka.CallbackTopicMessage{
 		CallbackURL:  server.URL + "/callback",
 		Type:         kafka.CallbackStump,
-		BlockHash:    "blockhash-missing",
+		BlockHash:    "0000000000000000000000000000000000000000000000000000000000111551",
 		SubtreeIndex: 7,
 		StumpRef:     "ref-that-was-never-stored",
 		RetryCount:   0,
@@ -545,7 +544,7 @@ func TestProcessDelivery_DedupSkipsDuplicate(t *testing.T) {
 	msg := &kafka.CallbackTopicMessage{
 		CallbackURL:  server.URL + "/callback",
 		Type:         kafka.CallbackStump,
-		BlockHash:    "blockhash",
+		BlockHash:    "00000000000000000000000000000000000000000000000000000000b10c0aa1",
 		SubtreeIndex: 3,
 	}
 
@@ -571,18 +570,18 @@ func TestBuildIdempotencyKey(t *testing.T) {
 			name: "BLOCK_PROCESSED uses blockHash",
 			msg: &kafka.CallbackTopicMessage{
 				Type:      kafka.CallbackBlockProcessed,
-				BlockHash: "blockhash123",
+				BlockHash: "0000000000000000000000000000000000000000000000000000000000b10c12",
 			},
-			expected: "blockhash123:BLOCK_PROCESSED",
+			expected: "0000000000000000000000000000000000000000000000000000000000b10c12:BLOCK_PROCESSED",
 		},
 		{
 			name: "STUMP uses blockHash and subtreeIndex",
 			msg: &kafka.CallbackTopicMessage{
 				Type:         kafka.CallbackStump,
-				BlockHash:    "blockhash",
+				BlockHash:    "00000000000000000000000000000000000000000000000000000000b10c0aa1",
 				SubtreeIndex: 3,
 			},
-			expected: "blockhash:3:STUMP",
+			expected: "00000000000000000000000000000000000000000000000000000000b10c0aa1:3:STUMP",
 		},
 		{
 			name: "batched SEEN_ON_NETWORK uses TxIDs hash",
@@ -637,18 +636,18 @@ func TestDedupKeyForMessage(t *testing.T) {
 			name: "BLOCK_PROCESSED uses blockHash",
 			msg: &kafka.CallbackTopicMessage{
 				Type:      kafka.CallbackBlockProcessed,
-				BlockHash: "block123",
+				BlockHash: "0000000000000000000000000000000000000000000000000000000000010c12",
 			},
-			expected: "block123",
+			expected: "0000000000000000000000000000000000000000000000000000000000010c12",
 		},
 		{
 			name: "STUMP uses blockHash and subtreeIndex",
 			msg: &kafka.CallbackTopicMessage{
 				Type:         kafka.CallbackStump,
-				BlockHash:    "blockhash",
+				BlockHash:    "00000000000000000000000000000000000000000000000000000000b10c0aa1",
 				SubtreeIndex: 3,
 			},
-			expected: "blockhash:3",
+			expected: "00000000000000000000000000000000000000000000000000000000b10c0aa1:3",
 		},
 		{
 			name: "batched SEEN uses TxIDs hash",
@@ -696,7 +695,7 @@ func TestDeliverCallback_BlockProcessedPayload(t *testing.T) {
 	msg := &kafka.CallbackTopicMessage{
 		CallbackURL: server.URL + "/callback",
 		Type:        kafka.CallbackBlockProcessed,
-		BlockHash:   "block-abc",
+		BlockHash:   "000000000000000000000000000000000000000000000000000000000abcabcd",
 	}
 
 	err := ds.deliverCallback(context.Background(), msg)
@@ -712,7 +711,7 @@ func TestDeliverCallback_BlockProcessedPayload(t *testing.T) {
 	if payload.Type != "BLOCK_PROCESSED" {
 		t.Errorf("expected type BLOCK_PROCESSED, got %q", payload.Type)
 	}
-	if payload.BlockHash != "block-abc" {
+	if payload.BlockHash != "000000000000000000000000000000000000000000000000000000000abcabcd" {
 		t.Errorf("expected blockHash block-abc, got %q", payload.BlockHash)
 	}
 	if payload.TxID != "" {

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -302,7 +302,7 @@ func TestMinedCallbackWithSTUMP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to put stump: %v", err)
 	}
-	blockHash := "00000000000000000abc123def456789"
+	blockHash := "00000000000000000abc123def4567890000000000000000000000000000ffff"
 
 	cbMsg := &kafka.CallbackTopicMessage{
 		CallbackURL:  callbackURL,

--- a/internal/kafka/messages.go
+++ b/internal/kafka/messages.go
@@ -1,7 +1,11 @@
 package kafka
 
 import (
+	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
 	"time"
 )
 
@@ -15,6 +19,18 @@ const (
 	CallbackBlockProcessed    CallbackType = "BLOCK_PROCESSED"
 )
 
+// hashHexLen is the expected length of a hex-encoded 32-byte block/subtree hash.
+const hashHexLen = 64
+
+// ErrInvalidMessage is returned by the Decode... helpers when a Kafka message
+// successfully unmarshals as JSON but fails post-decode validation (missing
+// required fields, malformed hashes, malformed URLs, unknown callback type,
+// negative retry counter). Callers should treat ErrInvalidMessage as a
+// poison-pill condition: re-driving the same bytes will never succeed, so the
+// consumer should log + ack rather than stalling the partition. Wrap with
+// errors.Is to detect.
+var ErrInvalidMessage = errors.New("kafka: invalid message")
+
 // SubtreeMessage represents a subtree announcement received from P2P.
 // AttemptCount is incremented by subtree-fetcher when re-publishing the message
 // for retry; on reaching SubtreeConfig.MaxAttempts the message is routed to
@@ -27,6 +43,23 @@ type SubtreeMessage struct {
 	AttemptCount int    `json:"attemptCount,omitempty"`
 }
 
+// Validate enforces the post-decode invariants that the JSON layer cannot
+// express on its own (non-empty required fields, well-formed hash hex,
+// well-formed URL, non-negative attempt counter). All errors are wrapped in
+// ErrInvalidMessage so callers can recognize poison pills.
+func (m *SubtreeMessage) Validate() error {
+	if err := validateHash("hash", m.Hash); err != nil {
+		return err
+	}
+	if err := validateRequiredURL("dataHubUrl", m.DataHubURL); err != nil {
+		return err
+	}
+	if m.AttemptCount < 0 {
+		return fmt.Errorf("%w: field %q must be >= 0 (got %d)", ErrInvalidMessage, "attemptCount", m.AttemptCount)
+	}
+	return nil
+}
+
 // BlockMessage represents a block announcement received from P2P.
 type BlockMessage struct {
 	Hash       string `json:"hash"`
@@ -36,6 +69,17 @@ type BlockMessage struct {
 	DataHubURL string `json:"dataHubUrl"`
 	PeerID     string `json:"peerId"`
 	ClientName string `json:"clientName"`
+}
+
+// Validate enforces the post-decode invariants for a BlockMessage.
+func (m *BlockMessage) Validate() error {
+	if err := validateHash("hash", m.Hash); err != nil {
+		return err
+	}
+	if err := validateRequiredURL("dataHubUrl", m.DataHubURL); err != nil {
+		return err
+	}
+	return nil
 }
 
 // CallbackTopicMessage is the message published to the callback Kafka topic.
@@ -52,24 +96,75 @@ type CallbackTopicMessage struct {
 	NextRetryAt  time.Time    `json:"nextRetryAt,omitempty"`
 }
 
+// Validate enforces the post-decode invariants for a CallbackTopicMessage.
+// The required fields differ per callback Type (e.g. STUMP carries a blockHash
+// and stumpRef, BLOCK_PROCESSED carries only a blockHash, SEEN_* carries
+// either a single TxID or a TxIDs batch). Unknown types are rejected outright.
+func (m *CallbackTopicMessage) Validate() error {
+	if err := validateRequiredURL("callbackUrl", m.CallbackURL); err != nil {
+		return err
+	}
+	if !isKnownCallbackType(m.Type) {
+		return fmt.Errorf("%w: field %q has unknown value %q", ErrInvalidMessage, "type", m.Type)
+	}
+	if m.RetryCount < 0 {
+		return fmt.Errorf("%w: field %q must be >= 0 (got %d)", ErrInvalidMessage, "retryCount", m.RetryCount)
+	}
+
+	switch m.Type {
+	case CallbackSeenOnNetwork, CallbackSeenMultipleNodes:
+		// Either a single TxID or a non-empty TxIDs batch must be present.
+		if m.TxID == "" && len(m.TxIDs) == 0 {
+			return fmt.Errorf("%w: field %q requires either %q or non-empty %q",
+				ErrInvalidMessage, "type", "txid", "txids")
+		}
+	case CallbackStump:
+		if err := validateHash("blockHash", m.BlockHash); err != nil {
+			return err
+		}
+		if m.StumpRef == "" {
+			return fmt.Errorf("%w: field %q is required for STUMP callback", ErrInvalidMessage, "stumpRef")
+		}
+	case CallbackBlockProcessed:
+		if err := validateHash("blockHash", m.BlockHash); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (m *SubtreeMessage) Encode() ([]byte, error) {
 	return json.Marshal(m)
 }
 
+// DecodeSubtreeMessage parses and validates a subtree announcement. A wrapped
+// ErrInvalidMessage indicates a poison-pill (consumers should log and ack);
+// any other error is a JSON parse failure (also poison-pill in practice).
 func DecodeSubtreeMessage(data []byte) (*SubtreeMessage, error) {
 	var msg SubtreeMessage
-	err := json.Unmarshal(data, &msg)
-	return &msg, err
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return nil, err
+	}
+	if err := msg.Validate(); err != nil {
+		return nil, err
+	}
+	return &msg, nil
 }
 
 func (m *BlockMessage) Encode() ([]byte, error) {
 	return json.Marshal(m)
 }
 
+// DecodeBlockMessage parses and validates a block announcement.
 func DecodeBlockMessage(data []byte) (*BlockMessage, error) {
 	var msg BlockMessage
-	err := json.Unmarshal(data, &msg)
-	return &msg, err
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return nil, err
+	}
+	if err := msg.Validate(); err != nil {
+		return nil, err
+	}
+	return &msg, nil
 }
 
 // SubtreeWorkMessage represents a subtree processing work item dispatched by the block processor.
@@ -87,22 +182,102 @@ type SubtreeWorkMessage struct {
 	AttemptCount int    `json:"attemptCount,omitempty"`
 }
 
+// Validate enforces the post-decode invariants for a SubtreeWorkMessage.
+func (m *SubtreeWorkMessage) Validate() error {
+	if err := validateHash("blockHash", m.BlockHash); err != nil {
+		return err
+	}
+	if err := validateHash("subtreeHash", m.SubtreeHash); err != nil {
+		return err
+	}
+	if err := validateRequiredURL("dataHubUrl", m.DataHubURL); err != nil {
+		return err
+	}
+	if m.SubtreeIndex < 0 {
+		return fmt.Errorf("%w: field %q must be >= 0 (got %d)", ErrInvalidMessage, "subtreeIndex", m.SubtreeIndex)
+	}
+	if m.AttemptCount < 0 {
+		return fmt.Errorf("%w: field %q must be >= 0 (got %d)", ErrInvalidMessage, "attemptCount", m.AttemptCount)
+	}
+	return nil
+}
+
 func (m *SubtreeWorkMessage) Encode() ([]byte, error) {
 	return json.Marshal(m)
 }
 
+// DecodeSubtreeWorkMessage parses and validates a subtree work item.
 func DecodeSubtreeWorkMessage(data []byte) (*SubtreeWorkMessage, error) {
 	var msg SubtreeWorkMessage
-	err := json.Unmarshal(data, &msg)
-	return &msg, err
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return nil, err
+	}
+	if err := msg.Validate(); err != nil {
+		return nil, err
+	}
+	return &msg, nil
 }
 
 func (m *CallbackTopicMessage) Encode() ([]byte, error) {
 	return json.Marshal(m)
 }
 
+// DecodeCallbackTopicMessage parses and validates a callback message.
 func DecodeCallbackTopicMessage(data []byte) (*CallbackTopicMessage, error) {
 	var msg CallbackTopicMessage
-	err := json.Unmarshal(data, &msg)
-	return &msg, err
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return nil, err
+	}
+	if err := msg.Validate(); err != nil {
+		return nil, err
+	}
+	return &msg, nil
+}
+
+// validateHash enforces non-empty + 64-char lowercase/uppercase hex (i.e. a
+// 32-byte hash, matching chainhash.HashSize). Returns an ErrInvalidMessage
+// wrapped error.
+func validateHash(field, value string) error {
+	if value == "" {
+		return fmt.Errorf("%w: field %q is required", ErrInvalidMessage, field)
+	}
+	if len(value) != hashHexLen {
+		return fmt.Errorf("%w: field %q must be %d hex chars (got %d)",
+			ErrInvalidMessage, field, hashHexLen, len(value))
+	}
+	if _, err := hex.DecodeString(value); err != nil {
+		return fmt.Errorf("%w: field %q is not valid hex: %v", ErrInvalidMessage, field, err)
+	}
+	return nil
+}
+
+// validateRequiredURL enforces non-empty + parseable as a request URI with an
+// http(s) scheme — peer-supplied URLs that don't parse cannot be safely fed to
+// HTTP clients downstream. SSRF-class checks (private IPs, etc.) live in the
+// dialer; this function only validates well-formedness.
+func validateRequiredURL(field, value string) error {
+	if value == "" {
+		return fmt.Errorf("%w: field %q is required", ErrInvalidMessage, field)
+	}
+	u, err := url.ParseRequestURI(value)
+	if err != nil {
+		return fmt.Errorf("%w: field %q is not a valid URL: %v", ErrInvalidMessage, field, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("%w: field %q must be http or https (got %q)",
+			ErrInvalidMessage, field, u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("%w: field %q must include a host", ErrInvalidMessage, field)
+	}
+	return nil
+}
+
+func isKnownCallbackType(t CallbackType) bool {
+	switch t {
+	case CallbackSeenOnNetwork, CallbackSeenMultipleNodes, CallbackStump, CallbackBlockProcessed:
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/kafka/messages_test.go
+++ b/internal/kafka/messages_test.go
@@ -1,13 +1,22 @@
 package kafka
 
 import (
+	"errors"
+	"strings"
 	"testing"
 	"time"
 )
 
+// Stable, valid 64-char hex hashes used across tests.
+const (
+	validHash1 = "0000000000000000000000000000000000000000000000000000000000000001"
+	validHash2 = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+	validHash3 = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+)
+
 func TestSubtreeMessage_EncodeDecode(t *testing.T) {
 	msg := &SubtreeMessage{
-		Hash:       "subtree-hash-123",
+		Hash:       validHash1,
 		DataHubURL: "https://datahub.example.com/subtree/123",
 		PeerID:     "peer1",
 		ClientName: "teranode-v1",
@@ -39,7 +48,7 @@ func TestSubtreeMessage_EncodeDecode(t *testing.T) {
 
 func TestBlockMessage_EncodeDecode(t *testing.T) {
 	msg := &BlockMessage{
-		Hash:       "blockhash123",
+		Hash:       validHash2,
 		Height:     200,
 		Header:     "0100000000000000",
 		Coinbase:   "01000000010000",
@@ -77,9 +86,9 @@ func TestBlockMessage_EncodeDecode(t *testing.T) {
 
 func TestSubtreeWorkMessage_EncodeDecode(t *testing.T) {
 	msg := &SubtreeWorkMessage{
-		BlockHash:    "blockhash789",
+		BlockHash:    validHash2,
 		BlockHeight:  850000,
-		SubtreeHash:  "subtree-hash-456",
+		SubtreeHash:  validHash3,
 		SubtreeIndex: 2,
 		DataHubURL:   "https://datahub.example.com/subtree/456",
 	}
@@ -147,7 +156,7 @@ func TestCallbackTopicMessage_Stump(t *testing.T) {
 		CallbackURL:  "https://example.com/cb",
 		Type:         CallbackStump,
 		TxID:         "txid1",
-		BlockHash:    "blockhash123",
+		BlockHash:    validHash1,
 		SubtreeIndex: 5,
 		StumpRef:     stumpRef,
 	}
@@ -168,7 +177,7 @@ func TestCallbackTopicMessage_Stump(t *testing.T) {
 	if decoded.TxID != "txid1" {
 		t.Errorf("txid mismatch: got %s", decoded.TxID)
 	}
-	if decoded.BlockHash != "blockhash123" {
+	if decoded.BlockHash != validHash1 {
 		t.Errorf("blockHash mismatch: got %s", decoded.BlockHash)
 	}
 	if decoded.SubtreeIndex != 5 {
@@ -240,7 +249,7 @@ func TestCallbackTopicMessage_BlockProcessed(t *testing.T) {
 	msg := &CallbackTopicMessage{
 		CallbackURL: "https://arcade.example.com/callback",
 		Type:        CallbackBlockProcessed,
-		BlockHash:   "000000000000000003a2d78e5f7c9012",
+		BlockHash:   validHash2,
 	}
 
 	data, err := msg.Encode()
@@ -267,5 +276,259 @@ func TestCallbackTopicMessage_BlockProcessed(t *testing.T) {
 	}
 	if decoded.StumpRef != "" {
 		t.Errorf("expected empty stumpRef, got %v", decoded.StumpRef)
+	}
+}
+
+// --- Validation (F-032) -------------------------------------------------
+
+// TestDecodeSubtreeMessage_Validation covers all the SubtreeMessage rejection
+// paths so a poison-pill message can never flow through the decoder.
+func TestDecodeSubtreeMessage_Validation(t *testing.T) {
+	cases := []struct {
+		name     string
+		raw      string
+		errField string
+	}{
+		{
+			name:     "empty hash",
+			raw:      `{"hash":"","dataHubUrl":"https://datahub.example.com/x"}`,
+			errField: "hash",
+		},
+		{
+			name:     "non-hex hash",
+			raw:      `{"hash":"zzzz000000000000000000000000000000000000000000000000000000000000","dataHubUrl":"https://datahub.example.com/x"}`,
+			errField: "hash",
+		},
+		{
+			name:     "short hash",
+			raw:      `{"hash":"deadbeef","dataHubUrl":"https://datahub.example.com/x"}`,
+			errField: "hash",
+		},
+		{
+			name:     "empty dataHubUrl",
+			raw:      `{"hash":"` + validHash1 + `","dataHubUrl":""}`,
+			errField: "dataHubUrl",
+		},
+		{
+			name:     "non-http dataHubUrl",
+			raw:      `{"hash":"` + validHash1 + `","dataHubUrl":"ftp://example.com/x"}`,
+			errField: "dataHubUrl",
+		},
+		{
+			name:     "garbage dataHubUrl",
+			raw:      `{"hash":"` + validHash1 + `","dataHubUrl":"::not a url::"}`,
+			errField: "dataHubUrl",
+		},
+		{
+			name:     "negative attemptCount",
+			raw:      `{"hash":"` + validHash1 + `","dataHubUrl":"https://example.com/x","attemptCount":-1}`,
+			errField: "attemptCount",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := DecodeSubtreeMessage([]byte(tc.raw))
+			assertInvalidMessageContains(t, err, tc.errField)
+		})
+	}
+}
+
+func TestDecodeBlockMessage_Validation(t *testing.T) {
+	cases := []struct {
+		name     string
+		raw      string
+		errField string
+	}{
+		{
+			name:     "empty hash",
+			raw:      `{"hash":"","dataHubUrl":"https://example.com/x"}`,
+			errField: "hash",
+		},
+		{
+			name:     "bad hex hash",
+			raw:      `{"hash":"not-a-hash","dataHubUrl":"https://example.com/x"}`,
+			errField: "hash",
+		},
+		{
+			name:     "empty dataHubUrl",
+			raw:      `{"hash":"` + validHash2 + `","dataHubUrl":""}`,
+			errField: "dataHubUrl",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := DecodeBlockMessage([]byte(tc.raw))
+			assertInvalidMessageContains(t, err, tc.errField)
+		})
+	}
+}
+
+func TestDecodeSubtreeWorkMessage_Validation(t *testing.T) {
+	cases := []struct {
+		name     string
+		raw      string
+		errField string
+	}{
+		{
+			name:     "empty blockHash",
+			raw:      `{"blockHash":"","subtreeHash":"` + validHash1 + `","dataHubUrl":"https://example.com/x"}`,
+			errField: "blockHash",
+		},
+		{
+			name:     "empty subtreeHash",
+			raw:      `{"blockHash":"` + validHash2 + `","subtreeHash":"","dataHubUrl":"https://example.com/x"}`,
+			errField: "subtreeHash",
+		},
+		{
+			name:     "bad subtreeHash hex",
+			raw:      `{"blockHash":"` + validHash2 + `","subtreeHash":"not-hex-not-hex-not-hex-not-hex-not-hex-not-hex-not-hex-not-hexx","dataHubUrl":"https://example.com/x"}`,
+			errField: "subtreeHash",
+		},
+		{
+			name:     "empty dataHubUrl",
+			raw:      `{"blockHash":"` + validHash2 + `","subtreeHash":"` + validHash1 + `","dataHubUrl":""}`,
+			errField: "dataHubUrl",
+		},
+		{
+			name:     "negative subtreeIndex",
+			raw:      `{"blockHash":"` + validHash2 + `","subtreeHash":"` + validHash1 + `","dataHubUrl":"https://example.com/x","subtreeIndex":-1}`,
+			errField: "subtreeIndex",
+		},
+		{
+			name:     "negative attemptCount",
+			raw:      `{"blockHash":"` + validHash2 + `","subtreeHash":"` + validHash1 + `","dataHubUrl":"https://example.com/x","attemptCount":-5}`,
+			errField: "attemptCount",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := DecodeSubtreeWorkMessage([]byte(tc.raw))
+			assertInvalidMessageContains(t, err, tc.errField)
+		})
+	}
+}
+
+func TestDecodeCallbackTopicMessage_Validation(t *testing.T) {
+	cases := []struct {
+		name     string
+		raw      string
+		errField string
+	}{
+		{
+			name:     "empty callbackUrl",
+			raw:      `{"callbackUrl":"","type":"SEEN_ON_NETWORK","txid":"t1"}`,
+			errField: "callbackUrl",
+		},
+		{
+			name:     "non-http callbackUrl",
+			raw:      `{"callbackUrl":"javascript:alert(1)","type":"SEEN_ON_NETWORK","txid":"t1"}`,
+			errField: "callbackUrl",
+		},
+		{
+			name:     "unknown type",
+			raw:      `{"callbackUrl":"https://example.com/cb","type":"NOT_A_REAL_TYPE","txid":"t1"}`,
+			errField: "type",
+		},
+		{
+			name:     "empty type",
+			raw:      `{"callbackUrl":"https://example.com/cb","type":"","txid":"t1"}`,
+			errField: "type",
+		},
+		{
+			name:     "negative retryCount",
+			raw:      `{"callbackUrl":"https://example.com/cb","type":"SEEN_ON_NETWORK","txid":"t1","retryCount":-1}`,
+			errField: "retryCount",
+		},
+		{
+			name:     "SEEN without txid or txids",
+			raw:      `{"callbackUrl":"https://example.com/cb","type":"SEEN_ON_NETWORK"}`,
+			errField: "type",
+		},
+		{
+			name:     "STUMP missing blockHash",
+			raw:      `{"callbackUrl":"https://example.com/cb","type":"STUMP","stumpRef":"abc"}`,
+			errField: "blockHash",
+		},
+		{
+			name:     "STUMP missing stumpRef",
+			raw:      `{"callbackUrl":"https://example.com/cb","type":"STUMP","blockHash":"` + validHash1 + `"}`,
+			errField: "stumpRef",
+		},
+		{
+			name:     "STUMP malformed blockHash",
+			raw:      `{"callbackUrl":"https://example.com/cb","type":"STUMP","blockHash":"deadbeef","stumpRef":"abc"}`,
+			errField: "blockHash",
+		},
+		{
+			name:     "BLOCK_PROCESSED missing blockHash",
+			raw:      `{"callbackUrl":"https://example.com/cb","type":"BLOCK_PROCESSED"}`,
+			errField: "blockHash",
+		},
+		{
+			name:     "BLOCK_PROCESSED malformed blockHash",
+			raw:      `{"callbackUrl":"https://example.com/cb","type":"BLOCK_PROCESSED","blockHash":"deadbeef"}`,
+			errField: "blockHash",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := DecodeCallbackTopicMessage([]byte(tc.raw))
+			assertInvalidMessageContains(t, err, tc.errField)
+		})
+	}
+}
+
+// TestDecodeCallbackTopicMessage_AcceptsBatchedSeen guards against regressing
+// to a stricter validator that would reject the batched (TxIDs-only) form
+// callers actually emit.
+func TestDecodeCallbackTopicMessage_AcceptsBatchedSeen(t *testing.T) {
+	raw := `{"callbackUrl":"https://example.com/cb","type":"SEEN_ON_NETWORK","txids":["t1","t2"]}`
+	if _, err := DecodeCallbackTopicMessage([]byte(raw)); err != nil {
+		t.Fatalf("expected batched SEEN to validate, got %v", err)
+	}
+}
+
+// TestDecodeReturnsErrInvalidMessage verifies callers can switch on the
+// sentinel via errors.Is so they can distinguish poison-pill from JSON-parse
+// failures (both are poison in practice; the consumer paths log+ack either
+// way).
+func TestDecodeReturnsErrInvalidMessage(t *testing.T) {
+	_, err := DecodeSubtreeMessage([]byte(`{"hash":"","dataHubUrl":""}`))
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	if !errors.Is(err, ErrInvalidMessage) {
+		t.Fatalf("expected error to wrap ErrInvalidMessage, got %v", err)
+	}
+}
+
+// TestDecodeRejectsMalformedJSON confirms json.Unmarshal errors also surface
+// as a non-nil error from the decoder (the existing behavior must be
+// preserved).
+func TestDecodeRejectsMalformedJSON(t *testing.T) {
+	if _, err := DecodeSubtreeMessage([]byte(`not-json`)); err == nil {
+		t.Fatal("expected JSON unmarshal error, got nil")
+	}
+	if _, err := DecodeBlockMessage([]byte(`{`)); err == nil {
+		t.Fatal("expected JSON unmarshal error, got nil")
+	}
+	if _, err := DecodeSubtreeWorkMessage([]byte(`[]`)); err == nil {
+		t.Fatal("expected JSON unmarshal error, got nil")
+	}
+	if _, err := DecodeCallbackTopicMessage([]byte(`{"type":}`)); err == nil {
+		t.Fatal("expected JSON unmarshal error, got nil")
+	}
+}
+
+func assertInvalidMessageContains(t *testing.T, err error, field string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected validation error mentioning %q, got nil", field)
+	}
+	if !errors.Is(err, ErrInvalidMessage) {
+		t.Fatalf("expected error to wrap ErrInvalidMessage, got %v", err)
+	}
+	if !strings.Contains(err.Error(), field) {
+		t.Errorf("expected error to mention field %q, got %v", field, err)
 	}
 }

--- a/internal/p2p/client_test.go
+++ b/internal/p2p/client_test.go
@@ -94,7 +94,7 @@ func TestHandleSubtreeMessage_ValidMessage(t *testing.T) {
 	client, mockProducer, _ := newTestClient(t)
 
 	msg := teranode.SubtreeMessage{
-		Hash:       "subtree-abc",
+		Hash:       "00000000000000000000000000000000000000000000000000000000000000ab",
 		DataHubURL: "https://datahub.example.com/subtree/abc",
 		PeerID:     "peer1",
 		ClientName: "teranode-v1",
@@ -114,7 +114,7 @@ func TestHandleSubtreeMessage_ValidMessage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to encode key: %v", err)
 	}
-	if string(keyBytes) != "subtree-abc" {
+	if string(keyBytes) != "00000000000000000000000000000000000000000000000000000000000000ab" {
 		t.Errorf("expected key 'subtree-abc', got %q", string(keyBytes))
 	}
 
@@ -127,7 +127,7 @@ func TestHandleSubtreeMessage_ValidMessage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to decode published subtree message: %v", err)
 	}
-	if decoded.Hash != "subtree-abc" {
+	if decoded.Hash != "00000000000000000000000000000000000000000000000000000000000000ab" {
 		t.Errorf("expected hash 'subtree-abc', got %q", decoded.Hash)
 	}
 	if decoded.DataHubURL != "https://datahub.example.com/subtree/abc" {
@@ -163,7 +163,7 @@ func TestHandleBlockMessage_ValidMessage(t *testing.T) {
 	client, _, mockProducer := newTestClient(t)
 
 	msg := teranode.BlockMessage{
-		Hash:       "00000000abc123",
+		Hash:       "00000000abc1230000000000000000000000000000000000000000000000abc1",
 		Height:     800000,
 		Header:     "0100000000000000",
 		Coinbase:   "01000000010000",
@@ -186,7 +186,7 @@ func TestHandleBlockMessage_ValidMessage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to encode key: %v", err)
 	}
-	if string(keyBytes) != "00000000abc123" {
+	if string(keyBytes) != "00000000abc1230000000000000000000000000000000000000000000000abc1" {
 		t.Errorf("expected key '00000000abc123', got %q", string(keyBytes))
 	}
 
@@ -199,7 +199,7 @@ func TestHandleBlockMessage_ValidMessage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to decode published block message: %v", err)
 	}
-	if decoded.Hash != "00000000abc123" {
+	if decoded.Hash != "00000000abc1230000000000000000000000000000000000000000000000abc1" {
 		t.Errorf("expected hash '00000000abc123', got %q", decoded.Hash)
 	}
 	if decoded.Height != 800000 {

--- a/internal/subtree/processor_test.go
+++ b/internal/subtree/processor_test.go
@@ -1203,7 +1203,7 @@ func TestHandleTransientFailure_RoutesToDLQAtMaxAttempts(t *testing.T) {
 	p.Logger = logger
 
 	subtreeMsg := &kafka.SubtreeMessage{
-		Hash:       "subtree-hash-abc",
+		Hash:       "0000000000000000000000000000000000000000000000000000000000abcabc",
 		DataHubURL: "http://datahub.example.com",
 	}
 	cause := errors.New("datahub 404")
@@ -1546,7 +1546,7 @@ func TestHandleMessage_CallbackPublishFailure_RoutesToRetry(t *testing.T) {
 	p.Logger = logger
 
 	subtreeMsg := &kafka.SubtreeMessage{
-		Hash:         "subtree-cb-fail",
+		Hash:         "00000000000000000000000000000000000000000000000000000000cbfa1100",
 		DataHubURL:   dataHubServer.URL,
 		AttemptCount: 0,
 	}
@@ -1677,7 +1677,7 @@ func TestHandleMessage_CachedLookupFailure_RoutesToRetryAndSkipsDedup(t *testing
 	p.Logger = logger
 
 	subtreeMsg := &kafka.SubtreeMessage{
-		Hash:         "subtree-cached-lookup-fail",
+		Hash:         "00000000000000000000000000000000000000000000000000000000cac1ed00",
 		DataHubURL:   dataHubServer.URL,
 		AttemptCount: 0,
 	}
@@ -1834,7 +1834,7 @@ func TestHandleMessage_SeenCounterIncrementFailure_RoutesToRetryAndSkipsDedup(t 
 	p.Logger = logger
 
 	subtreeMsg := &kafka.SubtreeMessage{
-		Hash:         "subtree-counter-fail",
+		Hash:         "0000000000000000000000000000000000000000000000000000000000c0fa11",
 		DataHubURL:   dataHubServer.URL,
 		AttemptCount: 0,
 	}
@@ -1917,7 +1917,7 @@ func TestHandleMessage_SeenCounterSuccess_UpdatesDedup(t *testing.T) {
 	p.Logger = logger
 
 	subtreeMsg := &kafka.SubtreeMessage{
-		Hash:         "subtree-counter-ok",
+		Hash:         "00000000000000000000000000000000000000000000000000000000000c0c00",
 		DataHubURL:   dataHubServer.URL,
 		AttemptCount: 0,
 	}


### PR DESCRIPTION
## Summary
- F-032 (issue #41): JSON decoders for kafka messages previously returned success even when required fields (hashes, callback URLs, DataHub URLs, types, retry counters) were empty or malformed. Poison-pill payloads could then flow into HTTP fetches, dedup keys, and store updates before failing later with less precise errors.
- Add per-message-type `Validate()` helpers plus a sentinel `kafka.ErrInvalidMessage`. Each `Decode*Message` runs the validator and returns a wrapped error naming the offending field. URL fields go through `url.ParseRequestURI` and are required to be `http`/`https`. Hash fields require non-empty 64-char hex (matching `chainhash.HashSize`).
- `CallbackTopicMessage.Validate()` enforces per-Type required fields: SEEN_* needs `txid` or non-empty `txids`; STUMP needs `blockHash` + `stumpRef`; BLOCK_PROCESSED needs `blockHash`. Unknown `type` values are rejected.
- The block-processor consumer (`internal/block/processor.go`) is updated to drop on decode error (log + return nil) matching the existing subtree-fetcher / subtree-worker / callback-delivery pattern. Re-driving a malformed payload cannot succeed; returning the error would stall the partition forever.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/kafka/... -count=1 -race` (all validation cases pass, existing encode/decode round-trips pass)
- [x] `go test ./... -count=1` (full repo green; tests with placeholder hashes updated to valid 64-char hex via a `testHashFromLabel` helper)

Closes #41