### PR TITLE
feat: accept and forward arcade callback token end-to-end

### DIFF
--- a/internal/api/api_integration_test.go
+++ b/internal/api/api_integration_test.go
@@ -95,8 +95,8 @@ func TestAPIIntegration_WatchValidRequest(t *testing.T) {
 	if len(urls) != 1 {
 		t.Fatalf("expected 1 callback in store, got %d", len(urls))
 	}
-	if urls[0] != callbackURL {
-		t.Fatalf("expected callback %q, got %q", callbackURL, urls[0])
+	if urls[0].URL != callbackURL {
+		t.Fatalf("expected callback %q, got %q", callbackURL, urls[0].URL)
 	}
 }
 
@@ -170,8 +170,8 @@ func TestAPIIntegration_WatchMultipleCallbacksSameTxid(t *testing.T) {
 
 	// The store uses ordered list, so verify sorted order.
 	for i, u := range urls {
-		if u != callbacks[i] {
-			t.Errorf("callback[%d] = %q, want %q", i, u, callbacks[i])
+		if u.URL != callbacks[i] {
+			t.Errorf("callback[%d] = %q, want %q", i, u.URL, callbacks[i])
 		}
 	}
 }

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -14,15 +14,27 @@ import (
 
 var txidRegex = regexp.MustCompile(`^[a-fA-F0-9]{64}$`)
 
+// maxCallbackTokenLen caps the bearer token we accept on /watch. Tokens are
+// short shared secrets (typically 32–64 bytes); rejecting absurd values is
+// cheap insurance against a buggy or hostile arcade deployment trying to
+// store arbitrary blobs in our registration record.
+const maxCallbackTokenLen = 4096
+
 func handleDashboard(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_, _ = w.Write(dashboardHTML)
 }
 
 // WatchRequest represents the POST /watch request body.
+//
+// CallbackToken is the bearer token arcade expects on its callback endpoint
+// (Authorization: Bearer <token>). The field is optional for backwards
+// compatibility with arcade deployments that haven't yet shipped the matching
+// token-passing change — empty token means "send no Authorization header".
 type WatchRequest struct {
-	TxID        string `json:"txid"`
-	CallbackURL string `json:"callbackUrl"`
+	TxID          string `json:"txid"`
+	CallbackURL   string `json:"callbackUrl"`
+	CallbackToken string `json:"callbackToken,omitempty"`
 }
 
 // WatchResponse represents the POST /watch response body.
@@ -87,8 +99,19 @@ func (s *Server) handleWatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Defensive cap on the optional bearer token. We don't validate the
+	// content (it's an opaque shared secret between merkle-service and
+	// arcade) but we refuse anything large enough to look like an attempt to
+	// stuff a payload into the registration record.
+	if len(req.CallbackToken) > maxCallbackTokenLen {
+		writeJSON(w, http.StatusBadRequest, ErrorResponse{
+			Error: "invalid callbackToken: exceeds maximum length",
+		})
+		return
+	}
+
 	// Store registration
-	if err := s.regStore.Add(req.TxID, req.CallbackURL); err != nil {
+	if err := s.regStore.Add(req.TxID, req.CallbackURL, req.CallbackToken); err != nil {
 		// F-050: surface the per-txid callback cap as a 429 so the caller can
 		// distinguish a quota error from a transient backend failure and back
 		// off accordingly. The body still uses the standard ErrorResponse shape.
@@ -105,9 +128,11 @@ func (s *Server) handleWatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Register callback URL in the broadcast registry.
+	// Register callback URL in the broadcast registry. The token is stored
+	// alongside so BLOCK_PROCESSED fan-out (which iterates urlRegistry rather
+	// than the per-txid map) can attach the same Authorization header.
 	if s.urlRegistry != nil {
-		if err := s.urlRegistry.Add(req.CallbackURL); err != nil {
+		if err := s.urlRegistry.Add(req.CallbackURL, req.CallbackToken); err != nil {
 			s.Logger.Warn("failed to add callback URL to registry", "url", req.CallbackURL, "error", err)
 		}
 	}
@@ -151,15 +176,16 @@ func (s *Server) handleLookup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	urls, err := s.regStore.Get(txid)
+	entries, err := s.regStore.Get(txid)
 	if err != nil {
 		s.Logger.Error("failed to lookup registration", "txid", txid, "error", err)
 		writeJSON(w, http.StatusInternalServerError, ErrorResponse{Error: "internal server error"})
 		return
 	}
 
-	if urls == nil {
-		urls = []string{}
+	urls := make([]string, 0, len(entries))
+	for _, e := range entries {
+		urls = append(urls, e.URL)
 	}
 
 	writeJSON(w, http.StatusOK, LookupResponse{

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -17,25 +17,25 @@ import (
 
 // fakeRegStore is a minimal RegistrationStore stub used by tests. When
 // addErr is non-nil, Add returns it (so error-mapping behavior can be
-// exercised). Otherwise Add records each (txid, url) pair in `added`.
+// exercised). Otherwise Add records each (txid, url, token) tuple in `added`.
 type fakeRegStore struct {
 	addErr error
-	added  []struct{ txid, url string }
+	added  []struct{ txid, url, token string }
 }
 
-func (f *fakeRegStore) Add(txid, url string) error {
+func (f *fakeRegStore) Add(txid, url, token string) error {
 	if f.addErr != nil {
 		return f.addErr
 	}
-	f.added = append(f.added, struct{ txid, url string }{txid, url})
+	f.added = append(f.added, struct{ txid, url, token string }{txid, url, token})
 	return nil
 }
 
-func (f *fakeRegStore) Get(string) ([]string, error) {
+func (f *fakeRegStore) Get(string) ([]store.CallbackEntry, error) {
 	return nil, nil
 }
 
-func (f *fakeRegStore) BatchGet([]string) (map[string][]string, error) {
+func (f *fakeRegStore) BatchGet([]string) (map[string][]store.CallbackEntry, error) {
 	return nil, nil
 }
 func (f *fakeRegStore) UpdateTTL(string, time.Duration) error        { return nil }
@@ -247,6 +247,71 @@ func TestHandleWatch_RejectsBadScheme(t *testing.T) {
 				t.Fatalf("expected 400, got %d (%s)", w.Code, w.Body.String())
 			}
 		})
+	}
+}
+
+// TestHandleWatch_AcceptsCallbackToken verifies that /watch threads the
+// optional callbackToken JSON field through to the registration store. The
+// store sees the exact bytes the caller sent.
+func TestHandleWatch_AcceptsCallbackToken(t *testing.T) {
+	fake := &fakeRegStore{}
+	router, _ := newTestRouterWithRegStore(fake)
+	const txid = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+	const token = "tok-arcade-mainnet-v1" //nolint:gosec // test fixture, not a real credential
+	body := `{"txid":"` + txid + `","callbackUrl":"https://1.1.1.1/cb","callbackToken":"` + token + `"}`
+	w := postWatch(router, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	if len(fake.added) != 1 {
+		t.Fatalf("expected 1 store.Add, got %d", len(fake.added))
+	}
+	if fake.added[0].token != token {
+		t.Fatalf("expected token %q persisted, got %q", token, fake.added[0].token)
+	}
+}
+
+// TestHandleWatch_EmptyCallbackTokenIsAccepted verifies that omitting
+// callbackToken is permitted and the store sees an empty string. Empty
+// token preserves today's no-Authorization behavior for arcade
+// deployments that haven't shipped the matching token-passing change.
+func TestHandleWatch_EmptyCallbackTokenIsAccepted(t *testing.T) {
+	fake := &fakeRegStore{}
+	router, _ := newTestRouterWithRegStore(fake)
+	const txid = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+	body := `{"txid":"` + txid + `","callbackUrl":"https://1.1.1.1/cb"}`
+	w := postWatch(router, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if len(fake.added) != 1 {
+		t.Fatalf("expected 1 store.Add, got %d", len(fake.added))
+	}
+	if fake.added[0].token != "" {
+		t.Fatalf("expected empty token, got %q", fake.added[0].token)
+	}
+}
+
+// TestHandleWatch_OverlongCallbackTokenRejected verifies the defensive
+// length cap on callbackToken. Tokens are short shared secrets; refusing
+// absurd values keeps a buggy or hostile arcade deployment from stuffing
+// payloads into the registration record.
+func TestHandleWatch_OverlongCallbackTokenRejected(t *testing.T) {
+	fake := &fakeRegStore{}
+	router, _ := newTestRouterWithRegStore(fake)
+	const txid = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+	// One byte over the cap.
+	huge := make([]byte, maxCallbackTokenLen+1)
+	for i := range huge {
+		huge[i] = 'a'
+	}
+	body := `{"txid":"` + txid + `","callbackUrl":"https://1.1.1.1/cb","callbackToken":"` + string(huge) + `"}`
+	w := postWatch(router, body)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for overlong token, got %d", w.Code)
+	}
+	if len(fake.added) != 0 {
+		t.Fatalf("expected no store.Add on rejection, got %d", len(fake.added))
 	}
 }
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -41,7 +41,7 @@ func (f *fakeRegStore) BatchGet([]string) (map[string][]store.CallbackEntry, err
 func (f *fakeRegStore) UpdateTTL(string, time.Duration) error        { return nil }
 func (f *fakeRegStore) BatchUpdateTTL([]string, time.Duration) error { return nil }
 
-func newTestRouterWithRegStore(rs store.RegistrationStore) (*chi.Mux, *Server) {
+func newTestRouterWithRegStore(rs store.RegistrationStore) *chi.Mux {
 	router := chi.NewRouter()
 	s := &Server{regStore: rs}
 	s.InitBase("test")
@@ -49,7 +49,7 @@ func newTestRouterWithRegStore(rs store.RegistrationStore) (*chi.Mux, *Server) {
 	router.Post("/watch", s.handleWatch)
 	router.Get("/health", s.handleHealth)
 	router.Get("/api/lookup/{txid}", s.handleLookup)
-	return router, s
+	return router
 }
 
 func newTestRouter() *chi.Mux {
@@ -163,7 +163,7 @@ func TestHandleDashboard(t *testing.T) {
 // translates store.ErrMaxCallbacksPerTxIDExceeded to HTTP 429 with a clear
 // JSON error body. F-050 / issue #27.
 func TestHandleWatch_MaxCallbacksReturns429(t *testing.T) {
-	router, _ := newTestRouterWithRegStore(&fakeRegStore{addErr: store.ErrMaxCallbacksPerTxIDExceeded})
+	router := newTestRouterWithRegStore(&fakeRegStore{addErr: store.ErrMaxCallbacksPerTxIDExceeded})
 	// IP literal avoids DNS lookup so the test runs in offline/sandbox
 	// environments. 1.1.1.1 is public and not on the SSRF deny-list.
 	w := postWatch(router, `{"txid":"a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2","callbackUrl":"https://1.1.1.1/cb"}`)
@@ -255,7 +255,7 @@ func TestHandleWatch_RejectsBadScheme(t *testing.T) {
 // store sees the exact bytes the caller sent.
 func TestHandleWatch_AcceptsCallbackToken(t *testing.T) {
 	fake := &fakeRegStore{}
-	router, _ := newTestRouterWithRegStore(fake)
+	router := newTestRouterWithRegStore(fake)
 	const txid = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
 	const token = "tok-arcade-mainnet-v1" //nolint:gosec // test fixture, not a real credential
 	body := `{"txid":"` + txid + `","callbackUrl":"https://1.1.1.1/cb","callbackToken":"` + token + `"}`
@@ -277,7 +277,7 @@ func TestHandleWatch_AcceptsCallbackToken(t *testing.T) {
 // deployments that haven't shipped the matching token-passing change.
 func TestHandleWatch_EmptyCallbackTokenIsAccepted(t *testing.T) {
 	fake := &fakeRegStore{}
-	router, _ := newTestRouterWithRegStore(fake)
+	router := newTestRouterWithRegStore(fake)
 	const txid = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
 	body := `{"txid":"` + txid + `","callbackUrl":"https://1.1.1.1/cb"}`
 	w := postWatch(router, body)
@@ -298,7 +298,7 @@ func TestHandleWatch_EmptyCallbackTokenIsAccepted(t *testing.T) {
 // payloads into the registration record.
 func TestHandleWatch_OverlongCallbackTokenRejected(t *testing.T) {
 	fake := &fakeRegStore{}
-	router, _ := newTestRouterWithRegStore(fake)
+	router := newTestRouterWithRegStore(fake)
 	const txid = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
 	// One byte over the cap.
 	huge := make([]byte, maxCallbackTokenLen+1)

--- a/internal/block/subtree_processor.go
+++ b/internal/block/subtree_processor.go
@@ -31,6 +31,13 @@ type RegCache interface {
 type SubtreeResult struct {
 	// CallbackGroups maps callbackURL → list of matched txids.
 	CallbackGroups map[string][]string
+	// CallbackTokens maps callbackURL → the bearer token registered for that
+	// URL on /watch. The publisher attaches the token to each
+	// CallbackTopicMessage so deliveries to arcade carry the
+	// `Authorization: Bearer <token>` header arcade requires. URLs without a
+	// configured token map to "" (no Authorization header) which preserves
+	// pre-token-rollout behavior.
+	CallbackTokens map[string]string
 	// SubtreeHash is the hash of the processed subtree.
 	SubtreeHash string
 	// StumpData is the serialized STUMP binary (BRC-0074 format).
@@ -108,6 +115,25 @@ func ProcessBlockSubtree(
 		return nil, nil
 	}
 
+	// Reduce CallbackEntry tuples back into the (txid → urls) shape that
+	// the STUMP grouping logic expects, while capturing the latest token
+	// per URL on the side. If multiple txids have the same callbackURL with
+	// different tokens (e.g. mid-rotation), the last token observed wins —
+	// in practice every txid registered against a given URL went through
+	// the same /watch payload, so they will agree.
+	registrationsByTxID := make(map[string][]string, len(registrations))
+	urlTokens := make(map[string]string)
+	for txid, entries := range registrations {
+		urls := make([]string, 0, len(entries))
+		for _, e := range entries {
+			urls = append(urls, e.URL)
+			if _, ok := urlTokens[e.URL]; !ok || e.Token != "" {
+				urlTokens[e.URL] = e.Token
+			}
+		}
+		registrationsByTxID[txid] = urls
+	}
+
 	// 6.5: Build full merkle tree from subtree nodes.
 	merkleTreeStore, err := subtreepkg.BuildMerkleTreeStoreFromBytes(nodes)
 	if err != nil {
@@ -148,7 +174,7 @@ func ProcessBlockSubtree(
 	stumpData := s.Encode()
 
 	// 6.9: Group txids by callback URL.
-	callbackGroups := stump.GroupByCallback(registrations)
+	callbackGroups := stump.GroupByCallback(registrationsByTxID)
 
 	// 6.11: Batch update registration TTLs (skip if postMineTTLSec is 0).
 	if postMineTTLSec > 0 {
@@ -170,12 +196,13 @@ func ProcessBlockSubtree(
 
 	return &SubtreeResult{
 		CallbackGroups: callbackGroups,
+		CallbackTokens: urlTokens,
 		SubtreeHash:    subtreeHash,
 		StumpData:      stumpData,
 	}, nil
 }
 
-// lookupRegistrations resolves txid → callbackURLs using the in-process
+// lookupRegistrations resolves txid → []CallbackEntry using the in-process
 // registration cache (when set) to filter out the unregistered majority before
 // issuing a single bounded BatchGet against Aerospike. The semaphore caps the
 // number of concurrent BatchGets across all callers in the process.
@@ -185,9 +212,9 @@ func lookupRegistrations(
 	regStore store.RegistrationStore,
 	regCache RegCache,
 	batchSem chan struct{},
-) (map[string][]string, error) {
+) (map[string][]store.CallbackEntry, error) {
 	if len(txids) == 0 {
-		return map[string][]string{}, nil
+		return map[string][]store.CallbackEntry{}, nil
 	}
 
 	uncached := txids
@@ -207,7 +234,7 @@ func lookupRegistrations(
 	}
 
 	if len(lookup) == 0 {
-		return map[string][]string{}, nil
+		return map[string][]store.CallbackEntry{}, nil
 	}
 
 	registered, err := batchGetWithSem(ctx, lookup, regStore, batchSem)
@@ -241,7 +268,7 @@ func batchGetWithSem(
 	txids []string,
 	regStore store.RegistrationStore,
 	batchSem chan struct{},
-) (map[string][]string, error) {
+) (map[string][]store.CallbackEntry, error) {
 	if batchSem != nil {
 		select {
 		case batchSem <- struct{}{}:

--- a/internal/block/subtree_worker.go
+++ b/internal/block/subtree_worker.go
@@ -475,11 +475,12 @@ func (s *SubtreeWorkerService) publishSubtreeCallbacks(workMsg *kafka.SubtreeWor
 	var firstErr error
 	for callbackURL := range result.CallbackGroups {
 		msg := &kafka.CallbackTopicMessage{
-			CallbackURL:  callbackURL,
-			Type:         kafka.CallbackStump,
-			BlockHash:    workMsg.BlockHash,
-			SubtreeIndex: workMsg.SubtreeIndex,
-			StumpRef:     stumpRef,
+			CallbackURL:   callbackURL,
+			CallbackToken: result.CallbackTokens[callbackURL],
+			Type:          kafka.CallbackStump,
+			BlockHash:     workMsg.BlockHash,
+			SubtreeIndex:  workMsg.SubtreeIndex,
+			StumpRef:      stumpRef,
 		}
 		data, encErr := msg.Encode()
 		if encErr != nil {
@@ -523,12 +524,12 @@ func (s *SubtreeWorkerService) emitBlockProcessed(blockHash string) error {
 		return nil
 	}
 
-	urls, err := s.urlRegistry.GetAll()
+	entries, err := s.urlRegistry.GetAll()
 	if err != nil {
 		s.Logger.Error("failed to get callback URLs for BLOCK_PROCESSED", "error", err)
 		return fmt.Errorf("getting callback URLs for BLOCK_PROCESSED on block %s: %w", blockHash, err)
 	}
-	if len(urls) == 0 {
+	if len(entries) == 0 {
 		return nil
 	}
 
@@ -538,30 +539,31 @@ func (s *SubtreeWorkerService) emitBlockProcessed(blockHash string) error {
 	// this attempt). Matches publishSubtreeCallbacks's partial-success
 	// pattern from PR #77.
 	var firstErr error
-	for _, callbackURL := range urls {
+	for _, entry := range entries {
 		msg := &kafka.CallbackTopicMessage{
-			CallbackURL: callbackURL,
-			Type:        kafka.CallbackBlockProcessed,
-			BlockHash:   blockHash,
+			CallbackURL:   entry.URL,
+			CallbackToken: entry.Token,
+			Type:          kafka.CallbackBlockProcessed,
+			BlockHash:     blockHash,
 		}
 		data, encErr := msg.Encode()
 		if encErr != nil {
 			s.Logger.Error("failed to encode BLOCK_PROCESSED message",
-				"callbackURL", callbackURL,
+				"callbackURL", entry.URL,
 				"error", encErr,
 			)
 			if firstErr == nil {
-				firstErr = fmt.Errorf("encoding BLOCK_PROCESSED for %s: %w", callbackURL, encErr)
+				firstErr = fmt.Errorf("encoding BLOCK_PROCESSED for %s: %w", entry.URL, encErr)
 			}
 			continue
 		}
-		if pubErr := s.callbackProducer.PublishWithHashKey(callbackURL, data); pubErr != nil {
+		if pubErr := s.callbackProducer.PublishWithHashKey(entry.URL, data); pubErr != nil {
 			s.Logger.Error("failed to publish BLOCK_PROCESSED callback",
-				"callbackURL", callbackURL,
+				"callbackURL", entry.URL,
 				"error", pubErr,
 			)
 			if firstErr == nil {
-				firstErr = fmt.Errorf("publishing BLOCK_PROCESSED for %s: %w", callbackURL, pubErr)
+				firstErr = fmt.Errorf("publishing BLOCK_PROCESSED for %s: %w", entry.URL, pubErr)
 			}
 		}
 	}
@@ -569,7 +571,7 @@ func (s *SubtreeWorkerService) emitBlockProcessed(blockHash string) error {
 	if firstErr == nil {
 		s.Logger.Info("emitted BLOCK_PROCESSED callbacks",
 			"blockHash", blockHash,
-			"callbackURLs", len(urls),
+			"callbackURLs", len(entries),
 		)
 	}
 	return firstErr

--- a/internal/block/subtree_worker_handle_message_test.go
+++ b/internal/block/subtree_worker_handle_message_test.go
@@ -183,18 +183,36 @@ func (c *countingSubtreeCounter) value(blockHash string) int {
 }
 
 // staticRegStore is a RegistrationStore that returns a pre-configured set of
-// callback URLs for any txid lookup. Enables ProcessBlockSubtree to produce
-// non-empty CallbackGroups without reaching for Aerospike.
+// callback URLs (with optional tokens) for any txid lookup. Enables
+// ProcessBlockSubtree to produce non-empty CallbackGroups without reaching
+// for Aerospike.
 type staticRegStore struct {
-	urls []string
+	urls    []string
+	tokens  map[string]string
+	entries []store.CallbackEntry
 }
 
-func (s *staticRegStore) Add(txid, callbackURL string) error { return nil }
-func (s *staticRegStore) Get(txid string) ([]string, error)  { return s.urls, nil }
-func (s *staticRegStore) BatchGet(txids []string) (map[string][]string, error) {
-	out := make(map[string][]string, len(txids))
+func (s *staticRegStore) lookup() []store.CallbackEntry {
+	if s.entries != nil {
+		return s.entries
+	}
+	out := make([]store.CallbackEntry, 0, len(s.urls))
+	for _, u := range s.urls {
+		out = append(out, store.CallbackEntry{URL: u, Token: s.tokens[u]})
+	}
+	return out
+}
+
+func (s *staticRegStore) Add(txid, callbackURL, callbackToken string) error { return nil }
+
+func (s *staticRegStore) Get(txid string) ([]store.CallbackEntry, error) {
+	return s.lookup(), nil
+}
+
+func (s *staticRegStore) BatchGet(txids []string) (map[string][]store.CallbackEntry, error) {
+	out := make(map[string][]store.CallbackEntry, len(txids))
 	for _, txid := range txids {
-		out[txid] = s.urls
+		out[txid] = s.lookup()
 	}
 	return out, nil
 }
@@ -676,15 +694,20 @@ func TestHandleMessage_HappyPath_DecrementToZeroEmitsBlockProcessed(t *testing.T
 // "registry lookup error during emit" path.
 type fakeURLRegistry struct {
 	urls      []string
+	tokens    map[string]string
 	getAllErr error
 }
 
-func (f *fakeURLRegistry) Add(callbackURL string) error { return nil }
-func (f *fakeURLRegistry) GetAll() ([]string, error) {
+func (f *fakeURLRegistry) Add(callbackURL, callbackToken string) error { return nil }
+func (f *fakeURLRegistry) GetAll() ([]store.CallbackEntry, error) {
 	if f.getAllErr != nil {
 		return nil, f.getAllErr
 	}
-	return f.urls, nil
+	out := make([]store.CallbackEntry, 0, len(f.urls))
+	for _, u := range f.urls {
+		out = append(out, store.CallbackEntry{URL: u, Token: f.tokens[u]})
+	}
+	return out, nil
 }
 
 // --- F-014 BLOCK_PROCESSED publish-failure tests ---

--- a/internal/callback/delivery.go
+++ b/internal/callback/delivery.go
@@ -529,7 +529,12 @@ func (d *DeliveryService) heartbeat(ctx context.Context) {
 	}
 }
 
-// deliverCallback makes an HTTP POST to the callback URL with the CallbackMessage payload.
+// deliverCallback makes an HTTP POST to the callback URL with the
+// CallbackMessage payload. When msg.CallbackToken is non-empty the request
+// carries `Authorization: Bearer <token>` — arcade's callback endpoint
+// requires this header. An empty token sends the request unauthenticated,
+// preserving today's behavior for deployments where arcade has not yet
+// shipped its matching token-passing change.
 func (d *DeliveryService) deliverCallback(ctx context.Context, msg *kafka.CallbackTopicMessage) error {
 	payload := callbackPayload{
 		Type:         string(msg.Type),
@@ -572,6 +577,13 @@ func (d *DeliveryService) deliverCallback(ctx context.Context, msg *kafka.Callba
 	idempotencyKey := buildIdempotencyKey(msg)
 	if idempotencyKey != "" {
 		req.Header.Set("X-Idempotency-Key", idempotencyKey)
+	}
+
+	// Bearer token authentication when arcade configured one for this URL.
+	// Empty token → no Authorization header so older deployments without the
+	// matching arcade-side token check continue to work.
+	if msg.CallbackToken != "" {
+		req.Header.Set("Authorization", "Bearer "+msg.CallbackToken)
 	}
 
 	start := time.Now()

--- a/internal/callback/delivery_test.go
+++ b/internal/callback/delivery_test.go
@@ -677,6 +677,66 @@ func TestDedupKeyForMessage(t *testing.T) {
 	}
 }
 
+// TestDeliverCallback_AuthorizationHeaderWhenTokenSet asserts the new
+// callback-token plumbing: a non-empty CallbackTopicMessage.CallbackToken
+// produces an `Authorization: Bearer <token>` header on the outbound POST.
+// arcade's callback endpoint requires this header — without it every
+// callback would 401.
+func TestDeliverCallback_AuthorizationHeaderWhenTokenSet(t *testing.T) {
+	var receivedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := defaultTestConfig()
+	ds, _, _ := newTestDeliveryService(t, cfg, server.Client())
+
+	const token = "tok-arcade-mainnet" //nolint:gosec // test fixture, not a real credential
+	msg := &kafka.CallbackTopicMessage{
+		CallbackURL:   server.URL + "/callback",
+		CallbackToken: token,
+		Type:          kafka.CallbackSeenOnNetwork,
+		TxID:          "tx-auth",
+	}
+	if err := ds.deliverCallback(context.Background(), msg); err != nil {
+		t.Fatalf("expected successful delivery, got error: %v", err)
+	}
+	if got, want := receivedAuth, "Bearer "+token; got != want {
+		t.Errorf("expected Authorization=%q, got %q", want, got)
+	}
+}
+
+// TestDeliverCallback_NoAuthorizationHeaderWhenTokenEmpty asserts the
+// back-compat invariant: when CallbackToken is empty, NO Authorization
+// header is set. This preserves today's behavior for arcade deployments
+// that haven't shipped the matching token-passing change.
+func TestDeliverCallback_NoAuthorizationHeaderWhenTokenEmpty(t *testing.T) {
+	var hadAuth bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, hadAuth = r.Header["Authorization"]
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := defaultTestConfig()
+	ds, _, _ := newTestDeliveryService(t, cfg, server.Client())
+
+	msg := &kafka.CallbackTopicMessage{
+		CallbackURL: server.URL + "/callback",
+		Type:        kafka.CallbackSeenOnNetwork,
+		TxID:        "tx-no-auth",
+		// CallbackToken intentionally left empty.
+	}
+	if err := ds.deliverCallback(context.Background(), msg); err != nil {
+		t.Fatalf("expected successful delivery, got error: %v", err)
+	}
+	if hadAuth {
+		t.Errorf("expected NO Authorization header for empty token, got one")
+	}
+}
+
 func TestDeliverCallback_BlockProcessedPayload(t *testing.T) {
 	var receivedBody []byte
 

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -131,7 +131,7 @@ func determineNamespace(t *testing.T) string {
 		}
 		// Try a write to verify the namespace is usable.
 		regStore := store.NewRegistrationStore(client, "ns_probe", 1, 50, 0, testLogger())
-		if err := regStore.Add("probe_txid", "http://probe"); err != nil {
+		if err := regStore.Add("probe_txid", "http://probe", ""); err != nil {
 			client.Close()
 			continue
 		}
@@ -222,7 +222,7 @@ func TestSeenOnNetworkCallback(t *testing.T) {
 	defer mockServer.Close()
 
 	callbackURL := mockServer.URL + "/callback"
-	if err := regStore.Add(txid, callbackURL); err != nil {
+	if err := regStore.Add(txid, callbackURL, ""); err != nil {
 		t.Fatalf("failed to register txid: %v", err)
 	}
 
@@ -286,7 +286,7 @@ func TestMinedCallbackWithSTUMP(t *testing.T) {
 	defer mockServer.Close()
 
 	callbackURL := mockServer.URL + "/mined-callback"
-	if err := regStore.Add(txid, callbackURL); err != nil {
+	if err := regStore.Add(txid, callbackURL, ""); err != nil {
 		t.Fatalf("failed to register txid: %v", err)
 	}
 
@@ -361,10 +361,10 @@ func TestMultipleCallbacks(t *testing.T) {
 	callbackURL1 := mockServer1.URL + "/cb1"
 	callbackURL2 := mockServer2.URL + "/cb2"
 
-	if err := regStore.Add(txid, callbackURL1); err != nil {
+	if err := regStore.Add(txid, callbackURL1, ""); err != nil {
 		t.Fatalf("failed to register txid with callback1: %v", err)
 	}
-	if err := regStore.Add(txid, callbackURL2); err != nil {
+	if err := regStore.Add(txid, callbackURL2, ""); err != nil {
 		t.Fatalf("failed to register txid with callback2: %v", err)
 	}
 
@@ -439,7 +439,7 @@ func TestSeenMultipleNodes(t *testing.T) {
 	defer mockServer.Close()
 
 	callbackURL := mockServer.URL + "/seen-multi"
-	if err := regStore.Add(txid, callbackURL); err != nil {
+	if err := regStore.Add(txid, callbackURL, ""); err != nil {
 		t.Fatalf("failed to register txid: %v", err)
 	}
 

--- a/internal/kafka/messages.go
+++ b/internal/kafka/messages.go
@@ -40,16 +40,23 @@ type BlockMessage struct {
 
 // CallbackTopicMessage is the message published to the callback Kafka topic.
 // It wraps the Arcade CallbackMessage fields plus delivery metadata.
+//
+// CallbackToken is the optional bearer token that the delivery service
+// attaches as `Authorization: Bearer <token>` on the outbound HTTP POST.
+// Empty / missing means "send no Authorization header" — preserves today's
+// behavior for any deployment that hasn't shipped arcade's matching
+// /watch token-passing change.
 type CallbackTopicMessage struct {
-	CallbackURL  string       `json:"callbackUrl"`
-	Type         CallbackType `json:"type"`
-	TxID         string       `json:"txid,omitempty"`
-	TxIDs        []string     `json:"txids,omitempty"`
-	BlockHash    string       `json:"blockHash,omitempty"`
-	SubtreeIndex int          `json:"subtreeIndex,omitempty"`
-	StumpRef     string       `json:"stumpRef,omitempty"`
-	RetryCount   int          `json:"retryCount,omitempty"`
-	NextRetryAt  time.Time    `json:"nextRetryAt,omitempty"`
+	CallbackURL   string       `json:"callbackUrl"`
+	CallbackToken string       `json:"callbackToken,omitempty"`
+	Type          CallbackType `json:"type"`
+	TxID          string       `json:"txid,omitempty"`
+	TxIDs         []string     `json:"txids,omitempty"`
+	BlockHash     string       `json:"blockHash,omitempty"`
+	SubtreeIndex  int          `json:"subtreeIndex,omitempty"`
+	StumpRef      string       `json:"stumpRef,omitempty"`
+	RetryCount    int          `json:"retryCount,omitempty"`
+	NextRetryAt   time.Time    `json:"nextRetryAt,omitempty"`
 }
 
 func (m *SubtreeMessage) Encode() ([]byte, error) {

--- a/internal/store/callback_url_registry.go
+++ b/internal/store/callback_url_registry.go
@@ -17,6 +17,12 @@ const (
 	// sha256(url); the bin lets GetAll reconstruct the URL list during scan.
 	callbackURLBin = "u"
 
+	// callbackURLTokenBin holds the per-URL bearer token used for outbound
+	// HTTP delivery. Empty string ("") is a valid value and means "no
+	// Authorization header" — preserves today's behavior for deployments
+	// where arcade has not yet shipped the matching token-passing change.
+	callbackURLTokenBin = "t"
+
 	// defaultCallbackURLRegistryTTLSec is the eviction window applied to a
 	// registered callback URL when no explicit TTL is configured. URLs that
 	// haven't seen a fresh `Add` within this window are evicted by Aerospike's
@@ -71,9 +77,12 @@ func callbackURLKey(url string) string {
 	return hex.EncodeToString(h[:])
 }
 
-// Add registers a callback URL in the registry. Repeat calls upsert the same
-// record and refresh its TTL, so an actively-watching URL never expires.
-func (r *aerospikeCallbackURLRegistry) Add(callbackURL string) error {
+// Add registers a callback URL + token in the registry. Repeat calls upsert
+// the same record (keyed by sha256(url)) and refresh its TTL, so an
+// actively-watching URL never expires; the token is rewritten on every Add
+// so a rotating arcade deployment converges on its current token within one
+// /watch round-trip.
+func (r *aerospikeCallbackURLRegistry) Add(callbackURL, callbackToken string) error {
 	key, err := as.NewKey(r.client.Namespace(), r.setName, callbackURLKey(callbackURL))
 	if err != nil {
 		return fmt.Errorf("failed to create key: %w", err)
@@ -85,7 +94,10 @@ func (r *aerospikeCallbackURLRegistry) Add(callbackURL string) error {
 		wp.Expiration = uint32(r.ttlSec) //nolint:gosec // ttlSec is config-validated and fits uint32
 	}
 
-	bins := as.BinMap{callbackURLBin: callbackURL}
+	bins := as.BinMap{
+		callbackURLBin:      callbackURL,
+		callbackURLTokenBin: callbackToken,
+	}
 	if err := r.client.Client().Put(wp, key, bins); err != nil {
 		// If TTL is rejected (namespace lacks nsup-period), retry without TTL.
 		// We log loudly because losing TTL re-introduces F-037's unbounded
@@ -108,12 +120,17 @@ func (r *aerospikeCallbackURLRegistry) Add(callbackURL string) error {
 	return nil
 }
 
-// GetAll returns every registered callback URL. Implemented as a ScanAll over
-// the registry set — the URL count is bounded by per-record TTL eviction
-// (typically <= a few thousand) and BLOCK_PROCESSED fan-out runs at most once
-// per block, so a scan-per-block is cheap relative to the actual callback
-// publish work.
-func (r *aerospikeCallbackURLRegistry) GetAll() ([]string, error) {
+// GetAll returns every registered (url, token) entry. Implemented as a
+// ScanAll over the registry set — the URL count is bounded by per-record TTL
+// eviction (typically <= a few thousand) and BLOCK_PROCESSED fan-out runs at
+// most once per block, so a scan-per-block is cheap relative to the actual
+// callback publish work.
+//
+// Records written before the token bin existed return Token = "" (the bin
+// will be missing, the type-assertion fails, and the zero value falls
+// through). That matches the dual-read invariant the registration store
+// holds and means a rolling deploy never produces a 401.
+func (r *aerospikeCallbackURLRegistry) GetAll() ([]CallbackEntry, error) {
 	sp := as.NewScanPolicy()
 	sp.IncludeBinData = true
 	// Bound the scan so a stalled node can't hang BLOCK_PROCESSED forever.
@@ -123,13 +140,13 @@ func (r *aerospikeCallbackURLRegistry) GetAll() ([]string, error) {
 	// flaky cluster — let the caller re-scan on the next block.
 	sp.MaxRetries = 0
 
-	rs, err := r.client.Client().ScanAll(sp, r.client.Namespace(), r.setName, callbackURLBin)
+	rs, err := r.client.Client().ScanAll(sp, r.client.Namespace(), r.setName, callbackURLBin, callbackURLTokenBin)
 	if err != nil {
 		return nil, fmt.Errorf("failed to scan callback URLs: %w", err)
 	}
 	defer func() { _ = rs.Close() }()
 
-	var urls []string
+	var entries []CallbackEntry
 	for res := range rs.Results() {
 		if res.Err != nil {
 			return nil, fmt.Errorf("scan error reading callback URLs: %w", res.Err)
@@ -137,11 +154,13 @@ func (r *aerospikeCallbackURLRegistry) GetAll() ([]string, error) {
 		if res.Record == nil {
 			continue
 		}
-		v, ok := res.Record.Bins[callbackURLBin].(string)
-		if !ok || v == "" {
+		url, ok := res.Record.Bins[callbackURLBin].(string)
+		if !ok || url == "" {
 			continue
 		}
-		urls = append(urls, v)
+		// Missing token bin (legacy record) or wrong type → empty token.
+		token, _ := res.Record.Bins[callbackURLTokenBin].(string)
+		entries = append(entries, CallbackEntry{URL: url, Token: token})
 	}
-	return urls, nil
+	return entries, nil
 }

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -5,12 +5,23 @@ import (
 	"time"
 )
 
-// RegistrationStore maps a txid to the set of callback URLs registered for it.
-// Add is set-insert: duplicate (txid, url) pairs are silently deduplicated.
+// CallbackEntry is a (URL, token) tuple returned by the registration stores.
+// Token is "" for legacy registrations that predate the per-callback bearer
+// token (arcade /watch payloads without callbackToken). Deliveries should
+// only attach an Authorization header when Token is non-empty so empty-token
+// rollouts preserve today's no-auth behavior.
+type CallbackEntry struct {
+	URL   string
+	Token string
+}
+
+// RegistrationStore maps a txid to the set of callback (URL, token) entries
+// registered for it. Add is set-insert keyed on URL: re-registering the same
+// (txid, url) pair refreshes the token and is otherwise a no-op.
 type RegistrationStore interface {
-	Add(txid, callbackURL string) error
-	Get(txid string) ([]string, error)
-	BatchGet(txids []string) (map[string][]string, error)
+	Add(txid, callbackURL, callbackToken string) error
+	Get(txid string) ([]CallbackEntry, error)
+	BatchGet(txids []string) (map[string][]CallbackEntry, error)
 	UpdateTTL(txid string, ttl time.Duration) error
 	BatchUpdateTTL(txids []string, ttl time.Duration) error
 }
@@ -40,10 +51,12 @@ type CallbackDedupStore interface {
 	Record(txid, callbackURL, statusType string, ttl time.Duration) error
 }
 
-// CallbackURLRegistry enumerates every known callback URL. Add is set-insert.
+// CallbackURLRegistry enumerates every known callback URL alongside its
+// per-URL bearer token. Add is set-insert keyed on URL — re-registering an
+// existing URL refreshes its token and last-seen timestamp.
 type CallbackURLRegistry interface {
-	Add(callbackURL string) error
-	GetAll() ([]string, error)
+	Add(callbackURL, callbackToken string) error
+	GetAll() ([]CallbackEntry, error)
 }
 
 // CallbackAccumulatorStore aggregates per-block, per-URL callback data across

--- a/internal/store/registration.go
+++ b/internal/store/registration.go
@@ -12,6 +12,12 @@ import (
 
 const (
 	callbacksBin = "callbacks"
+
+	// callbackEntryURLKey / callbackEntryTokenKey are the Aerospike CDT-map
+	// keys used by the new (url, token) entry shape stored in callbacksBin.
+	// Short single-character keys keep the on-wire payload small.
+	callbackEntryURLKey   = "u"
+	callbackEntryTokenKey = "t"
 )
 
 // ErrMaxCallbacksPerTxIDExceeded is returned by RegistrationStore.Add when
@@ -63,31 +69,32 @@ func NewRegistrationStore(client *AerospikeClient, setName string, maxRetries, r
 // loser finds the URL already present (idempotent success).
 const addCASMaxAttempts = 5
 
-// Add registers a callback URL for a txid using CDT list operations with the
-// UNIQUE flag for set semantics. When maxCallbacksPerTxID > 0, the read-and-
-// write is gated by an optimistic generation CAS so concurrent registrations
-// can't both observe (count == max-1) and both succeed past the cap.
-func (s *aerospikeRegistration) Add(txid, callbackURL string) error {
+// Add registers a (callbackURL, callbackToken) entry for a txid.
+//
+// Storage shape: callbacksBin holds an Aerospike CDT list of map entries
+// {u: url, t: token}. Set-semantics (one entry per URL) are enforced via a
+// read-modify-write under generation CAS rather than the previous
+// ListWriteFlagsAddUnique trick — Aerospike's UNIQUE flag matches on whole-
+// element equality, which broke once we promoted entries from bare strings
+// to maps (different tokens for the same URL would each be considered
+// distinct elements). The CAS loop keeps idempotent-on-URL semantics and
+// also lets a re-registration refresh the token.
+//
+// Backwards compatibility: the reader (Get / BatchGet) still accepts legacy
+// bare-string entries written by older deployments — those decode to a
+// CallbackEntry with Token = "". A re-registration of an existing URL
+// rewrites the entire list in the new map shape, migrating the record on
+// next /watch.
+//
+// Concurrency: the count + idempotency check + write all run under
+// EXPECT_GEN_EQUAL. A concurrent writer that wins our race trips
+// GENERATION_ERROR / KEY_EXISTS_ERROR and we re-read and re-decide.
+func (s *aerospikeRegistration) Add(txid, callbackURL, callbackToken string) error {
 	key, err := as.NewKey(s.client.Namespace(), s.setName, txid)
 	if err != nil {
 		return fmt.Errorf("failed to create key: %w", err)
 	}
 
-	// Cap disabled: preserve the original best-effort append, which already
-	// honors set semantics via ListWriteFlagsAddUnique|NoFail.
-	if s.maxCallbacksPerTxID <= 0 {
-		wp := s.client.WritePolicy(s.maxRetries, s.retryBaseMs)
-		wp.RecordExistsAction = as.UPDATE
-		listPolicy := as.NewListPolicy(as.ListOrderOrdered, as.ListWriteFlagsAddUnique|as.ListWriteFlagsNoFail)
-		ops := []*as.Operation{as.ListAppendWithPolicyOp(listPolicy, callbacksBin, callbackURL)}
-		if _, err := s.client.Client().Operate(wp, key, ops...); err != nil {
-			return fmt.Errorf("failed to add registration: %w", err)
-		}
-		return nil
-	}
-
-	// Cap enabled: read current list + record generation, decide, then write
-	// under EXPECT_GEN_EQUAL. Loop on generation mismatch.
 	for attempt := 0; attempt < addCASMaxAttempts; attempt++ {
 		record, err := s.client.Client().Get(s.client.ReadPolicy(), key, callbacksBin)
 		if err != nil {
@@ -108,15 +115,27 @@ func (s *aerospikeRegistration) Add(txid, callbackURL string) error {
 			}
 		}
 
-		// Idempotent: already registered, nothing to do (and the cap doesn't apply).
-		for _, v := range existing {
-			if s, ok := v.(string); ok && s == callbackURL {
-				return nil
+		entries := parseCallbackEntries(existing)
+
+		// Build the next list. If the URL is already present, refresh its
+		// token (idempotent re-registration may rotate the token); otherwise
+		// append. This both migrates legacy bare-string entries to the new
+		// map shape and keeps set-on-URL semantics.
+		next := make([]interface{}, 0, len(entries)+1)
+		found := false
+		for _, e := range entries {
+			if e.URL == callbackURL {
+				found = true
+				next = append(next, encodeCallbackEntry(callbackURL, callbackToken))
+			} else {
+				next = append(next, encodeCallbackEntry(e.URL, e.Token))
 			}
 		}
-
-		if len(existing) >= s.maxCallbacksPerTxID {
-			return ErrMaxCallbacksPerTxIDExceeded
+		if !found {
+			if s.maxCallbacksPerTxID > 0 && len(entries) >= s.maxCallbacksPerTxID {
+				return ErrMaxCallbacksPerTxIDExceeded
+			}
+			next = append(next, encodeCallbackEntry(callbackURL, callbackToken))
 		}
 
 		wp := s.client.WritePolicy(s.maxRetries, s.retryBaseMs)
@@ -130,10 +149,8 @@ func (s *aerospikeRegistration) Add(txid, callbackURL string) error {
 			wp.Generation = generation
 		}
 
-		listPolicy := as.NewListPolicy(as.ListOrderOrdered, as.ListWriteFlagsAddUnique|as.ListWriteFlagsNoFail)
-		ops := []*as.Operation{as.ListAppendWithPolicyOp(listPolicy, callbacksBin, callbackURL)}
-
-		if _, err := s.client.Client().Operate(wp, key, ops...); err != nil {
+		bins := as.BinMap{callbacksBin: next}
+		if err := s.client.Client().Put(wp, key, bins); err != nil {
 			var asErr *as.AerospikeError
 			if errors.As(err, &asErr) {
 				if asErr.Matches(astypes.GENERATION_ERROR, astypes.KEY_EXISTS_ERROR) {
@@ -150,8 +167,47 @@ func (s *aerospikeRegistration) Add(txid, callbackURL string) error {
 	return fmt.Errorf("failed to add registration: generation contention after %d attempts", addCASMaxAttempts)
 }
 
-// Get returns all callback URLs registered for a txid.
-func (s *aerospikeRegistration) Get(txid string) ([]string, error) {
+// encodeCallbackEntry produces the Aerospike map-shape representation for a
+// (url, token) pair. Tokens are stored unconditionally (including ""); the
+// reader treats a missing or empty token field as Token = "".
+func encodeCallbackEntry(url, token string) map[interface{}]interface{} {
+	return map[interface{}]interface{}{
+		callbackEntryURLKey:   url,
+		callbackEntryTokenKey: token,
+	}
+}
+
+// parseCallbackEntries decodes a callbacksBin list into CallbackEntry values.
+// Accepts both the legacy bare-string shape (token = "") and the new map
+// shape {u: url, t: token}. Anything that doesn't match either shape is
+// skipped — a defensive choice for forward-compat with future schema changes.
+func parseCallbackEntries(list []interface{}) []CallbackEntry {
+	if len(list) == 0 {
+		return nil
+	}
+	entries := make([]CallbackEntry, 0, len(list))
+	for _, v := range list {
+		switch tv := v.(type) {
+		case string:
+			// Legacy bare-string entry: no token.
+			entries = append(entries, CallbackEntry{URL: tv})
+		case map[interface{}]interface{}:
+			url, _ := tv[callbackEntryURLKey].(string)
+			token, _ := tv[callbackEntryTokenKey].(string)
+			if url == "" {
+				continue
+			}
+			entries = append(entries, CallbackEntry{URL: url, Token: token})
+		}
+	}
+	return entries
+}
+
+// Get returns all (url, token) registrations for a txid. Accepts both the
+// new {u, t} map entry shape and the legacy bare-string shape (token = "")
+// so an in-flight rolling deploy never 401s a callback that hasn't been
+// rewritten yet.
+func (s *aerospikeRegistration) Get(txid string) ([]CallbackEntry, error) {
 	key, err := as.NewKey(s.client.Namespace(), s.setName, txid)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create key: %w", err)
@@ -175,19 +231,14 @@ func (s *aerospikeRegistration) Get(txid string) ([]string, error) {
 		return nil, fmt.Errorf("unexpected bin type for callbacks")
 	}
 
-	urls := make([]string, 0, len(list))
-	for _, v := range list {
-		if s, ok := v.(string); ok {
-			urls = append(urls, s)
-		}
-	}
-	return urls, nil
+	return parseCallbackEntries(list), nil
 }
 
-// BatchGet returns callback URLs for multiple txids in a single batch call.
-func (s *aerospikeRegistration) BatchGet(txids []string) (map[string][]string, error) {
+// BatchGet returns (url, token) registrations for multiple txids in a single
+// batch call. Same dual-shape parsing as Get.
+func (s *aerospikeRegistration) BatchGet(txids []string) (map[string][]CallbackEntry, error) {
 	if len(txids) == 0 {
-		return make(map[string][]string), nil
+		return make(map[string][]CallbackEntry), nil
 	}
 
 	keys := make([]*as.Key, len(txids))
@@ -205,7 +256,7 @@ func (s *aerospikeRegistration) BatchGet(txids []string) (map[string][]string, e
 		return nil, fmt.Errorf("batch get failed: %w", err)
 	}
 
-	result := make(map[string][]string)
+	result := make(map[string][]CallbackEntry)
 	for i, record := range records {
 		if record == nil {
 			continue
@@ -218,14 +269,9 @@ func (s *aerospikeRegistration) BatchGet(txids []string) (map[string][]string, e
 		if !ok {
 			continue
 		}
-		urls := make([]string, 0, len(list))
-		for _, v := range list {
-			if s, ok := v.(string); ok {
-				urls = append(urls, s)
-			}
-		}
-		if len(urls) > 0 {
-			result[txids[i]] = urls
+		entries := parseCallbackEntries(list)
+		if len(entries) > 0 {
+			result[txids[i]] = entries
 		}
 	}
 

--- a/internal/store/registration_integration_test.go
+++ b/internal/store/registration_integration_test.go
@@ -36,7 +36,7 @@ func TestRegistrationStore_AddAndGet(t *testing.T) {
 	txid := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	callback := "https://example.com/cb1"
 
-	err := regStore.Add(txid, callback)
+	err := regStore.Add(txid, callback, "")
 	if err != nil {
 		t.Fatalf("Add failed: %v", err)
 	}
@@ -48,8 +48,8 @@ func TestRegistrationStore_AddAndGet(t *testing.T) {
 	if len(urls) != 1 {
 		t.Fatalf("expected 1 callback, got %d", len(urls))
 	}
-	if urls[0] != callback {
-		t.Fatalf("expected %q, got %q", callback, urls[0])
+	if urls[0].URL != callback {
+		t.Fatalf("expected %q, got %q", callback, urls[0].URL)
 	}
 }
 
@@ -64,7 +64,7 @@ func TestRegistrationStore_MultipleCallbacksSameTxid(t *testing.T) {
 	cb3 := "https://example.com/cb3"
 
 	for _, cb := range []string{cb1, cb2, cb3} {
-		if err := regStore.Add(txid, cb); err != nil {
+		if err := regStore.Add(txid, cb, ""); err != nil {
 			t.Fatalf("Add(%q) failed: %v", cb, err)
 		}
 	}
@@ -77,11 +77,16 @@ func TestRegistrationStore_MultipleCallbacksSameTxid(t *testing.T) {
 		t.Fatalf("expected 3 callbacks, got %d: %v", len(urls), urls)
 	}
 
-	// The store uses ordered list, so callbacks should be sorted.
-	expected := []string{cb1, cb2, cb3}
-	for i, u := range urls {
-		if u != expected[i] {
-			t.Errorf("callback[%d] = %q, want %q", i, u, expected[i])
+	// Reads are not guaranteed to be ordered post-token migration (the
+	// reader preserves insertion order from the bin's CDT list). Compare as
+	// a set instead.
+	got := map[string]bool{}
+	for _, u := range urls {
+		got[u.URL] = true
+	}
+	for _, want := range []string{cb1, cb2, cb3} {
+		if !got[want] {
+			t.Errorf("missing callback %q in result %+v", want, urls)
 		}
 	}
 }
@@ -95,10 +100,10 @@ func TestRegistrationStore_IdempotentAdd(t *testing.T) {
 	callback := "https://example.com/cb_dup"
 
 	// Add the same callback twice.
-	if err := regStore.Add(txid, callback); err != nil {
+	if err := regStore.Add(txid, callback, ""); err != nil {
 		t.Fatalf("first Add failed: %v", err)
 	}
-	if err := regStore.Add(txid, callback); err != nil {
+	if err := regStore.Add(txid, callback, ""); err != nil {
 		t.Fatalf("second Add failed: %v", err)
 	}
 
@@ -109,8 +114,8 @@ func TestRegistrationStore_IdempotentAdd(t *testing.T) {
 	if len(urls) != 1 {
 		t.Fatalf("expected 1 callback (idempotent), got %d: %v", len(urls), urls)
 	}
-	if urls[0] != callback {
-		t.Fatalf("expected %q, got %q", callback, urls[0])
+	if urls[0].URL != callback {
+		t.Fatalf("expected %q, got %q", callback, urls[0].URL)
 	}
 }
 
@@ -123,10 +128,10 @@ func TestRegistrationStore_BatchGet(t *testing.T) {
 	txid2 := "2222222222222222222222222222222222222222222222222222222222222222"
 	txid3 := "3333333333333333333333333333333333333333333333333333333333333333" // no registration
 
-	if err := regStore.Add(txid1, "https://example.com/a"); err != nil {
+	if err := regStore.Add(txid1, "https://example.com/a", ""); err != nil {
 		t.Fatalf("Add txid1 failed: %v", err)
 	}
-	if err := regStore.Add(txid2, "https://example.com/b"); err != nil {
+	if err := regStore.Add(txid2, "https://example.com/b", ""); err != nil {
 		t.Fatalf("Add txid2 failed: %v", err)
 	}
 
@@ -135,10 +140,10 @@ func TestRegistrationStore_BatchGet(t *testing.T) {
 		t.Fatalf("BatchGet failed: %v", err)
 	}
 
-	if len(result[txid1]) != 1 || result[txid1][0] != "https://example.com/a" {
+	if len(result[txid1]) != 1 || result[txid1][0].URL != "https://example.com/a" {
 		t.Errorf("txid1: expected [https://example.com/a], got %v", result[txid1])
 	}
-	if len(result[txid2]) != 1 || result[txid2][0] != "https://example.com/b" {
+	if len(result[txid2]) != 1 || result[txid2][0].URL != "https://example.com/b" {
 		t.Errorf("txid2: expected [https://example.com/b], got %v", result[txid2])
 	}
 	if _, exists := result[txid3]; exists {
@@ -154,7 +159,7 @@ func TestRegistrationStore_UpdateTTL(t *testing.T) {
 	txid := "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
 	callback := "https://example.com/ttl"
 
-	if err := regStore.Add(txid, callback); err != nil {
+	if err := regStore.Add(txid, callback, ""); err != nil {
 		t.Fatalf("Add failed: %v", err)
 	}
 

--- a/internal/store/registration_test.go
+++ b/internal/store/registration_test.go
@@ -1,0 +1,165 @@
+package store
+
+import (
+	"testing"
+)
+
+// TestParseCallbackEntries_DualRead verifies the legacy / new shape parser
+// the Aerospike RegistrationStore uses on every Get / BatchGet. The reader
+// must handle both:
+//
+//   - bare-string entries written by older deployments (token = "")
+//   - {u: url, t: token} map entries written post-callback-token rollout
+//
+// This is the unit-level coverage for the rolling-deploy guarantee called
+// out in the PR: existing in-flight registrations stay valid; nothing 401s
+// during the rollout window. A real Aerospike round-trip is exercised in
+// the integration suite.
+func TestParseCallbackEntries_DualRead(t *testing.T) {
+	t.Run("legacy bare-string entries decode with empty token", func(t *testing.T) {
+		// Aerospike returns CDT lists as []interface{}; emulate that here so
+		// the parse logic gets exactly what the live reader sees.
+		legacy := []interface{}{
+			"https://arcade.example/cb1",
+			"https://arcade.example/cb2",
+		}
+		got := parseCallbackEntries(legacy)
+		if len(got) != 2 {
+			t.Fatalf("want 2 entries, got %d", len(got))
+		}
+		for i, want := range []string{"https://arcade.example/cb1", "https://arcade.example/cb2"} {
+			if got[i].URL != want {
+				t.Errorf("entry %d URL = %q, want %q", i, got[i].URL, want)
+			}
+			if got[i].Token != "" {
+				t.Errorf("entry %d Token = %q, want empty (legacy entry)", i, got[i].Token)
+			}
+		}
+	})
+
+	t.Run("new map entries decode with token populated", func(t *testing.T) {
+		newShape := []interface{}{
+			map[interface{}]interface{}{
+				callbackEntryURLKey:   "https://arcade.example/cb1",
+				callbackEntryTokenKey: "tok-v1",
+			},
+			map[interface{}]interface{}{
+				callbackEntryURLKey:   "https://arcade.example/cb2",
+				callbackEntryTokenKey: "tok-v2",
+			},
+		}
+		got := parseCallbackEntries(newShape)
+		if len(got) != 2 {
+			t.Fatalf("want 2 entries, got %d", len(got))
+		}
+		if got[0].URL != "https://arcade.example/cb1" || got[0].Token != "tok-v1" {
+			t.Errorf("entry 0 = %+v", got[0])
+		}
+		if got[1].URL != "https://arcade.example/cb2" || got[1].Token != "tok-v2" {
+			t.Errorf("entry 1 = %+v", got[1])
+		}
+	})
+
+	t.Run("mixed legacy and new shapes coexist (mid-migration)", func(t *testing.T) {
+		// This is the rolling-deploy case: a record that had a bare-string
+		// entry pre-deploy, then got a new {u,t} entry appended after the
+		// new code rolled out. (In practice writers always rewrite the
+		// whole list, but the reader must still cope with whatever it
+		// finds in case of partial deploys or data older than this PR.)
+		mixed := []interface{}{
+			"https://legacy.example/cb",
+			map[interface{}]interface{}{
+				callbackEntryURLKey:   "https://new.example/cb",
+				callbackEntryTokenKey: "tok-v1",
+			},
+		}
+		got := parseCallbackEntries(mixed)
+		if len(got) != 2 {
+			t.Fatalf("want 2 entries, got %d", len(got))
+		}
+		if got[0].URL != "https://legacy.example/cb" || got[0].Token != "" {
+			t.Errorf("legacy entry = %+v, want url=https://legacy.example/cb token=\"\"", got[0])
+		}
+		if got[1].URL != "https://new.example/cb" || got[1].Token != "tok-v1" {
+			t.Errorf("new entry = %+v", got[1])
+		}
+	})
+
+	t.Run("map entry with missing token field decodes to empty token", func(t *testing.T) {
+		// Defensive: forward-compat with hand-edited records or future
+		// schema changes that drop the token field.
+		partial := []interface{}{
+			map[interface{}]interface{}{
+				callbackEntryURLKey: "https://arcade.example/cb",
+			},
+		}
+		got := parseCallbackEntries(partial)
+		if len(got) != 1 || got[0].URL != "https://arcade.example/cb" || got[0].Token != "" {
+			t.Fatalf("want one entry with empty token, got %+v", got)
+		}
+	})
+
+	t.Run("map entry with empty url is skipped", func(t *testing.T) {
+		bad := []interface{}{
+			map[interface{}]interface{}{
+				callbackEntryURLKey:   "",
+				callbackEntryTokenKey: "tok",
+			},
+			map[interface{}]interface{}{
+				callbackEntryURLKey:   "https://arcade.example/cb",
+				callbackEntryTokenKey: "tok",
+			},
+		}
+		got := parseCallbackEntries(bad)
+		if len(got) != 1 || got[0].URL != "https://arcade.example/cb" {
+			t.Fatalf("want only the non-empty entry, got %+v", got)
+		}
+	})
+
+	t.Run("non-string non-map entries are silently skipped", func(t *testing.T) {
+		// Forward-compat: don't propagate a parse error for an entry shape
+		// we don't understand; just ignore it. A noisy log would do more
+		// harm than good for a registry that fans out per-block.
+		junk := []interface{}{
+			42,
+			[]byte("oops"),
+			"https://arcade.example/cb",
+		}
+		got := parseCallbackEntries(junk)
+		if len(got) != 1 || got[0].URL != "https://arcade.example/cb" {
+			t.Fatalf("want only the string entry, got %+v", got)
+		}
+	})
+
+	t.Run("nil and empty inputs yield nil", func(t *testing.T) {
+		if got := parseCallbackEntries(nil); got != nil {
+			t.Errorf("nil input → want nil, got %+v", got)
+		}
+		if got := parseCallbackEntries([]interface{}{}); got != nil {
+			t.Errorf("empty input → want nil, got %+v", got)
+		}
+	})
+}
+
+// TestEncodeCallbackEntry_RoundTripThroughParser confirms the writer and
+// reader agree on the on-wire shape: every entry encoded by the writer is
+// recovered exactly by the reader.
+func TestEncodeCallbackEntry_RoundTripThroughParser(t *testing.T) {
+	cases := []CallbackEntry{
+		{URL: "https://arcade.example/cb", Token: "tok-v1"},
+		{URL: "https://arcade.example/cb-no-token", Token: ""},
+	}
+	encoded := make([]interface{}, 0, len(cases))
+	for _, c := range cases {
+		encoded = append(encoded, encodeCallbackEntry(c.URL, c.Token))
+	}
+	got := parseCallbackEntries(encoded)
+	if len(got) != len(cases) {
+		t.Fatalf("round-trip lost entries: want %d, got %d", len(cases), len(got))
+	}
+	for i, want := range cases {
+		if got[i] != want {
+			t.Errorf("round-trip mismatch at %d: got %+v, want %+v", i, got[i], want)
+		}
+	}
+}

--- a/internal/store/sql/callback_url_registry.go
+++ b/internal/store/sql/callback_url_registry.go
@@ -34,22 +34,24 @@ func newCallbackURLRegistry(db *sql.DB, d *dialect, retention time.Duration) *ca
 	return &callbackURLRegistry{db: db, d: d, retention: retention}
 }
 
-func (r *callbackURLRegistry) Add(callbackURL string) error {
+func (r *callbackURLRegistry) Add(callbackURL, callbackToken string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	// On conflict we must refresh last_seen_at — otherwise a URL added once
 	// would expire even though it is being actively re-registered. We use a
 	// dialect-portable UPSERT shape (ON CONFLICT ... DO UPDATE) which both
-	// PostgreSQL and SQLite (>= 3.24) support.
+	// PostgreSQL and SQLite (>= 3.24) support. The token is also refreshed
+	// so a rotation in arcade's cfg.CallbackToken converges within one
+	// /watch round-trip.
 	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
-		"INSERT INTO callback_urls (callback_url, last_seen_at) VALUES (%s, %s) "+
-			"ON CONFLICT (callback_url) DO UPDATE SET last_seen_at = %s",
-		r.d.placeholder(1), r.d.now, r.d.now)
-	_, err := r.db.ExecContext(ctx, q, callbackURL)
+		"INSERT INTO callback_urls (callback_url, last_seen_at, callback_token) VALUES (%s, %s, %s) "+
+			"ON CONFLICT (callback_url) DO UPDATE SET last_seen_at = %s, callback_token = EXCLUDED.callback_token",
+		r.d.placeholder(1), r.d.now, r.d.placeholder(2), r.d.now)
+	_, err := r.db.ExecContext(ctx, q, callbackURL, callbackToken)
 	return err
 }
 
-func (r *callbackURLRegistry) GetAll() ([]string, error) {
+func (r *callbackURLRegistry) GetAll() ([]storepkg.CallbackEntry, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -58,7 +60,7 @@ func (r *callbackURLRegistry) GetAll() ([]string, error) {
 	// or the next sweeper tick (which uses the same NULL-tolerant predicate).
 	cutoff := -int(r.retention / time.Second)
 	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
-		"SELECT callback_url FROM callback_urls "+
+		"SELECT callback_url, callback_token FROM callback_urls "+
 			"WHERE last_seen_at IS NULL OR last_seen_at >= %s "+
 			"ORDER BY callback_url",
 		r.d.intervalSeconds(cutoff))
@@ -68,13 +70,13 @@ func (r *callbackURLRegistry) GetAll() ([]string, error) {
 		return nil, err
 	}
 	defer ensureRowsClosed(rows)
-	var out []string
+	var out []storepkg.CallbackEntry
 	for rows.Next() {
-		var u string
-		if err := rows.Scan(&u); err != nil {
+		var entry storepkg.CallbackEntry
+		if err := rows.Scan(&entry.URL, &entry.Token); err != nil {
 			return nil, err
 		}
-		out = append(out, u)
+		out = append(out, entry)
 	}
 	return out, rows.Err()
 }

--- a/internal/store/sql/migrations/0003_callback_token.sql
+++ b/internal/store/sql/migrations/0003_callback_token.sql
@@ -1,0 +1,13 @@
+-- 0003: Per-callback bearer token (paired with arcade /watch callbackToken).
+--
+-- arcade's callback endpoint requires Authorization: Bearer <cfg.CallbackToken>
+-- but until now merkle-service had no concept of a per-callback token. We
+-- accept the token via /watch, persist it alongside the URL here, propagate
+-- it through Kafka, and apply it on outbound HTTP delivery.
+--
+-- The new column is NOT NULL DEFAULT '' so existing rows survive the
+-- migration without a backfill — empty token means "send no Authorization
+-- header", which preserves today's behaviour for any deployment that hasn't
+-- yet shipped arcade's matching change.
+
+ALTER TABLE registration_urls ADD COLUMN callback_token TEXT NOT NULL DEFAULT '';

--- a/internal/store/sql/migrations/0004_url_registry_callback_token.sql
+++ b/internal/store/sql/migrations/0004_url_registry_callback_token.sql
@@ -1,0 +1,9 @@
+-- 0004: Per-URL bearer token in the callback URL registry.
+--
+-- Mirror of 0003 for the broadcast registry used by BLOCK_PROCESSED fan-out.
+-- Same NOT NULL DEFAULT '' shape so existing rows survive the migration; the
+-- application updates the column on every Add() call so an actively
+-- registering URL converges on the latest arcade-issued token within one
+-- /watch round-trip.
+
+ALTER TABLE callback_urls ADD COLUMN callback_token TEXT NOT NULL DEFAULT '';

--- a/internal/store/sql/registration.go
+++ b/internal/store/sql/registration.go
@@ -27,10 +27,10 @@ func newRegistrationStore(db *sql.DB, d *dialect, maxCallbacksPerTxID int) *regi
 	return &registrationStore{db: db, d: d, maxCallbacksPerTxID: maxCallbacksPerTxID}
 }
 
-// Add registers callbackURL for txid. Re-adding an already-known URL is a
-// no-op (set semantics, idempotent). When maxCallbacksPerTxID > 0, exceeding
-// the cap returns store.ErrMaxCallbacksPerTxIDExceeded — the API layer maps
-// this to HTTP 429.
+// Add registers callbackURL + callbackToken for txid. Re-adding an
+// already-known URL refreshes the token (set semantics on URL, idempotent
+// on the row). When maxCallbacksPerTxID > 0, exceeding the cap returns
+// store.ErrMaxCallbacksPerTxIDExceeded — the API layer maps this to HTTP 429.
 //
 // Concurrency: on Postgres we acquire a SELECT ... FOR UPDATE on the parent
 // `registrations` row before counting and inserting, so two concurrent Add
@@ -38,7 +38,7 @@ func newRegistrationStore(db *sql.DB, d *dialect, maxCallbacksPerTxID int) *regi
 // On SQLite the database serializes writers globally (BEGIN IMMEDIATE in the
 // driver), so the count-then-insert pair is already atomic without an
 // explicit lock.
-func (s *registrationStore) Add(txid, callbackURL string) error {
+func (s *registrationStore) Add(txid, callbackURL, callbackToken string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -66,15 +66,22 @@ func (s *registrationStore) Add(txid, callbackURL string) error {
 		}
 
 		// Idempotency probe: if the URL is already registered, re-adding is
-		// a no-op regardless of the cap. Otherwise enforce the limit.
+		// a no-op for the count check (regardless of the cap). The token is
+		// still refreshed via the ON CONFLICT DO UPDATE in the INSERT below.
 		probeQ := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 			"SELECT 1 FROM registration_urls WHERE txid = %s AND callback_url = %s",
 			s.d.placeholder(1), s.d.placeholder(2))
 		var exists int
 		switch err := tx.QueryRowContext(ctx, probeQ, txid, callbackURL).Scan(&exists); err {
 		case nil:
-			// URL already present — commit so the registrations row sticks
-			// (preserving prior behavior where the parent row is upserted).
+			// URL already present — refresh its token and commit. Without
+			// this UPDATE a token rotation would never propagate.
+			updateTokenQ := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
+				"UPDATE registration_urls SET callback_token = %s WHERE txid = %s AND callback_url = %s",
+				s.d.placeholder(1), s.d.placeholder(2), s.d.placeholder(3))
+			if _, updateErr := tx.ExecContext(ctx, updateTokenQ, callbackToken, txid, callbackURL); updateErr != nil {
+				return fmt.Errorf("refresh callback token: %w", updateErr)
+			}
 			return tx.Commit()
 		case sql.ErrNoRows:
 			// fall through to count + insert
@@ -92,38 +99,43 @@ func (s *registrationStore) Add(txid, callbackURL string) error {
 		}
 	}
 
+	// Cap-disabled / new-row path: upsert the (txid, callback_url) row,
+	// refreshing callback_token on conflict so a token rotation lands.
 	insertURL := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
-		"INSERT INTO registration_urls (txid, callback_url) VALUES (%s, %s)%s",
-		s.d.placeholder(1), s.d.placeholder(2), s.d.onConflictDoNothing)
-	if _, err := tx.ExecContext(ctx, insertURL, txid, callbackURL); err != nil {
+		"INSERT INTO registration_urls (txid, callback_url, callback_token) VALUES (%s, %s, %s) "+
+			"ON CONFLICT (txid, callback_url) DO UPDATE SET callback_token = EXCLUDED.callback_token",
+		s.d.placeholder(1), s.d.placeholder(2), s.d.placeholder(3))
+	if _, err := tx.ExecContext(ctx, insertURL, txid, callbackURL, callbackToken); err != nil {
 		return fmt.Errorf("insert registration url: %w", err)
 	}
 	return tx.Commit()
 }
 
-func (s *registrationStore) Get(txid string) ([]string, error) {
+func (s *registrationStore) Get(txid string) ([]storepkg.CallbackEntry, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	q := fmt.Sprintf("SELECT callback_url FROM registration_urls WHERE txid = %s ORDER BY callback_url", s.d.placeholder(1)) //nolint:gosec // placeholder from internal function
+	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
+		"SELECT callback_url, callback_token FROM registration_urls WHERE txid = %s ORDER BY callback_url",
+		s.d.placeholder(1))
 	rows, err := s.db.QueryContext(ctx, q, txid)
 	if err != nil {
 		return nil, err
 	}
 	defer ensureRowsClosed(rows)
-	var out []string
+	var out []storepkg.CallbackEntry
 	for rows.Next() {
-		var u string
-		if err := rows.Scan(&u); err != nil {
+		var entry storepkg.CallbackEntry
+		if err := rows.Scan(&entry.URL, &entry.Token); err != nil {
 			return nil, err
 		}
-		out = append(out, u)
+		out = append(out, entry)
 	}
 	return out, rows.Err()
 }
 
-func (s *registrationStore) BatchGet(txids []string) (map[string][]string, error) {
+func (s *registrationStore) BatchGet(txids []string) (map[string][]storepkg.CallbackEntry, error) {
 	if len(txids) == 0 {
-		return map[string][]string{}, nil
+		return map[string][]storepkg.CallbackEntry{}, nil
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -135,7 +147,7 @@ func (s *registrationStore) BatchGet(txids []string) (map[string][]string, error
 		args[i] = t
 	}
 	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
-		"SELECT txid, callback_url FROM registration_urls WHERE txid IN (%s)",
+		"SELECT txid, callback_url, callback_token FROM registration_urls WHERE txid IN (%s)",
 		strings.Join(placeholders, ", "))
 	rows, err := s.db.QueryContext(ctx, q, args...)
 	if err != nil {
@@ -143,13 +155,14 @@ func (s *registrationStore) BatchGet(txids []string) (map[string][]string, error
 	}
 	defer ensureRowsClosed(rows)
 
-	result := map[string][]string{}
+	result := map[string][]storepkg.CallbackEntry{}
 	for rows.Next() {
-		var txid, url string
-		if err := rows.Scan(&txid, &url); err != nil {
+		var txid string
+		var entry storepkg.CallbackEntry
+		if err := rows.Scan(&txid, &entry.URL, &entry.Token); err != nil {
 			return nil, err
 		}
-		result[txid] = append(result[txid], url)
+		result[txid] = append(result[txid], entry)
 	}
 	return result, rows.Err()
 }

--- a/internal/store/sql/sql_test.go
+++ b/internal/store/sql/sql_test.go
@@ -44,7 +44,7 @@ func TestRegistrationStore_IdempotentAdd(t *testing.T) {
 	s := newRegistrationStore(db, d, 0)
 
 	for i := 0; i < 3; i++ {
-		if err := s.Add("tx1", "http://cb1"); err != nil {
+		if err := s.Add("tx1", "http://cb1", ""); err != nil {
 			t.Fatalf("Add: %v", err)
 		}
 	}
@@ -52,21 +52,67 @@ func TestRegistrationStore_IdempotentAdd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if len(got) != 1 || got[0] != "http://cb1" {
+	if len(got) != 1 || got[0].URL != "http://cb1" {
 		t.Fatalf("got %v, want [http://cb1]", got)
+	}
+}
+
+// TestRegistrationStore_TokenRoundTrip verifies the new callback_token column
+// is persisted and retrieved on /watch round-trip, including the
+// "re-registration refreshes the token" semantics that let arcade rotate
+// without bouncing every txid.
+func TestRegistrationStore_TokenRoundTrip(t *testing.T) {
+	db, d := newTestDB(t)
+	s := newRegistrationStore(db, d, 0)
+
+	if err := s.Add("tx1", "http://cb", "tok-v1"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	got, err := s.Get("tx1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(got) != 1 || got[0].URL != "http://cb" || got[0].Token != "tok-v1" {
+		t.Fatalf("first round-trip: got %+v, want [{http://cb tok-v1}]", got)
+	}
+
+	// Re-register the same URL with a rotated token: Get should now return
+	// the new token (refresh-on-conflict).
+	if addErr := s.Add("tx1", "http://cb", "tok-v2"); addErr != nil {
+		t.Fatalf("Add (rotation): %v", addErr)
+	}
+	got, err = s.Get("tx1")
+	if err != nil {
+		t.Fatalf("Get after rotation: %v", err)
+	}
+	if len(got) != 1 || got[0].Token != "tok-v2" {
+		t.Fatalf("rotated round-trip: got %+v, want token tok-v2", got)
+	}
+
+	// Empty token is a valid value (back-compat: deployments where arcade
+	// hasn't shipped the matching change). Get returns Token = "".
+	if addErr := s.Add("tx2", "http://cb2", ""); addErr != nil {
+		t.Fatalf("Add empty token: %v", addErr)
+	}
+	got, err = s.Get("tx2")
+	if err != nil {
+		t.Fatalf("Get empty token: %v", err)
+	}
+	if len(got) != 1 || got[0].Token != "" {
+		t.Fatalf("empty-token round-trip: got %+v, want token \"\"", got)
 	}
 }
 
 func TestRegistrationStore_BatchGet(t *testing.T) {
 	db, d := newTestDB(t)
 	s := newRegistrationStore(db, d, 0)
-	if err := s.Add("a", "u1"); err != nil {
+	if err := s.Add("a", "u1", "tok-a1"); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.Add("a", "u2"); err != nil {
+	if err := s.Add("a", "u2", ""); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.Add("b", "u3"); err != nil {
+	if err := s.Add("b", "u3", "tok-b"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -79,6 +125,19 @@ func TestRegistrationStore_BatchGet(t *testing.T) {
 	}
 	if len(got["b"]) != 1 {
 		t.Fatalf("b urls = %v, want 1", got["b"])
+	}
+	// Locate u1 and verify token survived the batch fetch.
+	foundToken := false
+	for _, e := range got["a"] {
+		if e.URL == "u1" && e.Token == "tok-a1" {
+			foundToken = true
+		}
+	}
+	if !foundToken {
+		t.Fatalf("expected (u1, tok-a1) in got[\"a\"]: %+v", got["a"])
+	}
+	if got["b"][0].Token != "tok-b" {
+		t.Fatalf("got[\"b\"][0].Token = %q, want tok-b", got["b"][0].Token)
 	}
 	if _, ok := got["c"]; ok {
 		t.Fatalf("c should not be present")
@@ -96,13 +155,13 @@ func TestRegistrationStore_MaxCallbacksPerTxID(t *testing.T) {
 
 	// First `max` distinct URLs succeed.
 	for i := 0; i < max; i++ {
-		if err := s.Add("tx1", fmt.Sprintf("http://cb/%d", i)); err != nil {
+		if err := s.Add("tx1", fmt.Sprintf("http://cb/%d", i), ""); err != nil {
 			t.Fatalf("Add #%d: %v", i, err)
 		}
 	}
 
 	// (max+1)-th distinct URL is rejected with the sentinel.
-	err := s.Add("tx1", "http://cb/overflow")
+	err := s.Add("tx1", "http://cb/overflow", "")
 	if !errors.Is(err, storepkg.ErrMaxCallbacksPerTxIDExceeded) {
 		t.Fatalf("expected ErrMaxCallbacksPerTxIDExceeded, got %v", err)
 	}
@@ -117,7 +176,7 @@ func TestRegistrationStore_MaxCallbacksPerTxID(t *testing.T) {
 	}
 
 	// A different txid is unaffected by the first txid's cap.
-	if err := s.Add("tx2", "http://cb/tx2"); err != nil {
+	if err := s.Add("tx2", "http://cb/tx2", ""); err != nil {
 		t.Fatalf("unrelated txid Add: %v", err)
 	}
 }
@@ -130,22 +189,22 @@ func TestRegistrationStore_MaxCallbacksIdempotent(t *testing.T) {
 	const max = 2
 	s := newRegistrationStore(db, d, max)
 
-	if err := s.Add("tx1", "http://cb/a"); err != nil {
+	if err := s.Add("tx1", "http://cb/a", ""); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.Add("tx1", "http://cb/b"); err != nil {
+	if err := s.Add("tx1", "http://cb/b", ""); err != nil {
 		t.Fatal(err)
 	}
 
 	// At cap: re-adding either existing URL must succeed (idempotent set add).
 	for _, url := range []string{"http://cb/a", "http://cb/b"} {
-		if err := s.Add("tx1", url); err != nil {
+		if err := s.Add("tx1", url, ""); err != nil {
 			t.Fatalf("idempotent re-add of %q: %v", url, err)
 		}
 	}
 
 	// And a NEW URL still trips the cap.
-	if err := s.Add("tx1", "http://cb/c"); !errors.Is(err, storepkg.ErrMaxCallbacksPerTxIDExceeded) {
+	if err := s.Add("tx1", "http://cb/c", ""); !errors.Is(err, storepkg.ErrMaxCallbacksPerTxIDExceeded) {
 		t.Fatalf("expected ErrMaxCallbacksPerTxIDExceeded, got %v", err)
 	}
 
@@ -167,7 +226,7 @@ func TestRegistrationStore_MaxCallbacksDisabled(t *testing.T) {
 	s := newRegistrationStore(db, d, 0)
 
 	for i := 0; i < 25; i++ {
-		if err := s.Add("tx1", fmt.Sprintf("http://cb/%d", i)); err != nil {
+		if err := s.Add("tx1", fmt.Sprintf("http://cb/%d", i), ""); err != nil {
 			t.Fatalf("Add #%d: %v", i, err)
 		}
 	}
@@ -234,15 +293,15 @@ func TestCallbackURLRegistry_AddGetAll(t *testing.T) {
 	db, d := newTestDB(t)
 	r := newCallbackURLRegistry(db, d, time.Hour)
 
-	if err := r.Add("http://one"); err != nil {
+	if err := r.Add("http://one", "tok-1"); err != nil {
 		t.Fatal(err)
 	}
-	if err := r.Add("http://two"); err != nil {
+	if err := r.Add("http://two", ""); err != nil {
 		t.Fatal(err)
 	}
-	if err := r.Add("http://one"); err != nil {
+	if err := r.Add("http://one", "tok-1-rotated"); err != nil {
 		t.Fatal(err)
-	} // duplicate
+	} // duplicate URL — token refreshes
 
 	all, err := r.GetAll()
 	if err != nil {
@@ -250,6 +309,17 @@ func TestCallbackURLRegistry_AddGetAll(t *testing.T) {
 	}
 	if len(all) != 2 {
 		t.Fatalf("got %v, want 2 URLs", all)
+	}
+	// Verify token is preserved end-to-end and that re-Add rotates it.
+	tokenByURL := map[string]string{}
+	for _, e := range all {
+		tokenByURL[e.URL] = e.Token
+	}
+	if tokenByURL["http://one"] != "tok-1-rotated" {
+		t.Fatalf("expected http://one token tok-1-rotated, got %q", tokenByURL["http://one"])
+	}
+	if tokenByURL["http://two"] != "" {
+		t.Fatalf("expected http://two token \"\", got %q", tokenByURL["http://two"])
 	}
 }
 
@@ -261,7 +331,7 @@ func TestCallbackURLRegistry_RetentionWindow(t *testing.T) {
 	db, d := newTestDB(t)
 	r := newCallbackURLRegistry(db, d, time.Hour)
 
-	if err := r.Add("http://recent"); err != nil {
+	if err := r.Add("http://recent", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -279,18 +349,18 @@ func TestCallbackURLRegistry_RetentionWindow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetAll: %v", err)
 	}
-	for _, u := range all {
-		if u == stale {
-			t.Fatalf("GetAll returned stale URL %q (retention window not enforced)", u)
+	for _, e := range all {
+		if e.URL == stale {
+			t.Fatalf("GetAll returned stale URL %q (retention window not enforced)", e.URL)
 		}
 	}
-	if len(all) != 1 || all[0] != "http://recent" {
+	if len(all) != 1 || all[0].URL != "http://recent" {
 		t.Fatalf("expected only http://recent, got %v", all)
 	}
 
 	// Re-Add the stale URL: that should refresh last_seen_at and bring it
 	// back into the active window.
-	if err = r.Add(stale); err != nil {
+	if err = r.Add(stale, ""); err != nil {
 		t.Fatalf("re-Add stale: %v", err)
 	}
 	all, err = r.GetAll()
@@ -310,7 +380,7 @@ func TestCallbackURLRegistry_SweeperEvicts(t *testing.T) {
 	db, d := newTestDB(t)
 	r := newCallbackURLRegistry(db, d, time.Hour)
 
-	if err := r.Add("http://recent"); err != nil {
+	if err := r.Add("http://recent", ""); err != nil {
 		t.Fatal(err)
 	}
 	stale := "http://ancient"

--- a/internal/store/sql/sweeper_test.go
+++ b/internal/store/sql/sweeper_test.go
@@ -17,13 +17,13 @@ func TestSweeper_CascadesRegistrationChildren(t *testing.T) {
 	r := newRegistrationStore(db, d, 0)
 
 	// Two txids: one we'll expire in the past, one fresh.
-	if err := r.Add("tx-old", "http://old1"); err != nil {
+	if err := r.Add("tx-old", "http://old1", ""); err != nil {
 		t.Fatal(err)
 	}
-	if err := r.Add("tx-old", "http://old2"); err != nil {
+	if err := r.Add("tx-old", "http://old2", ""); err != nil {
 		t.Fatal(err)
 	}
-	if err := r.Add("tx-fresh", "http://fresh"); err != nil {
+	if err := r.Add("tx-fresh", "http://fresh", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -62,7 +62,7 @@ func TestSweeper_CascadesRegistrationChildren(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(urls) != 1 || urls[0] != "http://fresh" {
+	if len(urls) != 1 || urls[0].URL != "http://fresh" {
 		t.Fatalf("fresh registration mutated: got %v", urls)
 	}
 }

--- a/internal/subtree/processor.go
+++ b/internal/subtree/processor.go
@@ -16,9 +16,14 @@ import (
 )
 
 // RegistrationGetter abstracts registration lookups for testability.
+//
+// The shape mirrors store.RegistrationStore: BatchGet/Get return
+// []store.CallbackEntry so the per-URL bearer token reaches the SEEN
+// callback emit sites and is propagated through CallbackTopicMessage to
+// the delivery service.
 type RegistrationGetter interface {
-	BatchGet(txids []string) (map[string][]string, error)
-	Get(txid string) ([]string, error)
+	BatchGet(txids []string) (map[string][]store.CallbackEntry, error)
+	Get(txid string) ([]store.CallbackEntry, error)
 }
 
 // SeenCounter abstracts seen-count tracking for testability.
@@ -393,8 +398,8 @@ func (p *Processor) handleTransientFailure(subtreeMsg *kafka.SubtreeMessage, sta
 }
 
 // findRegisteredTxids uses the cache and Aerospike to find which txids are registered.
-// Returns a map of txid → callbackURLs for all registered txids.
-func (p *Processor) findRegisteredTxids(txids []string) (map[string][]string, error) {
+// Returns a map of txid → []CallbackEntry (URL + token) for all registered txids.
+func (p *Processor) findRegisteredTxids(txids []string) (map[string][]store.CallbackEntry, error) {
 	var uncached, cachedRegistered []string
 
 	if p.regCache != nil {
@@ -404,7 +409,7 @@ func (p *Processor) findRegisteredTxids(txids []string) (map[string][]string, er
 	}
 
 	// 4.3: Batch lookup uncached txids in Aerospike.
-	var registeredFromStore map[string][]string
+	var registeredFromStore map[string][]store.CallbackEntry
 	if len(uncached) > 0 {
 		var err error
 		registeredFromStore, err = p.registrationStore.BatchGet(uncached)
@@ -428,13 +433,13 @@ func (p *Processor) findRegisteredTxids(txids []string) (map[string][]string, er
 		}
 	}
 
-	// Combine: start with uncached results (already have callbackURLs from BatchGet).
-	allRegistered := make(map[string][]string, len(cachedRegistered)+len(registeredFromStore))
-	for txid, urls := range registeredFromStore {
-		allRegistered[txid] = urls
+	// Combine: start with uncached results (already have CallbackEntry from BatchGet).
+	allRegistered := make(map[string][]store.CallbackEntry, len(cachedRegistered)+len(registeredFromStore))
+	for txid, entries := range registeredFromStore {
+		allRegistered[txid] = entries
 	}
 
-	// For cached-registered txids, fetch callbackURLs via BatchGet.
+	// For cached-registered txids, fetch CallbackEntry tuples via BatchGet.
 	//
 	// A failure here MUST surface as an error (F-056). The cache told us these
 	// txids are registered; if the backing store lookup fails we cannot
@@ -445,12 +450,12 @@ func (p *Processor) findRegisteredTxids(txids []string) (map[string][]string, er
 	// re-drives via handleTransientFailure (which leaves the dedup cache
 	// untouched).
 	if len(cachedRegistered) > 0 {
-		cachedURLs, err := p.registrationStore.BatchGet(cachedRegistered)
+		cachedEntries, err := p.registrationStore.BatchGet(cachedRegistered)
 		if err != nil {
 			return nil, fmt.Errorf("batch get callbackURLs for cached txids: %w", err)
 		}
-		for txid, urls := range cachedURLs {
-			allRegistered[txid] = urls
+		for txid, entries := range cachedEntries {
+			allRegistered[txid] = entries
 		}
 	}
 
@@ -476,7 +481,7 @@ func (p *Processor) findRegisteredTxids(txids []string) (map[string][]string, er
 // callbacks for the affected txids. Returning the error keeps the dedup
 // cache untouched (handleMessage gates that add on success) and routes the
 // work through handleTransientFailure for redelivery.
-func (p *Processor) emitBatchedSeenCallbacks(registeredTxids map[string][]string, subtreeID string) error {
+func (p *Processor) emitBatchedSeenCallbacks(registeredTxids map[string][]store.CallbackEntry, subtreeID string) error {
 	if len(registeredTxids) == 0 {
 		return nil
 	}
@@ -487,11 +492,18 @@ func (p *Processor) emitBatchedSeenCallbacks(registeredTxids map[string][]string
 	// on this attempt).
 	var firstErr error
 
-	// Invert txid→callbackURLs to callbackURL→txids for SEEN_ON_NETWORK.
+	// Invert txid→[]CallbackEntry to callbackURL→txids for SEEN_ON_NETWORK,
+	// while remembering the latest token observed per URL. If multiple txids
+	// have the same URL with different tokens (mid-rotation), the non-empty
+	// token wins; in practice they all came through the same /watch payload.
 	seenGroups := make(map[string][]string)
-	for txid, callbackURLs := range registeredTxids {
-		for _, url := range callbackURLs {
-			seenGroups[url] = append(seenGroups[url], txid)
+	urlTokens := make(map[string]string)
+	for txid, entries := range registeredTxids {
+		for _, e := range entries {
+			seenGroups[e.URL] = append(seenGroups[e.URL], txid)
+			if existing, ok := urlTokens[e.URL]; !ok || (existing == "" && e.Token != "") {
+				urlTokens[e.URL] = e.Token
+			}
 		}
 	}
 
@@ -500,9 +512,10 @@ func (p *Processor) emitBatchedSeenCallbacks(registeredTxids map[string][]string
 	for callbackURL, txids := range seenGroups {
 		for _, chunk := range chunkTxIDs(txids, callbackBatchChunkSize) {
 			msg := &kafka.CallbackTopicMessage{
-				CallbackURL: callbackURL,
-				Type:        kafka.CallbackSeenOnNetwork,
-				TxIDs:       chunk,
+				CallbackURL:   callbackURL,
+				CallbackToken: urlTokens[callbackURL],
+				Type:          kafka.CallbackSeenOnNetwork,
+				TxIDs:         chunk,
 			}
 			data, err := msg.Encode()
 			if err != nil {
@@ -532,7 +545,7 @@ func (p *Processor) emitBatchedSeenCallbacks(registeredTxids map[string][]string
 	// keep iterating remaining txids so independent counters still get their
 	// best-effort increment + threshold callback on this attempt.
 	thresholdGroups := make(map[string][]string) // callbackURL → threshold-reached txids
-	for txid, callbackURLs := range registeredTxids {
+	for txid, entries := range registeredTxids {
 		result, err := p.seenCounterStore.Increment(txid, subtreeID)
 		if err != nil {
 			p.Logger.Error("failed to increment seen counter", "txid", txid, "subtreeID", subtreeID, "error", err)
@@ -542,8 +555,8 @@ func (p *Processor) emitBatchedSeenCallbacks(registeredTxids map[string][]string
 			continue
 		}
 		if result.ThresholdReached {
-			for _, url := range callbackURLs {
-				thresholdGroups[url] = append(thresholdGroups[url], txid)
+			for _, e := range entries {
+				thresholdGroups[e.URL] = append(thresholdGroups[e.URL], txid)
 			}
 		}
 	}
@@ -552,9 +565,10 @@ func (p *Processor) emitBatchedSeenCallbacks(registeredTxids map[string][]string
 	for callbackURL, txids := range thresholdGroups {
 		for _, chunk := range chunkTxIDs(txids, callbackBatchChunkSize) {
 			msg := &kafka.CallbackTopicMessage{
-				CallbackURL: callbackURL,
-				Type:        kafka.CallbackSeenMultipleNodes,
-				TxIDs:       chunk,
+				CallbackURL:   callbackURL,
+				CallbackToken: urlTokens[callbackURL],
+				Type:          kafka.CallbackSeenMultipleNodes,
+				TxIDs:         chunk,
 			}
 			data, err := msg.Encode()
 			if err != nil {

--- a/internal/subtree/processor_test.go
+++ b/internal/subtree/processor_test.go
@@ -35,30 +35,47 @@ func startRawSubtreeServer(payload []byte) *httptest.Server {
 // --- Mock implementations ---
 
 type mockRegStore struct {
-	// registrations maps txid -> []callbackURL
+	// registrations maps txid -> []callbackURL. Tokens are "" for these
+	// entries — the SEEN-callback emit tests assert URL behavior, and a
+	// dedicated test exercises the token-propagation path.
 	registrations map[string][]string
+	// tokens optionally maps callbackURL → bearer token. Missing keys yield
+	// the zero value, i.e. no Authorization header is sent.
+	tokens        map[string]string
 	batchGetCalls [][]string // records each BatchGet call's txids
 	// batchGetErr, when non-nil, is returned from BatchGet instead of a result.
 	// Used to simulate backing-store outages (F-056).
 	batchGetErr error
 }
 
-func (m *mockRegStore) BatchGet(txids []string) (map[string][]string, error) {
+func (m *mockRegStore) entriesFor(txid string) []store.CallbackEntry {
+	urls, ok := m.registrations[txid]
+	if !ok {
+		return nil
+	}
+	out := make([]store.CallbackEntry, 0, len(urls))
+	for _, u := range urls {
+		out = append(out, store.CallbackEntry{URL: u, Token: m.tokens[u]})
+	}
+	return out
+}
+
+func (m *mockRegStore) BatchGet(txids []string) (map[string][]store.CallbackEntry, error) {
 	m.batchGetCalls = append(m.batchGetCalls, txids)
 	if m.batchGetErr != nil {
 		return nil, m.batchGetErr
 	}
-	result := make(map[string][]string)
+	result := make(map[string][]store.CallbackEntry)
 	for _, txid := range txids {
-		if urls, ok := m.registrations[txid]; ok {
-			result[txid] = urls
+		if entries := m.entriesFor(txid); len(entries) > 0 {
+			result[txid] = entries
 		}
 	}
 	return result, nil
 }
 
-func (m *mockRegStore) Get(txid string) ([]string, error) {
-	return m.registrations[txid], nil
+func (m *mockRegStore) Get(txid string) ([]store.CallbackEntry, error) {
+	return m.entriesFor(txid), nil
 }
 
 type mockSeenCounter struct{}
@@ -94,6 +111,22 @@ func (m *mockRegCache) SetMultiRegistered(txids []string) error {
 }
 
 // --- Helpers ---
+
+// toEntries lifts a urlsByTxID map into the CallbackEntry shape that
+// emitBatchedSeenCallbacks now consumes. Tokens default to empty (matches
+// the legacy URL-only test fixtures); pass a non-nil tokensByURL to attach
+// per-URL bearer tokens for token-propagation assertions.
+func toEntries(urlsByTxID map[string][]string, tokensByURL map[string]string) map[string][]store.CallbackEntry {
+	out := make(map[string][]store.CallbackEntry, len(urlsByTxID))
+	for txid, urls := range urlsByTxID {
+		entries := make([]store.CallbackEntry, 0, len(urls))
+		for _, u := range urls {
+			entries = append(entries, store.CallbackEntry{URL: u, Token: tokensByURL[u]})
+		}
+		out[txid] = entries
+	}
+	return out
+}
 
 // buildRawBytes creates DataHub-format raw subtree data from given 32-byte hashes.
 func buildRawBytes(hashes ...[]byte) []byte {
@@ -227,12 +260,12 @@ func TestFindRegisteredTxids_NoCache(t *testing.T) {
 	if len(result) != 1 {
 		t.Fatalf("expected 1 registered txid, got %d", len(result))
 	}
-	urls, ok := result[regTxid]
+	entries, ok := result[regTxid]
 	if !ok {
 		t.Fatalf("expected %s in result", regTxid)
 	}
-	if len(urls) != 1 || urls[0] != "http://callback.example.com/notify" {
-		t.Errorf("expected [http://callback.example.com/notify], got %v", urls)
+	if len(entries) != 1 || entries[0].URL != "http://callback.example.com/notify" {
+		t.Errorf("expected [http://callback.example.com/notify], got %v", entries)
 	}
 
 	// All txids should have been sent to store (no cache)
@@ -980,7 +1013,7 @@ func TestBatchedSeenCallbacks_SingleCallbackURL(t *testing.T) {
 		"tx3": {"http://arcade.example.com/cb"},
 	}
 
-	if err := p.emitBatchedSeenCallbacks(registered, "subtree-A"); err != nil {
+	if err := p.emitBatchedSeenCallbacks(toEntries(registered, nil), "subtree-A"); err != nil {
 		t.Fatalf("emitBatchedSeenCallbacks: %v", err)
 	}
 
@@ -1020,7 +1053,7 @@ func TestBatchedSeenCallbacks_MultipleCallbackURLs(t *testing.T) {
 		"tx3": {"http://url-A/cb"},
 	}
 
-	if err := p.emitBatchedSeenCallbacks(registered, "subtree-A"); err != nil {
+	if err := p.emitBatchedSeenCallbacks(toEntries(registered, nil), "subtree-A"); err != nil {
 		t.Fatalf("emitBatchedSeenCallbacks: %v", err)
 	}
 
@@ -1045,12 +1078,40 @@ func TestBatchedSeenCallbacks_MultipleCallbackURLs(t *testing.T) {
 	}
 }
 
+// TestBatchedSeenCallbacks_PropagatesCallbackToken verifies that the per-URL
+// bearer token registered on /watch flows all the way into the
+// CallbackTopicMessage that the SEEN callback emit publishes. Without this,
+// arcade's authenticated callback endpoint would 401 every SEEN delivery.
+func TestBatchedSeenCallbacks_PropagatesCallbackToken(t *testing.T) {
+	regStore := &mockRegStore{registrations: map[string][]string{}}
+	p, mockProd := newTestProcessor(t, regStore, &mockSeenCounter{})
+
+	const url = "http://arcade.example.com/cb"
+	const token = "tok-arcade-mainnet-v1" //nolint:gosec // test fixture, not a real credential
+	registered := map[string][]string{
+		"tx1": {url},
+		"tx2": {url},
+	}
+	if err := p.emitBatchedSeenCallbacks(toEntries(registered, map[string]string{url: token}), "subtree-A"); err != nil {
+		t.Fatalf("emitBatchedSeenCallbacks: %v", err)
+	}
+
+	msgs := mockProd.getMessages()
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 SEEN_ON_NETWORK message, got %d", len(msgs))
+	}
+	cb := decodeCallbackMsg(t, msgs[0])
+	if cb.CallbackToken != token {
+		t.Errorf("expected token %q on emitted message, got %q", token, cb.CallbackToken)
+	}
+}
+
 // TestBatchedSeenCallbacks_NoRegistered verifies no messages when no txids registered.
 func TestBatchedSeenCallbacks_NoRegistered(t *testing.T) {
 	regStore := &mockRegStore{registrations: map[string][]string{}}
 	p, mockProd := newTestProcessor(t, regStore, &mockSeenCounter{})
 
-	if err := p.emitBatchedSeenCallbacks(map[string][]string{}, "subtree-A"); err != nil {
+	if err := p.emitBatchedSeenCallbacks(map[string][]store.CallbackEntry{}, "subtree-A"); err != nil {
 		t.Fatalf("emitBatchedSeenCallbacks: %v", err)
 	}
 
@@ -1071,7 +1132,7 @@ func TestBatchedSeenCallbacks_SeenMultipleNodesThreshold(t *testing.T) {
 		"tx2": {"http://arcade/cb"},
 	}
 
-	if err := p.emitBatchedSeenCallbacks(registered, "subtree-A"); err != nil {
+	if err := p.emitBatchedSeenCallbacks(toEntries(registered, nil), "subtree-A"); err != nil {
 		t.Fatalf("emitBatchedSeenCallbacks: %v", err)
 	}
 
@@ -1112,7 +1173,7 @@ func TestBatchedSeenCallbacks_PartialThreshold(t *testing.T) {
 		"tx2": {"http://arcade/cb"},
 	}
 
-	if err := p.emitBatchedSeenCallbacks(registered, "subtree-A"); err != nil {
+	if err := p.emitBatchedSeenCallbacks(toEntries(registered, nil), "subtree-A"); err != nil {
 		t.Fatalf("emitBatchedSeenCallbacks: %v", err)
 	}
 
@@ -1145,7 +1206,7 @@ func TestBatchedSeenCallbacks_ChunksLargeBatch(t *testing.T) {
 		registered[fmt.Sprintf("tx%05d", i)] = []string{"http://arcade/cb"}
 	}
 
-	if err := p.emitBatchedSeenCallbacks(registered, "subtree-A"); err != nil {
+	if err := p.emitBatchedSeenCallbacks(toEntries(registered, nil), "subtree-A"); err != nil {
 		t.Fatalf("emitBatchedSeenCallbacks: %v", err)
 	}
 
@@ -1422,7 +1483,7 @@ func TestEmitBatchedSeenCallbacks_HappyPathReturnsNil(t *testing.T) {
 		"tx2": {"http://url-B/cb"},
 	}
 
-	if err := p.emitBatchedSeenCallbacks(registered, "subtree-happy"); err != nil {
+	if err := p.emitBatchedSeenCallbacks(toEntries(registered, nil), "subtree-happy"); err != nil {
 		t.Fatalf("expected nil error on happy path, got: %v", err)
 	}
 	if got := len(mockProd.getMessages()); got != 2 {
@@ -1449,7 +1510,7 @@ func TestEmitBatchedSeenCallbacks_PublishFailureReturnsError(t *testing.T) {
 		"tx2": {"http://url-B/cb"},
 	}
 
-	err := p.emitBatchedSeenCallbacks(registered, "subtree-fail")
+	err := p.emitBatchedSeenCallbacks(toEntries(registered, nil), "subtree-fail")
 	if err == nil {
 		t.Fatalf("expected non-nil error when callback publish fails")
 	}
@@ -1484,7 +1545,7 @@ func TestEmitBatchedSeenCallbacks_PartialFailureStillAttemptsOtherURLs(t *testin
 		"tx2": {okURL},
 	}
 
-	err := p.emitBatchedSeenCallbacks(registered, "subtree-partial")
+	err := p.emitBatchedSeenCallbacks(toEntries(registered, nil), "subtree-partial")
 	if err == nil {
 		t.Fatalf("expected non-nil error when one callback URL publish fails")
 	}
@@ -1759,7 +1820,7 @@ func TestEmitBatchedSeenCallbacks_IncrementFailureReturnsError(t *testing.T) {
 		"tx2": {"http://url-B/cb"},
 	}
 
-	err := p.emitBatchedSeenCallbacks(registered, "subtree-counter-fail")
+	err := p.emitBatchedSeenCallbacks(toEntries(registered, nil), "subtree-counter-fail")
 	if err == nil {
 		t.Fatalf("expected non-nil error when seen-counter Increment fails")
 	}

--- a/test/scale/scale_test.go
+++ b/test/scale/scale_test.go
@@ -57,7 +57,7 @@ func findNamespace() string {
 		}
 		// Verify namespace is writable with a probe write.
 		regStore := store.NewRegistrationStore(client, "ns_probe", 1, 50, 0, logger)
-		if err := regStore.Add("probe_txid", "http://probe"); err != nil {
+		if err := regStore.Add("probe_txid", "http://probe", ""); err != nil {
 			client.Close()
 			continue
 		}

--- a/test/scale/setup.go
+++ b/test/scale/setup.go
@@ -41,7 +41,7 @@ func preloadRegistrations(manifest *Manifest, txids [][]byte, regStore *store.Re
 					copy(h[:], txids[j])
 					txidStr := h.String()
 
-					if err := regStore.Add(txidStr, arcade.CallbackURL); err != nil {
+					if err := regStore.Add(txidStr, arcade.CallbackURL, ""); err != nil {
 						mu.Lock()
 						if firstErr == nil {
 							firstErr = fmt.Errorf("adding registration for txid index %d: %w", j, err)
@@ -69,7 +69,7 @@ func preloadRegistrations(manifest *Manifest, txids [][]byte, regStore *store.Re
 // preloadCallbackURLRegistry adds all callback URLs to the broadcast registry.
 func preloadCallbackURLRegistry(manifest *Manifest, urlRegistry *store.CallbackURLRegistry) error {
 	for _, arcade := range manifest.ArcadeInstances {
-		if err := urlRegistry.Add(arcade.CallbackURL); err != nil {
+		if err := urlRegistry.Add(arcade.CallbackURL, ""); err != nil {
 			return fmt.Errorf("adding callback URL for arcade %d: %w", arcade.Index, err)
 		}
 	}

--- a/tools/debug-dashboard/handlers.go
+++ b/tools/debug-dashboard/handlers.go
@@ -146,16 +146,20 @@ func (h *Handlers) handleLookup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	urls, err := h.regStore.Get(txid)
+	entries, err := h.regStore.Get(txid)
 
 	data := h.newHomeData()
 	data.LookupTxid = txid
 
 	if err != nil {
 		data.LookupErr = fmt.Sprintf("Error querying Aerospike: %v", err)
-	} else if len(urls) == 0 {
+	} else if len(entries) == 0 {
 		data.LookupErr = "No registrations found"
 	} else {
+		urls := make([]string, 0, len(entries))
+		for _, e := range entries {
+			urls = append(urls, e.URL)
+		}
 		data.LookupURLs = urls
 		// Track this txid if not already tracked.
 		h.txidTracker.Add(txid, urls)
@@ -169,8 +173,12 @@ func (h *Handlers) handleRegistrations(w http.ResponseWriter, r *http.Request) {
 	// Refresh callback URLs from Aerospike for all tracked txids.
 	tracked := h.txidTracker.GetAll()
 	for _, t := range tracked {
-		urls, err := h.regStore.Get(t.Txid)
-		if err == nil && len(urls) > 0 {
+		entries, err := h.regStore.Get(t.Txid)
+		if err == nil && len(entries) > 0 {
+			urls := make([]string, 0, len(entries))
+			for _, e := range entries {
+				urls = append(urls, e.URL)
+			}
 			h.txidTracker.UpdateCallbackURLs(t.Txid, urls)
 		}
 	}


### PR DESCRIPTION
## Summary

Closes the merkle-service half of the broken callback-auth loop. arcade requires `Authorization: Bearer <cfg.CallbackToken>` on its callback endpoint (PR #112), but until now we had no concept of a token. This PR:

- Accepts `callbackToken` in `/watch` JSON
- Stores it per-URL in both Aerospike and SQL backends
- Propagates it through `CallbackTopicMessage` to delivery
- Sets `Authorization: Bearer <token>` on outbound HTTP when non-empty

## Migration safety

Aerospike reader dual-reads both bare-string entries (legacy, token = "") and `{u, t}` map entries (new). Writers always emit the new shape. Existing in-flight registrations stay valid; on next `/watch` from arcade they get rewritten with the token. **No callbacks are lost during rollout.**

SQL migrations 0003 and 0004 `ADD COLUMN ... NOT NULL DEFAULT ''`. Existing rows untouched.

## Back-compat

Empty/missing token = no `Authorization` header. Identical to today's behaviour. Pre-rollout arcade deployments (without the matching PR) continue to silently fail closed at arcade's inbound check, which is the correct semantics.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race`
- [x] /watch round-trip stores/returns the token
- [x] Delivery sets Authorization when non-empty, omits when empty
- [x] SQL round-trip via in-memory sqlite
- [x] Aerospike dual-read parse logic exercised in unit test
- [ ] Reviewer to validate the migration ordering on the running mainnet DB

## Coordination
Pairs with arcade PR <link>. Land both within the same window. **arcade-v2 testnet and teratestnet flux configmaps need a callback_token added** (mainnet already has one). See plan in /home/dylan/.claude/plans/in-this-directory-we-serene-star.md.