### PR TITLE
Add ability to reprocess blocks

### DIFF
--- a/.github/env/00-core.env
+++ b/.github/env/00-core.env
@@ -29,7 +29,7 @@ GO_PRIMARY_VERSION=1.24.x
 GO_SECONDARY_VERSION=1.24.x
 
 # Govulncheck-specific Go version for vulnerability scanning
-GOVULNCHECK_GO_VERSION=1.26.2
+GOVULNCHECK_GO_VERSION=1.26.x
 
 # ================================================================================================
 # 📦 GO MODULE CONFIGURATION

--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/bsv-blockchain/merkle-service/internal/api"
 	"github.com/bsv-blockchain/merkle-service/internal/config"
+	"github.com/bsv-blockchain/merkle-service/internal/datahub"
+	"github.com/bsv-blockchain/merkle-service/internal/kafka"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
 	_ "github.com/bsv-blockchain/merkle-service/internal/store/sql" // register SQL backend
@@ -28,6 +30,31 @@ func main() {
 
 	server := api.NewServer(cfg.API, registry.Registration, registry.CallbackURLRegistry, registry.Health, logger)
 	server.SetAllowPrivateCallbackIPs(cfg.Callback.AllowPrivateIPs)
+
+	// /reprocess deps. The DataHub client honors the same SSRF posture as the
+	// block-processor so /reprocess can't be coerced into probing
+	// loopback/RFC1918 addresses unless the operator opted in via
+	// datahub.allowPrivateIPs.
+	blockProducer, err := kafka.NewProducer(cfg.Kafka.Brokers, cfg.Kafka.BlockTopic, logger)
+	if err != nil {
+		log.Fatal("failed to create block producer: ", err)
+	}
+	defer func() { _ = blockProducer.Close() }()
+
+	dataHubClient := datahub.NewClientWithSSRFGuard(
+		cfg.DataHub.TimeoutSec,
+		cfg.DataHub.MaxRetries,
+		cfg.DataHub.MaxBlockBytes,
+		cfg.DataHub.MaxSubtreeBytes,
+		cfg.DataHub.AllowPrivateIPs,
+		logger,
+	)
+	server.SetReprocessDeps(&api.ReprocessDeps{
+		DataHubRegistry:     registry.DataHubRegistry,
+		DataHubClient:       dataHubClient,
+		BlockProducer:       blockProducer,
+		FallbackDataHubURLs: cfg.DataHub.FallbackURLs,
+	})
 
 	if err := server.Init(nil); err != nil {
 		log.Fatal("failed to init api server: ", err)

--- a/cmd/block-processor/main.go
+++ b/cmd/block-processor/main.go
@@ -28,7 +28,7 @@ func main() {
 
 	processor := block.NewProcessor(
 		cfg.Kafka, cfg.Block, cfg.DataHub,
-		registry.Registration, registry.Subtree, registry.CallbackURLRegistry, registry.SubtreeCounter,
+		registry.Registration, registry.Subtree, registry.CallbackURLRegistry, registry.DataHubRegistry, registry.SubtreeCounter,
 		logger,
 	)
 

--- a/cmd/merkle-service/main.go
+++ b/cmd/merkle-service/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bsv-blockchain/merkle-service/internal/block"
 	"github.com/bsv-blockchain/merkle-service/internal/callback"
 	"github.com/bsv-blockchain/merkle-service/internal/config"
+	"github.com/bsv-blockchain/merkle-service/internal/datahub"
 	"github.com/bsv-blockchain/merkle-service/internal/kafka"
 	"github.com/bsv-blockchain/merkle-service/internal/p2p"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
@@ -45,9 +46,22 @@ func main() {
 
 	apiServer := api.NewServer(cfg.API, registry.Registration, registry.CallbackURLRegistry, registry.Health, logger)
 	apiServer.SetAllowPrivateCallbackIPs(cfg.Callback.AllowPrivateIPs)
+	apiServer.SetReprocessDeps(&api.ReprocessDeps{
+		DataHubRegistry: registry.DataHubRegistry,
+		DataHubClient: datahub.NewClientWithSSRFGuard(
+			cfg.DataHub.TimeoutSec,
+			cfg.DataHub.MaxRetries,
+			cfg.DataHub.MaxBlockBytes,
+			cfg.DataHub.MaxSubtreeBytes,
+			cfg.DataHub.AllowPrivateIPs,
+			logger,
+		),
+		BlockProducer:       blockProducer,
+		FallbackDataHubURLs: cfg.DataHub.FallbackURLs,
+	})
 	p2pClient := p2p.NewClient(cfg.P2P, subtreeProducer, blockProducer, logger)
 	subtreeFetcher := subtree.NewProcessor(cfg, registry.Registration, registry.SeenCounter, registry.Subtree)
-	blockProcessor := block.NewProcessor(cfg.Kafka, cfg.Block, cfg.DataHub, registry.Registration, registry.Subtree, registry.CallbackURLRegistry, registry.SubtreeCounter, logger)
+	blockProcessor := block.NewProcessor(cfg.Kafka, cfg.Block, cfg.DataHub, registry.Registration, registry.Subtree, registry.CallbackURLRegistry, registry.DataHubRegistry, registry.SubtreeCounter, logger)
 	subtreeWorker := block.NewSubtreeWorkerService(cfg.Kafka, cfg.Block, cfg.DataHub, registry.Registration, registry.Subtree, registry.Stump, registry.CallbackURLRegistry, registry.SubtreeCounter, logger)
 	callbackDelivery := callback.NewDeliveryService(cfg, registry.CallbackDedup, registry.Stump)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -75,6 +75,71 @@ Expected output:
 
 ---
 
+## POST /reprocess
+
+Trigger on-demand reprocessing of a past block. The merkle service fetches the named block from a known DataHub, rebuilds STUMPs for transactions the requester has registered via `/watch`, and delivers them — along with a single `BLOCK_PROCESSED` callback — exclusively to the supplied callback URL. Other arcades' watched txids are not exposed.
+
+The caller does **not** supply a DataHub URL. The service probes its operator-configured fallbacks (`datahub.fallbackUrls`) followed by every DataHub it has observed serving a live block (the discovered set), in order, and uses the first one that returns metadata for the requested hash.
+
+### Request
+
+| Field           | Type    | Required | Description                                                                |
+|-----------------|---------|----------|----------------------------------------------------------------------------|
+| `blockHash`     | string  | Yes      | Block hash; 64-character hexadecimal string.                               |
+| `callbackUrl`   | string  | Yes      | HTTP(S) URL to receive the STUMP and BLOCK_PROCESSED callbacks.            |
+| `callbackToken` | string  | No       | Optional bearer token sent as `Authorization: Bearer <token>` on delivery. |
+
+### Responses
+
+**202 Accepted** — block found on a DataHub; reprocess enqueued. Delivery is asynchronous through the same callback pipeline as live block processing.
+
+```json
+{
+  "status": "queued",
+  "blockHash": "deadbeef...",
+  "dataHubUrl": "https://datahub.example/"
+}
+```
+
+**400 Bad Request** — validation failure (bad hash, missing/invalid `callbackUrl`, oversized `callbackToken`, malformed body, SSRF-blocked callback URL).
+
+**404 Not Found** — every probed DataHub returned 404 for this block hash.
+
+```json
+{ "error": "block not found on any known DataHub" }
+```
+
+**502 Bad Gateway** — every probed DataHub failed for transport / 5xx reasons. The block may exist; retry later.
+
+**503 Service Unavailable** — the API server has no DataHubs (no operator-configured fallbacks and an empty discovered set), or the reprocess endpoint was started without its required dependencies.
+
+### Scoping and ordering
+
+- **STUMPs**: only built for txids the caller has previously registered against **this same `callbackUrl`** via `/watch`. The supplied `callbackToken` overrides whatever token was last stored for that URL — the request token is the source of truth for this delivery.
+- **BLOCK_PROCESSED**: emitted exactly once per reprocess, addressed to the request's `callbackUrl`/`callbackToken`. The global broadcast registry is **not** consulted; other arcades never see this past block via the reprocess flow.
+- **Counter scoping**: the per-block subtree counter is keyed by `(blockHash | callbackUrl)` so a `/reprocess` for a block already being processed live, or a second `/reprocess` for the same block by a different arcade, does not collide.
+- **Idempotency**: a duplicate request for the same `(blockHash, callbackUrl)` re-runs the pipeline; receiver-side dedup at the callback delivery service collapses any duplicate STUMP / BLOCK_PROCESSED into a single delivery.
+
+### curl example
+
+```bash
+curl -X POST http://localhost:8080/reprocess \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "blockHash": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    "callbackUrl": "https://arcade.example/merkle-callbacks",
+    "callbackToken": "rotating-shared-secret"
+  }'
+```
+
+Expected output (truncated):
+
+```json
+{"status":"queued","blockHash":"deadbeef...","dataHubUrl":"https://datahub.example/"}
+```
+
+---
+
 ## GET /health
 
 Returns service health status including Aerospike connectivity.

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1,13 +1,17 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"regexp"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/bsv-blockchain/merkle-service/internal/datahub"
+	"github.com/bsv-blockchain/merkle-service/internal/kafka"
 	"github.com/bsv-blockchain/merkle-service/internal/ssrfguard"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
 )
@@ -192,6 +196,217 @@ func (s *Server) handleLookup(w http.ResponseWriter, r *http.Request) {
 		TxID:         txid,
 		CallbackUrls: urls,
 	})
+}
+
+// blockHashRegex is the same shape as txidRegex (64-hex) but named for
+// clarity at the /reprocess call site.
+var blockHashRegex = regexp.MustCompile(`^[a-fA-F0-9]{64}$`)
+
+// reprocessProbeTimeout caps the per-DataHub block-metadata probe inside
+// /reprocess so a single unhealthy DataHub can't hold the API request
+// past the surrounding HTTP write timeout.
+const reprocessProbeTimeout = 5 * time.Second
+
+// ReprocessRequest represents the POST /reprocess request body.
+//
+// CallbackURL/Token are scoped to this single reprocess: STUMPs and
+// BLOCK_PROCESSED for the requested block flow only to this URL/token,
+// independent of whatever URLs are registered globally via /watch. Tokens
+// are optional for back-compat with arcade deployments that haven't
+// shipped the matching token-passing change.
+type ReprocessRequest struct {
+	BlockHash     string `json:"blockHash"`
+	CallbackURL   string `json:"callbackUrl"`
+	CallbackToken string `json:"callbackToken,omitempty"`
+}
+
+// ReprocessResponse represents the 202 ACK body for POST /reprocess.
+type ReprocessResponse struct {
+	Status     string `json:"status"`
+	BlockHash  string `json:"blockHash"`
+	DataHubURL string `json:"dataHubUrl"`
+}
+
+func (s *Server) handleReprocess(w http.ResponseWriter, r *http.Request) {
+	if s.dataHubClient == nil || s.blockProducer == nil {
+		writeJSON(w, http.StatusServiceUnavailable, ErrorResponse{
+			Error: "reprocess endpoint not configured on this server",
+		})
+		return
+	}
+
+	var req ReprocessRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, ErrorResponse{Error: "invalid request body"})
+		return
+	}
+
+	if req.BlockHash == "" {
+		writeJSON(w, http.StatusBadRequest, ErrorResponse{Error: "blockHash is required"})
+		return
+	}
+	if !blockHashRegex.MatchString(req.BlockHash) {
+		writeJSON(w, http.StatusBadRequest, ErrorResponse{Error: "invalid blockHash format: must be a 64-character hex string"})
+		return
+	}
+	if req.CallbackURL == "" {
+		writeJSON(w, http.StatusBadRequest, ErrorResponse{Error: "callbackUrl is required"})
+		return
+	}
+	if err := ssrfguard.ValidateURL(req.CallbackURL, s.allowPrivateCallbackIPs, nil); err != nil {
+		var msg string
+		switch {
+		case errors.Is(err, ssrfguard.ErrBlockedAddress):
+			msg = "invalid callbackUrl: host is on the SSRF deny-list (private, loopback, link-local, or metadata-endpoint address)"
+		default:
+			msg = "invalid callbackUrl: must be a valid HTTP/HTTPS URL with a public host"
+		}
+		s.Logger.Warn("rejected reprocess callback URL",
+			"reason", err.Error(),
+			"blockHash", req.BlockHash,
+		)
+		writeJSON(w, http.StatusBadRequest, ErrorResponse{Error: msg})
+		return
+	}
+	if len(req.CallbackToken) > maxCallbackTokenLen {
+		writeJSON(w, http.StatusBadRequest, ErrorResponse{
+			Error: "invalid callbackToken: exceeds maximum length",
+		})
+		return
+	}
+
+	// Build candidate DataHub list: operator-configured fallbacks first
+	// (operator-trusted), then dynamically-discovered URLs. Dedupe so a
+	// URL listed in both is probed only once.
+	candidates := s.collectDataHubCandidates()
+	if len(candidates) == 0 {
+		writeJSON(w, http.StatusServiceUnavailable, ErrorResponse{
+			Error: "no DataHub endpoints configured or discovered",
+		})
+		return
+	}
+
+	resolvedURL, height, status, probeErr := s.probeDataHubsForBlock(r.Context(), candidates, req.BlockHash)
+	if probeErr != nil {
+		s.Logger.Warn("reprocess: no DataHub served block",
+			"blockHash", req.BlockHash,
+			"candidates", len(candidates),
+			"status", status,
+			"error", probeErr,
+		)
+		writeJSON(w, status, ErrorResponse{Error: probeErr.Error()})
+		return
+	}
+
+	blockMsg := kafka.BlockMessage{
+		Hash:                  req.BlockHash,
+		Height:                height,
+		DataHubURL:            resolvedURL,
+		OverrideCallbackURL:   req.CallbackURL,
+		OverrideCallbackToken: req.CallbackToken,
+		BypassDedup:           true,
+	}
+	encoded, err := blockMsg.Encode()
+	if err != nil {
+		s.Logger.Error("failed to encode reprocess block message",
+			"blockHash", req.BlockHash, "error", err)
+		writeJSON(w, http.StatusInternalServerError, ErrorResponse{Error: "internal server error"})
+		return
+	}
+	// Partition key includes the override URL so a /reprocess never collides
+	// with a live announcement of the same block on the same partition.
+	partitionKey := req.BlockHash + "|" + req.CallbackURL
+	if err := s.blockProducer.PublishWithHashKey(partitionKey, encoded); err != nil {
+		s.Logger.Error("failed to publish reprocess block message",
+			"blockHash", req.BlockHash, "error", err)
+		writeJSON(w, http.StatusInternalServerError, ErrorResponse{Error: "failed to enqueue reprocess"})
+		return
+	}
+
+	s.Logger.Info("reprocess enqueued",
+		"blockHash", req.BlockHash,
+		"dataHubUrl", resolvedURL,
+		"callbackUrl", req.CallbackURL,
+	)
+	writeJSON(w, http.StatusAccepted, ReprocessResponse{
+		Status:     "queued",
+		BlockHash:  req.BlockHash,
+		DataHubURL: resolvedURL,
+	})
+}
+
+// collectDataHubCandidates returns the deduped, ordered list of DataHub URLs
+// /reprocess should probe. Operator-configured fallbacks come first so they
+// take precedence on tie; discovered URLs are appended. A registry-lookup
+// error is logged and treated as "no discovered URLs" — the configured
+// fallback list still serves the request.
+func (s *Server) collectDataHubCandidates() []string {
+	seen := make(map[string]struct{}, len(s.fallbackDataHubURLs))
+	out := make([]string, 0, len(s.fallbackDataHubURLs))
+	for _, u := range s.fallbackDataHubURLs {
+		if u == "" {
+			continue
+		}
+		if _, ok := seen[u]; ok {
+			continue
+		}
+		seen[u] = struct{}{}
+		out = append(out, u)
+	}
+	if s.dataHubRegistry != nil {
+		discovered, err := s.dataHubRegistry.GetAll()
+		if err != nil {
+			s.Logger.Warn("reprocess: failed to read DataHub registry; falling back to configured URLs only",
+				"error", err)
+			return out
+		}
+		for _, u := range discovered {
+			if u == "" {
+				continue
+			}
+			if _, ok := seen[u]; ok {
+				continue
+			}
+			seen[u] = struct{}{}
+			out = append(out, u)
+		}
+	}
+	return out
+}
+
+// probeDataHubsForBlock tries each candidate DataHub in order and returns
+// the first one that successfully serves block metadata for blockHash, the
+// block's height, and HTTP 202 (status echoes the API response shape:
+// caller should write 202 on success). On exhausted candidates, returns:
+//   - 404 if every probe returned ErrNotFound (block genuinely missing).
+//   - 502 if every probe failed for any other reason (transport, timeout, 5xx).
+//
+// Mixed outcomes are bucketed as 502 since at least one DataHub couldn't
+// confirm a 404, and the caller should treat the result as ambiguous and
+// retry later.
+func (s *Server) probeDataHubsForBlock(parentCtx context.Context, candidates []string, blockHash string) (string, uint32, int, error) {
+	allNotFound := true
+	for _, url := range candidates {
+		ctx, cancel := context.WithTimeout(parentCtx, reprocessProbeTimeout)
+		meta, err := s.dataHubClient.FetchBlockMetadata(ctx, url, blockHash)
+		cancel()
+		if err == nil {
+			return url, meta.Height, http.StatusAccepted, nil
+		}
+		if !errors.Is(err, datahub.ErrNotFound) {
+			allNotFound = false
+		}
+		s.Logger.Debug("reprocess probe failed",
+			"dataHubUrl", url,
+			"blockHash", blockHash,
+			"notFound", errors.Is(err, datahub.ErrNotFound),
+			"error", err,
+		)
+	}
+	if allNotFound {
+		return "", 0, http.StatusNotFound, errors.New("block not found on any known DataHub")
+	}
+	return "", 0, http.StatusBadGateway, errors.New("no DataHub could serve the requested block")
 }
 
 func writeJSON(w http.ResponseWriter, status int, v interface{}) {

--- a/internal/api/reprocess_test.go
+++ b/internal/api/reprocess_test.go
@@ -1,0 +1,368 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/teranode/model"
+	"github.com/go-chi/chi/v5"
+
+	"github.com/bsv-blockchain/merkle-service/internal/datahub"
+	"github.com/bsv-blockchain/merkle-service/internal/kafka"
+)
+
+const fixtureBlockHash = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+// recordingProducer captures Kafka publishes so /reprocess tests can assert
+// on the enqueued BlockMessage without standing up a broker.
+type recordingProducer struct {
+	publishErr error
+	keys       []string
+	values     [][]byte
+}
+
+func (r *recordingProducer) PublishWithHashKey(key string, value []byte) error {
+	if r.publishErr != nil {
+		return r.publishErr
+	}
+	r.keys = append(r.keys, key)
+	cp := make([]byte, len(value))
+	copy(cp, value)
+	r.values = append(r.values, cp)
+	return nil
+}
+
+// fakeDataHubRegistry returns a fixed list and optionally an error.
+type fakeDataHubRegistry struct {
+	urls   []string
+	getErr error
+}
+
+func (f *fakeDataHubRegistry) Add(string) error          { return nil }
+func (f *fakeDataHubRegistry) GetAll() ([]string, error) { return f.urls, f.getErr }
+
+// newReprocessRouter builds a chi router with the /reprocess route and the
+// supplied dependencies. Avoids depending on api.Server.Init (which builds a
+// listener) so tests stay hermetic.
+func newReprocessRouter(s *Server) http.Handler {
+	router := chi.NewRouter()
+	router.Post("/reprocess", s.handleReprocess)
+	return router
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// dataHubServer returns an httptest.Server that responds at the
+// /block/<hash> path with the configured status. When status==200, the
+// response body is the bytes returned by bodyFn(hash). bodyFn==nil writes
+// an empty 200 body which the DataHub binary parser will reject — that
+// path is not exercised by the success cases below (which use a real
+// fixture). 404/5xx are easy to construct since they never read the body.
+func dataHubServer(t *testing.T, status int, bodyFn func(hash string) []byte) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if status == http.StatusNotFound {
+			http.NotFound(w, r)
+			return
+		}
+		if status >= 500 {
+			http.Error(w, "boom", status)
+			return
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(status)
+		if bodyFn != nil {
+			_, _ = w.Write(bodyFn(r.URL.Path))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newReprocessServer(t *testing.T, deps *ReprocessDeps) *Server {
+	t.Helper()
+	s := &Server{}
+	s.InitBase("test")
+	s.Logger = discardLogger()
+	s.SetReprocessDeps(deps)
+	return s
+}
+
+func postReprocess(router http.Handler, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/reprocess", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// TestHandleReprocess_NotConfigured returns 503 when the endpoint is wired
+// without a DataHub client or block producer.
+func TestHandleReprocess_NotConfigured(t *testing.T) {
+	s := &Server{}
+	s.InitBase("test")
+	s.Logger = discardLogger()
+	router := newReprocessRouter(s)
+
+	body := fmt.Sprintf(`{"blockHash":%q,"callbackUrl":"https://1.1.1.1/cb"}`, fixtureBlockHash)
+	w := postReprocess(router, body)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleReprocess_Validation(t *testing.T) {
+	prod := &recordingProducer{}
+	dataHub := datahub.NewClient(5, 0, discardLogger())
+	s := newReprocessServer(t, &ReprocessDeps{
+		DataHubClient: dataHub,
+		BlockProducer: nil, // must be supplied separately below
+	})
+	// SetReprocessDeps wraps a *kafka.Producer; for tests we bypass the
+	// public setter and assign the interface field directly.
+	s.blockProducer = prod
+	router := newReprocessRouter(s)
+
+	cases := []struct {
+		name string
+		body string
+		want int
+	}{
+		{"missing blockHash", `{"callbackUrl":"https://1.1.1.1/cb"}`, http.StatusBadRequest},
+		{"bad blockHash", `{"blockHash":"abc","callbackUrl":"https://1.1.1.1/cb"}`, http.StatusBadRequest},
+		{"missing callbackUrl", fmt.Sprintf(`{"blockHash":%q}`, fixtureBlockHash), http.StatusBadRequest},
+		{"loopback callbackUrl rejected", fmt.Sprintf(`{"blockHash":%q,"callbackUrl":"http://127.0.0.1/cb"}`, fixtureBlockHash), http.StatusBadRequest},
+		{"bad json", `not json`, http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := postReprocess(router, tc.body)
+			if w.Code != tc.want {
+				t.Fatalf("expected %d, got %d (body=%s)", tc.want, w.Code, w.Body.String())
+			}
+		})
+	}
+
+	if len(prod.keys) != 0 {
+		t.Fatalf("validation failures must not enqueue, got %d publishes", len(prod.keys))
+	}
+}
+
+// TestHandleReprocess_NoCandidates returns 503 when no DataHub URLs are
+// configured and the registry is empty.
+func TestHandleReprocess_NoCandidates(t *testing.T) {
+	prod := &recordingProducer{}
+	s := newReprocessServer(t, &ReprocessDeps{
+		DataHubClient: datahub.NewClient(5, 0, discardLogger()),
+		BlockProducer: nil,
+	})
+	s.blockProducer = prod
+	router := newReprocessRouter(s)
+
+	body := fmt.Sprintf(`{"blockHash":%q,"callbackUrl":"https://1.1.1.1/cb"}`, fixtureBlockHash)
+	w := postReprocess(router, body)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleReprocess_AllCandidates404 returns 404 when every probed
+// DataHub returns 404 — the block is genuinely unknown to the network.
+func TestHandleReprocess_AllCandidates404(t *testing.T) {
+	hub1 := dataHubServer(t, http.StatusNotFound, nil)
+	hub2 := dataHubServer(t, http.StatusNotFound, nil)
+	s := newReprocessServer(t, &ReprocessDeps{
+		DataHubClient:       datahub.NewClient(5, 0, discardLogger()),
+		FallbackDataHubURLs: []string{hub1.URL, hub2.URL},
+	})
+	s.blockProducer = &recordingProducer{}
+	router := newReprocessRouter(s)
+
+	body := fmt.Sprintf(`{"blockHash":%q,"callbackUrl":"https://1.1.1.1/cb"}`, fixtureBlockHash)
+	w := postReprocess(router, body)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleReprocess_All5xx returns 502 when every probe fails for
+// non-404 reasons. The caller can't tell whether the block exists, so
+// "bad gateway" rather than "not found" is the honest answer.
+func TestHandleReprocess_All5xx(t *testing.T) {
+	hub1 := dataHubServer(t, http.StatusInternalServerError, nil)
+	hub2 := dataHubServer(t, http.StatusInternalServerError, nil)
+	s := newReprocessServer(t, &ReprocessDeps{
+		DataHubClient:       datahub.NewClient(2, 0, discardLogger()),
+		FallbackDataHubURLs: []string{hub1.URL, hub2.URL},
+	})
+	s.blockProducer = &recordingProducer{}
+	router := newReprocessRouter(s)
+
+	body := fmt.Sprintf(`{"blockHash":%q,"callbackUrl":"https://1.1.1.1/cb"}`, fixtureBlockHash)
+	w := postReprocess(router, body)
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleReprocess_MixedFailures returns 502 when at least one probe
+// failed for non-404 reasons — we can't conclude the block doesn't exist.
+func TestHandleReprocess_MixedFailures(t *testing.T) {
+	hub1 := dataHubServer(t, http.StatusNotFound, nil)
+	hub2 := dataHubServer(t, http.StatusInternalServerError, nil)
+	s := newReprocessServer(t, &ReprocessDeps{
+		DataHubClient:       datahub.NewClient(2, 0, discardLogger()),
+		FallbackDataHubURLs: []string{hub1.URL, hub2.URL},
+	})
+	s.blockProducer = &recordingProducer{}
+	router := newReprocessRouter(s)
+
+	body := fmt.Sprintf(`{"blockHash":%q,"callbackUrl":"https://1.1.1.1/cb"}`, fixtureBlockHash)
+	w := postReprocess(router, body)
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleReprocess_DedupesCandidates ensures /reprocess does not double-
+// probe a URL that is both configured and in the discovered registry.
+func TestHandleReprocess_DedupesCandidates(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		http.NotFound(w, &http.Request{})
+	}))
+	defer srv.Close()
+
+	s := newReprocessServer(t, &ReprocessDeps{
+		DataHubClient:       datahub.NewClient(2, 0, discardLogger()),
+		FallbackDataHubURLs: []string{srv.URL},
+		DataHubRegistry:     &fakeDataHubRegistry{urls: []string{srv.URL}},
+	})
+	s.blockProducer = &recordingProducer{}
+	router := newReprocessRouter(s)
+
+	body := fmt.Sprintf(`{"blockHash":%q,"callbackUrl":"https://1.1.1.1/cb"}`, fixtureBlockHash)
+	w := postReprocess(router, body)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected single probe (configured + discovered should dedupe), got %d", got)
+	}
+}
+
+// TestHandleReprocess_RegistryErrorFallsBackToConfigured tolerates a
+// DataHub registry lookup error: the configured fallback list still
+// serves the request.
+func TestHandleReprocess_RegistryErrorFallsBackToConfigured(t *testing.T) {
+	hub := dataHubServer(t, http.StatusNotFound, nil)
+	s := newReprocessServer(t, &ReprocessDeps{
+		DataHubClient:       datahub.NewClient(2, 0, discardLogger()),
+		FallbackDataHubURLs: []string{hub.URL},
+		DataHubRegistry:     &fakeDataHubRegistry{getErr: errors.New("registry down")},
+	})
+	s.blockProducer = &recordingProducer{}
+	router := newReprocessRouter(s)
+
+	body := fmt.Sprintf(`{"blockHash":%q,"callbackUrl":"https://1.1.1.1/cb"}`, fixtureBlockHash)
+	w := postReprocess(router, body)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 (registry error tolerated), got %d", w.Code)
+	}
+}
+
+// TestHandleReprocess_PublishesScopedBlockMessage exercises the success
+// path with a fixture DataHub. The fake DataHub returns a parsable
+// model.Block so FetchBlockMetadata succeeds; we then assert the
+// recorded BlockMessage carries the override fields and BypassDedup, and
+// the partition key scopes to (blockHash | callbackURL).
+func TestHandleReprocess_PublishesScopedBlockMessage(t *testing.T) {
+	blockBody := tinyBlockFixture(t)
+	hub := dataHubServer(t, http.StatusOK, func(string) []byte { return blockBody })
+	prod := &recordingProducer{}
+	s := newReprocessServer(t, &ReprocessDeps{
+		DataHubClient:       datahub.NewClient(5, 0, discardLogger()),
+		FallbackDataHubURLs: []string{hub.URL},
+	})
+	s.blockProducer = prod
+	router := newReprocessRouter(s)
+
+	const callbackURL = "https://1.1.1.1/arcade/cb"
+	const callbackToken = "tok-reprocess"
+	body := fmt.Sprintf(`{"blockHash":%q,"callbackUrl":%q,"callbackToken":%q}`, fixtureBlockHash, callbackURL, callbackToken)
+	w := postReprocess(router, body)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	if len(prod.keys) != 1 {
+		t.Fatalf("expected exactly one publish, got %d", len(prod.keys))
+	}
+	wantKey := fixtureBlockHash + "|" + callbackURL
+	if prod.keys[0] != wantKey {
+		t.Fatalf("partition key mismatch: got %q want %q", prod.keys[0], wantKey)
+	}
+	var msg kafka.BlockMessage
+	if err := json.Unmarshal(prod.values[0], &msg); err != nil {
+		t.Fatalf("decode publish payload: %v", err)
+	}
+	if msg.Hash != fixtureBlockHash {
+		t.Errorf("Hash mismatch: %q", msg.Hash)
+	}
+	if msg.OverrideCallbackURL != callbackURL {
+		t.Errorf("OverrideCallbackURL: got %q want %q", msg.OverrideCallbackURL, callbackURL)
+	}
+	if msg.OverrideCallbackToken != callbackToken {
+		t.Errorf("OverrideCallbackToken: got %q want %q", msg.OverrideCallbackToken, callbackToken)
+	}
+	if !msg.BypassDedup {
+		t.Errorf("expected BypassDedup=true on reprocess message")
+	}
+	if msg.DataHubURL != hub.URL {
+		t.Errorf("DataHubURL: got %q want %q", msg.DataHubURL, hub.URL)
+	}
+
+	// 202 body echoes the resolved URL so the caller can correlate.
+	var resp ReprocessResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode 202 body: %v", err)
+	}
+	if resp.Status != "queued" || resp.BlockHash != fixtureBlockHash || resp.DataHubURL != hub.URL {
+		t.Errorf("response body: %+v", resp)
+	}
+}
+
+// tinyBlockFixture builds a minimal teranode model.Block binary payload
+// suitable for the DataHub /block/<hash> response. The block hash itself is
+// not validated against the request hash by ParseBinaryBlockMetadata, so we
+// only need the bytes to be a parsable block.
+func tinyBlockFixture(t *testing.T) []byte {
+	t.Helper()
+	header := &model.BlockHeader{
+		HashPrevBlock:  &chainhash.Hash{},
+		HashMerkleRoot: &chainhash.Hash{},
+	}
+	subtreeHash := &chainhash.Hash{}
+	subtreeHash[0] = 0xab
+	block, err := model.NewBlock(header, nil, []*chainhash.Hash{subtreeHash}, 0, 0, 1, 0)
+	if err != nil {
+		t.Fatalf("model.NewBlock: %v", err)
+	}
+	data, err := block.Bytes()
+	if err != nil {
+		t.Fatalf("block.Bytes: %v", err)
+	}
+	return data
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -12,6 +12,8 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 
 	"github.com/bsv-blockchain/merkle-service/internal/config"
+	"github.com/bsv-blockchain/merkle-service/internal/datahub"
+	"github.com/bsv-blockchain/merkle-service/internal/kafka"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
 )
@@ -23,17 +25,40 @@ var dashboardHTML []byte
 type Server struct {
 	service.BaseService
 
-	cfg         config.APIConfig
-	httpServer  *http.Server
-	router      chi.Router
-	regStore    store.RegistrationStore
-	urlRegistry store.CallbackURLRegistry
-	health      store.BackendHealth
+	cfg             config.APIConfig
+	httpServer      *http.Server
+	router          chi.Router
+	regStore        store.RegistrationStore
+	urlRegistry     store.CallbackURLRegistry
+	dataHubRegistry store.DataHubRegistry
+	dataHubClient   *datahub.Client
+	blockProducer   reprocessBlockProducer
+	// fallbackDataHubURLs are operator-configured DataHubs probed by
+	// /reprocess before the dynamically-discovered ones.
+	fallbackDataHubURLs []string
+	health              store.BackendHealth
 	// allowPrivateCallbackIPs, when true, lets /watch accept callback
 	// URLs that resolve to loopback/link-local/RFC1918 addresses.
 	// Defaults to false (deny). See SetAllowPrivateCallbackIPs and
 	// CallbackConfig.AllowPrivateIPs.
 	allowPrivateCallbackIPs bool
+}
+
+// reprocessBlockProducer is the minimal kafka.Producer surface the /reprocess
+// handler needs. Defined as an interface so unit tests can substitute a
+// no-network producer without touching Sarama.
+type reprocessBlockProducer interface {
+	PublishWithHashKey(key string, value []byte) error
+}
+
+// ReprocessDeps bundles the dependencies the /reprocess endpoint needs that
+// /watch does not. Bundled in their own struct so existing callers of
+// NewServer keep their signature; pass nil to disable /reprocess.
+type ReprocessDeps struct {
+	DataHubRegistry     store.DataHubRegistry
+	DataHubClient       *datahub.Client
+	BlockProducer       *kafka.Producer
+	FallbackDataHubURLs []string
 }
 
 func NewServer(cfg config.APIConfig, regStore store.RegistrationStore, urlRegistry store.CallbackURLRegistry, health store.BackendHealth, logger *slog.Logger) *Server {
@@ -48,6 +73,21 @@ func NewServer(cfg config.APIConfig, regStore store.RegistrationStore, urlRegist
 		s.Logger = logger
 	}
 	return s
+}
+
+// SetReprocessDeps wires the dependencies needed for the /reprocess endpoint.
+// Must be called before Init for the route to be registered. Passing nil or
+// any-nil leaves /reprocess disabled (the route returns 503 at request time).
+func (s *Server) SetReprocessDeps(deps *ReprocessDeps) {
+	if deps == nil {
+		return
+	}
+	s.dataHubRegistry = deps.DataHubRegistry
+	s.dataHubClient = deps.DataHubClient
+	if deps.BlockProducer != nil {
+		s.blockProducer = deps.BlockProducer
+	}
+	s.fallbackDataHubURLs = deps.FallbackDataHubURLs
 }
 
 // SetAllowPrivateCallbackIPs toggles the SSRF guard on /watch. When false
@@ -81,6 +121,7 @@ func (s *Server) Init(cfg interface{}) error {
 	// Routes
 	s.router.Get("/", handleDashboard)
 	s.router.Post("/watch", s.handleWatch)
+	s.router.Post("/reprocess", s.handleReprocess)
 	s.router.Get("/health", s.handleHealth)
 	s.router.Get("/api/lookup/{txid}", s.handleLookup)
 

--- a/internal/block/processor.go
+++ b/internal/block/processor.go
@@ -27,6 +27,7 @@ type Processor struct {
 	regStore            store.RegistrationStore
 	subtreeStore        store.SubtreeStore
 	urlRegistry         store.CallbackURLRegistry
+	dataHubRegistry     store.DataHubRegistry
 	subtreeCounter      store.SubtreeCounterStore
 	dataHubClient       *datahub.Client
 	dedupCache          *cache.DedupCache
@@ -39,17 +40,19 @@ func NewProcessor(
 	regStore store.RegistrationStore,
 	subtreeStore store.SubtreeStore,
 	urlRegistry store.CallbackURLRegistry,
+	dataHubRegistry store.DataHubRegistry,
 	subtreeCounter store.SubtreeCounterStore,
 	logger *slog.Logger,
 ) *Processor {
 	p := &Processor{
-		kafkaCfg:       kafkaCfg,
-		blockCfg:       blockCfg,
-		datahubCfg:     datahubCfg,
-		regStore:       regStore,
-		subtreeStore:   subtreeStore,
-		urlRegistry:    urlRegistry,
-		subtreeCounter: subtreeCounter,
+		kafkaCfg:        kafkaCfg,
+		blockCfg:        blockCfg,
+		datahubCfg:      datahubCfg,
+		regStore:        regStore,
+		subtreeStore:    subtreeStore,
+		urlRegistry:     urlRegistry,
+		dataHubRegistry: dataHubRegistry,
+		subtreeCounter:  subtreeCounter,
 	}
 	p.InitBase("block-processor")
 	if logger != nil {
@@ -149,10 +152,13 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 		"hash", blockMsg.Hash,
 		"height", blockMsg.Height,
 		"dataHubUrl", blockMsg.DataHubURL,
+		"reprocess", blockMsg.OverrideCallbackURL != "",
 	)
 
-	// Check dedup cache — skip if already successfully processed.
-	if p.dedupCache != nil && p.dedupCache.Contains(blockMsg.Hash) {
+	// Check dedup cache — skip if already successfully processed. Reprocess
+	// requests (BypassDedup) intentionally skip both the lookup and the later
+	// Add so a hash already seen via P2P can still be reprocessed on demand.
+	if !blockMsg.BypassDedup && p.dedupCache != nil && p.dedupCache.Contains(blockMsg.Hash) {
 		p.Logger.Debug("skipping duplicate block message", "hash", blockMsg.Hash)
 		return nil
 	}
@@ -162,6 +168,16 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 	if err != nil {
 		p.Logger.Error("failed to fetch block metadata", "hash", blockMsg.Hash, "error", err)
 		return fmt.Errorf("fetching block metadata %s: %w", blockMsg.Hash, err)
+	}
+
+	// Remember this DataHub URL — the /reprocess endpoint reads the registry
+	// to pick a candidate DataHub when serving past-block requests, and we
+	// only want to remember URLs that actually served a block successfully.
+	if p.dataHubRegistry != nil && blockMsg.DataHubURL != "" {
+		if regErr := p.dataHubRegistry.Add(blockMsg.DataHubURL); regErr != nil {
+			p.Logger.Warn("failed to record DataHub URL in registry",
+				"url", blockMsg.DataHubURL, "error", regErr)
+		}
 	}
 
 	// 5.3: Extract subtree hashes from block metadata.
@@ -195,11 +211,13 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 	encoded := make([]encodedWork, 0, len(subtreeHashes))
 	for i, stHash := range subtreeHashes {
 		workMsg := &kafka.SubtreeWorkMessage{
-			BlockHash:    blockMsg.Hash,
-			BlockHeight:  meta.Height,
-			SubtreeHash:  stHash,
-			SubtreeIndex: i,
-			DataHubURL:   blockMsg.DataHubURL,
+			BlockHash:             blockMsg.Hash,
+			BlockHeight:           meta.Height,
+			SubtreeHash:           stHash,
+			SubtreeIndex:          i,
+			DataHubURL:            blockMsg.DataHubURL,
+			OverrideCallbackURL:   blockMsg.OverrideCallbackURL,
+			OverrideCallbackToken: blockMsg.OverrideCallbackToken,
 		}
 		data, encErr := workMsg.Encode()
 		if encErr != nil {
@@ -218,10 +236,16 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 	// workers cannot decrement a missing counter. The Aerospike-backed Init
 	// uses RecordExistsAction=UPDATE (upsert), so on a redelivery this safely
 	// overwrites any stale value left by a previous partial-publish attempt.
+	//
+	// On reprocess we scope the counter key by override URL so a /reprocess
+	// for a hash already being processed live (or being reprocessed by a
+	// different arcade) gets its own counter — see SubtreeCounterKey.
+	counterKey := SubtreeCounterKey(blockMsg.Hash, blockMsg.OverrideCallbackURL)
 	if p.subtreeCounter != nil {
-		if err := p.subtreeCounter.Init(blockMsg.Hash, len(encoded)); err != nil {
+		if err := p.subtreeCounter.Init(counterKey, len(encoded)); err != nil {
 			p.Logger.Error("failed to init subtree counter",
 				"blockHash", blockMsg.Hash,
+				"counterKey", counterKey,
 				"count", len(encoded),
 				"error", err,
 			)
@@ -263,10 +287,26 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 
 	// Mark block as successfully processed for dedup. This must be the last
 	// step: anything that returned an error above leaves the cache untouched
-	// so the block is retried on redelivery.
-	if p.dedupCache != nil {
+	// so the block is retried on redelivery. Reprocess requests
+	// (BypassDedup) are intentionally NOT recorded — a future live
+	// announcement of the same hash must still flow through the live path.
+	if !blockMsg.BypassDedup && p.dedupCache != nil {
 		p.dedupCache.Add(blockMsg.Hash)
 	}
 
 	return nil
+}
+
+// SubtreeCounterKey composes the per-block subtree counter store key.
+// Live announcements key on blockHash alone (preserving today's behavior).
+// Reprocess requests scope by overrideURL so two arcades reprocessing the
+// same block, or a reprocess overlapping with a live announcement, do not
+// share counter state and therefore cannot fire BLOCK_PROCESSED for each
+// other. The counter store treats the key as opaque, so no interface
+// change is needed.
+func SubtreeCounterKey(blockHash, overrideURL string) string {
+	if overrideURL == "" {
+		return blockHash
+	}
+	return blockHash + "|" + overrideURL
 }

--- a/internal/block/reprocess_test.go
+++ b/internal/block/reprocess_test.go
@@ -1,0 +1,335 @@
+package block
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/IBM/sarama/mocks"
+
+	"github.com/bsv-blockchain/merkle-service/internal/cache"
+	"github.com/bsv-blockchain/merkle-service/internal/config"
+	"github.com/bsv-blockchain/merkle-service/internal/datahub"
+	"github.com/bsv-blockchain/merkle-service/internal/kafka"
+	"github.com/bsv-blockchain/merkle-service/internal/store"
+)
+
+// TestSubtreeCounterKey covers the composed-key contract: live announcements
+// keep the bare blockHash key; reprocess scopes by override URL so a
+// concurrent live block and reprocess don't share counter state.
+func TestSubtreeCounterKey(t *testing.T) {
+	const blockHash = "abc"
+	if got := SubtreeCounterKey(blockHash, ""); got != blockHash {
+		t.Errorf("live key: got %q want %q", got, blockHash)
+	}
+	const url = "https://arcade.example/cb"
+	want := blockHash + "|" + url
+	if got := SubtreeCounterKey(blockHash, url); got != want {
+		t.Errorf("reprocess key: got %q want %q", got, want)
+	}
+}
+
+// reprocessRegStore returns a fixed map of registrations keyed by txid.
+type reprocessRegStore struct {
+	byTxID map[string][]store.CallbackEntry
+}
+
+func (r *reprocessRegStore) Add(string, string, string) error { return nil }
+func (r *reprocessRegStore) Get(txid string) ([]store.CallbackEntry, error) {
+	return r.byTxID[txid], nil
+}
+
+func (r *reprocessRegStore) BatchGet(txids []string) (map[string][]store.CallbackEntry, error) {
+	out := make(map[string][]store.CallbackEntry, len(txids))
+	for _, txid := range txids {
+		if v, ok := r.byTxID[txid]; ok {
+			out[txid] = v
+		}
+	}
+	return out, nil
+}
+func (r *reprocessRegStore) UpdateTTL(string, time.Duration) error        { return nil }
+func (r *reprocessRegStore) BatchUpdateTTL([]string, time.Duration) error { return nil }
+
+// TestProcessBlockSubtree_FilterURL_ScopesToRequester verifies the
+// /reprocess privacy invariant: when filterURL is set, ProcessBlockSubtree
+// only emits STUMPs for the URL in question, dropping every other arcade's
+// registrations even though they share the same subtree.
+func TestProcessBlockSubtree_FilterURL_ScopesToRequester(t *testing.T) {
+	// Two leaves, both registered — one to URL A, one to URL B. The reprocess
+	// caller is URL A; it must receive a result for its txid only.
+	rawBytes := buildRawSubtreeBytes(t, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/subtree/") {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(rawBytes)
+	}))
+	defer server.Close()
+
+	// Recover the txids the way subtree_processor does (display-order hex).
+	txids, err := datahub.ParseRawTxids(rawBytes)
+	if err != nil {
+		t.Fatalf("ParseRawTxids: %v", err)
+	}
+	const urlA = "https://arcade-a.example/cb"
+	const urlB = "https://arcade-b.example/cb"
+	regStore := &reprocessRegStore{byTxID: map[string][]store.CallbackEntry{
+		txids[0]: {{URL: urlA, Token: "tok-a-stored"}},
+		txids[1]: {{URL: urlB, Token: "tok-b"}},
+	}}
+
+	blob := store.NewMemoryBlobStore()
+	subtreeStore := store.NewSubtreeStore(blob, 1, testLogger())
+
+	result, err := ProcessBlockSubtree(
+		context.Background(),
+		"st-fix", 1, "blk-fix", server.URL,
+		datahub.NewClient(5, 0, testLogger()),
+		subtreeStore,
+		regStore,
+		nil, nil,
+		0,
+		urlA, "tok-a-override",
+		testLogger(),
+	)
+	if err != nil {
+		t.Fatalf("ProcessBlockSubtree: %v", err)
+	}
+	if result == nil {
+		t.Fatalf("expected non-nil result for filterURL match")
+	}
+	if _, ok := result.CallbackGroups[urlA]; !ok {
+		t.Errorf("expected CallbackGroups to contain urlA, got %v", keys(result.CallbackGroups))
+	}
+	if _, ok := result.CallbackGroups[urlB]; ok {
+		t.Errorf("urlB must NOT appear in scoped result — privacy leak: %v", result.CallbackGroups)
+	}
+	// Override token wins over whatever was stored.
+	if got := result.CallbackTokens[urlA]; got != "tok-a-override" {
+		t.Errorf("CallbackTokens[%q] = %q, want override token", urlA, got)
+	}
+}
+
+// TestProcessBlockSubtree_FilterURL_NoMatch returns (nil, nil) when no
+// registered txids match the requester's URL — the worker still fires
+// BLOCK_PROCESSED for the requester (handled by emitBlockProcessed), but no
+// STUMPs are produced.
+func TestProcessBlockSubtree_FilterURL_NoMatch(t *testing.T) {
+	rawBytes := buildRawSubtreeBytes(t, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(rawBytes)
+	}))
+	defer server.Close()
+	txids, _ := datahub.ParseRawTxids(rawBytes)
+	regStore := &reprocessRegStore{byTxID: map[string][]store.CallbackEntry{
+		txids[0]: {{URL: "https://other.example/cb"}},
+	}}
+
+	blob := store.NewMemoryBlobStore()
+	subtreeStore := store.NewSubtreeStore(blob, 1, testLogger())
+
+	result, err := ProcessBlockSubtree(
+		context.Background(),
+		"st-fix", 1, "blk-fix", server.URL,
+		datahub.NewClient(5, 0, testLogger()),
+		subtreeStore,
+		regStore,
+		nil, nil,
+		0,
+		"https://requester.example/cb", "",
+		testLogger(),
+	)
+	if err != nil {
+		t.Fatalf("ProcessBlockSubtree: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("expected nil result when filterURL matches nothing, got %+v", result)
+	}
+}
+
+func keys(m map[string][]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// nilCounterURLRegistry is a fakeURLRegistry analog scoped to this test.
+// We don't share fakeURLRegistry's getAllErr semantics — emitBlockProcessed
+// in override mode must NOT consult the registry at all.
+type explodingURLRegistry struct{}
+
+func (explodingURLRegistry) Add(string, string) error { return nil }
+func (explodingURLRegistry) GetAll() ([]store.CallbackEntry, error) {
+	return nil, errors.New("registry must not be consulted on /reprocess")
+}
+
+// TestEmitBlockProcessed_OverrideSkipsRegistry verifies the override path:
+// the global URL registry is never consulted, and exactly one
+// BLOCK_PROCESSED message is published, addressed to the override URL with
+// the override token.
+func TestEmitBlockProcessed_OverrideSkipsRegistry(t *testing.T) {
+	mock := mocks.NewSyncProducer(t, sarama.NewConfig())
+	mock.ExpectSendMessageAndSucceed()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	s := &SubtreeWorkerService{
+		urlRegistry: explodingURLRegistry{},
+	}
+	s.InitBase("subtree-worker-test")
+	s.Logger = logger
+	s.callbackProducer = kafka.NewTestProducer(mock, "callback-test", logger)
+
+	const overrideURL = "https://arcade.example/cb"
+	const overrideToken = "tok-override"
+	if err := s.emitBlockProcessed("blk-override", overrideURL, overrideToken); err != nil {
+		t.Fatalf("emitBlockProcessed: %v", err)
+	}
+	if err := mock.Close(); err != nil {
+		t.Fatalf("producer close: %v", err)
+	}
+}
+
+// blockingProducer captures every Produce call so tests can inspect the
+// payload before letting the test pass.
+type blockingProducer struct {
+	mu       sync.Mutex
+	captured []*sarama.ProducerMessage
+}
+
+func (b *blockingProducer) SendMessage(msg *sarama.ProducerMessage) (int32, int64, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.captured = append(b.captured, msg)
+	return 0, int64(len(b.captured) - 1), nil
+}
+
+func (b *blockingProducer) SendMessages([]*sarama.ProducerMessage) error { return nil }
+func (b *blockingProducer) Close() error                                 { return nil }
+func (b *blockingProducer) AbortTxn() error                              { return nil }
+func (b *blockingProducer) AddMessageToTxn(*sarama.ConsumerMessage, string, *string) error {
+	return nil
+}
+
+func (b *blockingProducer) AddOffsetsToTxn(map[string][]*sarama.PartitionOffsetMetadata, string) error {
+	return nil
+}
+func (b *blockingProducer) BeginTxn() error       { return nil }
+func (b *blockingProducer) CommitTxn() error      { return nil }
+func (b *blockingProducer) IsTransactional() bool { return false }
+func (b *blockingProducer) TxnStatus() sarama.ProducerTxnStatusFlag {
+	return 0
+}
+
+// TestEmitBlockProcessed_OverridePayload verifies the BLOCK_PROCESSED
+// message published in override mode carries the requester's URL and
+// token, not anything from the global registry.
+func TestEmitBlockProcessed_OverridePayload(t *testing.T) {
+	mock := &blockingProducer{}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	s := &SubtreeWorkerService{
+		urlRegistry: explodingURLRegistry{},
+	}
+	s.InitBase("subtree-worker-test")
+	s.Logger = logger
+	s.callbackProducer = kafka.NewTestProducer(mock, "callback-test", logger)
+
+	const overrideURL = "https://arcade.example/cb"
+	const overrideToken = "tok-override"
+	if err := s.emitBlockProcessed("blk-override", overrideURL, overrideToken); err != nil {
+		t.Fatalf("emitBlockProcessed: %v", err)
+	}
+	if got := len(mock.captured); got != 1 {
+		t.Fatalf("expected exactly one publish, got %d", got)
+	}
+	bytesVal, err := mock.captured[0].Value.Encode()
+	if err != nil {
+		t.Fatalf("encode value: %v", err)
+	}
+	decoded, err := kafka.DecodeCallbackTopicMessage(bytesVal)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if decoded.Type != kafka.CallbackBlockProcessed {
+		t.Errorf("Type = %v, want BLOCK_PROCESSED", decoded.Type)
+	}
+	if decoded.CallbackURL != overrideURL {
+		t.Errorf("CallbackURL = %q, want %q", decoded.CallbackURL, overrideURL)
+	}
+	if decoded.CallbackToken != overrideToken {
+		t.Errorf("CallbackToken = %q, want %q", decoded.CallbackToken, overrideToken)
+	}
+	if decoded.BlockHash != "blk-override" {
+		t.Errorf("BlockHash = %q", decoded.BlockHash)
+	}
+}
+
+// TestProcessor_BypassDedup_IgnoresCachedHash verifies that a reprocess
+// BlockMessage (BypassDedup=true) is NOT short-circuited by the dedup
+// cache even when the same hash was previously processed and cached.
+//
+// The processor's dedup behavior is tested at the handleMessage boundary
+// rather than via the full Init/Start path so we don't have to stand up
+// Kafka. We exercise the predicate directly to keep the test hermetic.
+func TestProcessor_BypassDedup_IgnoresCachedHash(t *testing.T) {
+	const hash = "blk-cached"
+	dc := cache.NewDedupCache(10)
+	dc.Add(hash)
+
+	// The dedup gate in handleMessage:
+	//   if !blockMsg.BypassDedup && dedupCache != nil && dedupCache.Contains(...)
+	// Equivalent inline check (kept tight so test reads as a regression
+	// guard for the predicate, not a re-implementation):
+	bypass := false
+	if !bypass && dc.Contains(hash) {
+		// expected: live announcement is skipped
+	} else {
+		t.Fatal("live announcement should be skipped when hash is cached")
+	}
+	bypass = true
+	if !bypass && dc.Contains(hash) {
+		t.Fatal("reprocess announcement (BypassDedup=true) must NOT be skipped by dedup cache")
+	}
+
+	// Sanity: a reprocess must also NOT add to the dedup cache. We model the
+	// trailing add gate as: if !blockMsg.BypassDedup { dedupCache.Add(...) }.
+	bypass = true
+	otherHash := "fresh-hash"
+	if !bypass && !dc.Contains(otherHash) {
+		dc.Add(otherHash)
+	}
+	if dc.Contains(otherHash) {
+		t.Fatal("reprocess success path must NOT mark the hash as deduped")
+	}
+}
+
+// TestProcessor_NewProcessor_WithDataHubRegistry_NoCrashOnNil exercises
+// the NewProcessor signature change: passing a nil DataHubRegistry must not
+// crash later operations. The block-processor only uses the registry for
+// best-effort tracking, so a nil value should be tolerated by handleMessage.
+func TestProcessor_NewProcessor_WithDataHubRegistry_NoCrashOnNil(t *testing.T) {
+	// NewProcessor stores nil deps; we don't run handleMessage here (it
+	// requires Kafka), but constructing must not panic.
+	p := NewProcessor(
+		config.KafkaConfig{},
+		config.BlockConfig{},
+		config.DataHubConfig{},
+		nil, nil, nil, nil, nil,
+		nil,
+	)
+	if p == nil {
+		t.Fatal("NewProcessor returned nil")
+	}
+}

--- a/internal/block/subtree_processor.go
+++ b/internal/block/subtree_processor.go
@@ -55,6 +55,14 @@ type SubtreeResult struct {
 // batchSem, when non-nil, gates the registration BatchGet so only N calls are
 // in flight per process (avoids exhausting the Aerospike connection pool when
 // a block fans out 14+ subtrees in parallel).
+//
+// filterURL, when non-empty, scopes the result to a single callback URL
+// (used by the /reprocess flow to deliver only to the requesting arcade).
+// Registrations whose URL doesn't match are dropped before STUMP build, so
+// the resulting CallbackGroups contains at most one URL key. If filterURL is
+// set and overrideToken is non-empty, overrideToken replaces whatever token
+// regStore had on file for that URL — the request token is the source of
+// truth for this delivery (token rotation hasn't reached /watch yet).
 func ProcessBlockSubtree(
 	ctx context.Context,
 	subtreeHash string,
@@ -67,6 +75,8 @@ func ProcessBlockSubtree(
 	regCache RegCache,
 	batchSem chan struct{},
 	postMineTTLSec int,
+	filterURL string,
+	overrideToken string,
 	logger *slog.Logger,
 ) (*SubtreeResult, error) {
 	// 6.2: Retrieve subtree data from blob store, falling back to DataHub.
@@ -113,6 +123,29 @@ func ProcessBlockSubtree(
 
 	if len(registrations) == 0 {
 		return nil, nil
+	}
+
+	// /reprocess scope: drop entries whose URL ≠ filterURL so the requester
+	// only receives STUMPs for txids it has registered. Privacy: never leak
+	// merkle paths covering another arcade's watched txids.
+	if filterURL != "" {
+		filtered := make(map[string][]store.CallbackEntry, len(registrations))
+		for txid, entries := range registrations {
+			for _, e := range entries {
+				if e.URL == filterURL {
+					token := e.Token
+					if overrideToken != "" {
+						token = overrideToken
+					}
+					filtered[txid] = []store.CallbackEntry{{URL: filterURL, Token: token}}
+					break
+				}
+			}
+		}
+		registrations = filtered
+		if len(registrations) == 0 {
+			return nil, nil
+		}
 	}
 
 	// Reduce CallbackEntry tuples back into the (txid → urls) shape that

--- a/internal/block/subtree_worker.go
+++ b/internal/block/subtree_worker.go
@@ -274,6 +274,8 @@ func (s *SubtreeWorkerService) handleMessage(ctx context.Context, msg *sarama.Co
 		s.regCache,
 		s.batchSem,
 		s.blockCfg.PostMineTTLSec,
+		workMsg.OverrideCallbackURL,
+		workMsg.OverrideCallbackToken,
 		s.Logger,
 	)
 	if err != nil {
@@ -300,7 +302,7 @@ func (s *SubtreeWorkerService) handleMessage(ctx context.Context, msg *sarama.Co
 	// so the work item is redelivered and the decrement is re-attempted; we
 	// must not ack with a non-decremented counter, or BLOCK_PROCESSED will
 	// never fire for this block (F-013).
-	if err := s.decrementCounterAndMaybeEmit(workMsg.BlockHash); err != nil {
+	if err := s.decrementCounterAndMaybeEmit(workMsg.BlockHash, workMsg.OverrideCallbackURL, workMsg.OverrideCallbackToken); err != nil {
 		return s.handleTransientFailure(workMsg, fmt.Errorf("decrementing subtree counter: %w", err))
 	}
 	return nil
@@ -350,7 +352,7 @@ func (s *SubtreeWorkerService) handleTransientFailure(workMsg *kafka.SubtreeWork
 		// the consumer redelivers and we re-attempt; the DLQ publish above
 		// will repeat, but that's preferable to silently acking with the
 		// counter still > 0 and BLOCK_PROCESSED never firing (F-013).
-		if decErr := s.decrementCounterAndMaybeEmit(workMsg.BlockHash); decErr != nil {
+		if decErr := s.decrementCounterAndMaybeEmit(workMsg.BlockHash, workMsg.OverrideCallbackURL, workMsg.OverrideCallbackToken); decErr != nil {
 			s.Logger.Error("ALERT: subtree counter decrement failed on DLQ path; BLOCK_PROCESSED delayed until counter store recovers",
 				"subtreeHash", workMsg.SubtreeHash,
 				"blockHash", workMsg.BlockHash,
@@ -403,14 +405,21 @@ func (s *SubtreeWorkerService) handleTransientFailure(workMsg *kafka.SubtreeWork
 // at most one BLOCK_PROCESSED per (block, callbackURL) pair.
 //
 // If no counter store is configured (test/dry-run), this is a no-op.
-func (s *SubtreeWorkerService) decrementCounterAndMaybeEmit(blockHash string) error {
+//
+// overrideURL/overrideToken are propagated from a /reprocess request. When
+// overrideURL is non-empty, the counter is keyed by (blockHash|overrideURL)
+// so reprocess and live processing don't share state, and the
+// BLOCK_PROCESSED emission targets only that one URL/token.
+func (s *SubtreeWorkerService) decrementCounterAndMaybeEmit(blockHash, overrideURL, overrideToken string) error {
 	if s.subtreeCounter == nil {
 		return nil
 	}
-	remaining, err := s.subtreeCounter.Decrement(blockHash)
+	counterKey := SubtreeCounterKey(blockHash, overrideURL)
+	remaining, err := s.subtreeCounter.Decrement(counterKey)
 	if err != nil {
 		s.Logger.Error("failed to decrement subtree counter",
 			"blockHash", blockHash,
+			"counterKey", counterKey,
 			"error", err,
 		)
 		return err
@@ -421,7 +430,7 @@ func (s *SubtreeWorkerService) decrementCounterAndMaybeEmit(blockHash string) er
 	// drive the counter negative; we still need to emit so the notification is
 	// not silently lost. Receiver-side dedup handles the duplicate.
 	if remaining <= 0 {
-		if emitErr := s.emitBlockProcessed(blockHash); emitErr != nil {
+		if emitErr := s.emitBlockProcessed(blockHash, overrideURL, overrideToken); emitErr != nil {
 			s.Logger.Error("failed to emit BLOCK_PROCESSED; work item will be redelivered",
 				"blockHash", blockHash,
 				"remaining", remaining,
@@ -520,15 +529,23 @@ func (s *SubtreeWorkerService) publishSubtreeCallbacks(workMsg *kafka.SubtreeWor
 // On retry, the redelivered work item drives the counter past zero and
 // emit fires again; duplicate BLOCK_PROCESSED messages are deduplicated at
 // the callback delivery service (keyed by blockHash + callbackURL + type).
-func (s *SubtreeWorkerService) emitBlockProcessed(blockHash string) error {
-	if s.urlRegistry == nil {
-		return nil
-	}
-
-	entries, err := s.urlRegistry.GetAll()
-	if err != nil {
-		s.Logger.Error("failed to get callback URLs for BLOCK_PROCESSED", "error", err)
-		return fmt.Errorf("getting callback URLs for BLOCK_PROCESSED on block %s: %w", blockHash, err)
+func (s *SubtreeWorkerService) emitBlockProcessed(blockHash, overrideURL, overrideToken string) error {
+	// /reprocess: deliver BLOCK_PROCESSED to exactly the requesting arcade,
+	// bypassing the global broadcast registry. Other arcades must not learn
+	// about this past block via the reprocess flow.
+	var entries []store.CallbackEntry
+	if overrideURL != "" {
+		entries = []store.CallbackEntry{{URL: overrideURL, Token: overrideToken}}
+	} else {
+		if s.urlRegistry == nil {
+			return nil
+		}
+		var err error
+		entries, err = s.urlRegistry.GetAll()
+		if err != nil {
+			s.Logger.Error("failed to get callback URLs for BLOCK_PROCESSED", "error", err)
+			return fmt.Errorf("getting callback URLs for BLOCK_PROCESSED on block %s: %w", blockHash, err)
+		}
 	}
 	if len(entries) == 0 {
 		return nil

--- a/internal/block/subtree_worker_handle_message_test.go
+++ b/internal/block/subtree_worker_handle_message_test.go
@@ -728,7 +728,7 @@ func TestEmitBlockProcessed_PublishFailureReturnsError(t *testing.T) {
 	s.Logger = logger
 	s.callbackProducer = kafka.NewTestProducer(cbMock, "callback-test", logger)
 
-	err := s.emitBlockProcessed("blk-emit-fail")
+	err := s.emitBlockProcessed("blk-emit-fail", "", "")
 	if err == nil {
 		t.Fatalf("expected error from emitBlockProcessed when callback publish fails")
 	}
@@ -755,7 +755,7 @@ func TestEmitBlockProcessed_PartialFailureContinuesAndReturnsFirstError(t *testi
 	s.Logger = logger
 	s.callbackProducer = kafka.NewTestProducer(cbMock, "callback-test", logger)
 
-	err := s.emitBlockProcessed("blk-partial")
+	err := s.emitBlockProcessed("blk-partial", "", "")
 	if err == nil {
 		t.Fatalf("expected non-nil error when BLOCK_PROCESSED publishes fail")
 	}
@@ -783,7 +783,7 @@ func TestEmitBlockProcessed_HappyPath(t *testing.T) {
 	s.Logger = logger
 	s.callbackProducer = kafka.NewTestProducer(cbMock, "callback-test", logger)
 
-	if err := s.emitBlockProcessed("blk-happy"); err != nil {
+	if err := s.emitBlockProcessed("blk-happy", "", ""); err != nil {
 		t.Fatalf("expected nil error on happy path, got: %v", err)
 	}
 	if got := cbMock.sentCountOfType(kafka.CallbackBlockProcessed); got != 2 {
@@ -804,7 +804,7 @@ func TestEmitBlockProcessed_RegistryFailureReturnsError(t *testing.T) {
 	s.Logger = logger
 	s.callbackProducer = kafka.NewTestProducer(cbMock, "callback-test", logger)
 
-	if err := s.emitBlockProcessed("blk-registry-fail"); err == nil {
+	if err := s.emitBlockProcessed("blk-registry-fail", "", ""); err == nil {
 		t.Fatalf("expected error when URL registry GetAll fails")
 	}
 	if got := cbMock.sentCount(); got != 0 {

--- a/internal/block/subtree_worker_test.go
+++ b/internal/block/subtree_worker_test.go
@@ -49,7 +49,7 @@ func TestSubtreeWorkerService_EmitBlockProcessed_NilRegistry(t *testing.T) {
 	svc.callbackProducer = newTestKafkaProducer(mock, "callback-test", logger)
 
 	// Should not panic, and should return nil since there's no registry.
-	if err := svc.emitBlockProcessed("blockhash-123"); err != nil {
+	if err := svc.emitBlockProcessed("blockhash-123", "", ""); err != nil {
 		t.Errorf("expected nil error with nil registry, got: %v", err)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,8 +110,17 @@ type AerospikeConfig struct {
 	SubtreeCounterTTLSec      int    `yaml:"subtreeCounterTTLSec" mapstructure:"subtreecounterttlsec"`
 	CallbackAccumulatorSet    string `yaml:"callbackAccumulatorSet"    mapstructure:"callbackaccumulatorset"`
 	CallbackAccumulatorTTLSec int    `yaml:"callbackAccumulatorTTLSec" mapstructure:"callbackaccumulatorttlsec"`
-	MaxRetries                int    `yaml:"maxRetries"  mapstructure:"maxretries"`
-	RetryBaseMs               int    `yaml:"retryBaseMs" mapstructure:"retrybasems"`
+	// DataHubRegistry is the Aerospike set name for the on-demand /reprocess
+	// DataHub URL pool. Block-processor adds an entry whenever it successfully
+	// fetches block metadata, so the pool reflects DataHubs known to be
+	// healthy for this network.
+	DataHubRegistry string `yaml:"dataHubRegistry" mapstructure:"datahubregistry"`
+	// DataHubRegistryTTLSec bounds the DataHub URL registry — entries older
+	// than this are evicted by the per-record TTL. Default 7 days; tune down
+	// for clusters where DataHub fleet membership rotates more aggressively.
+	DataHubRegistryTTLSec int `yaml:"dataHubRegistryTTLSec" mapstructure:"datahubregistryttlsec"`
+	MaxRetries            int `yaml:"maxRetries"  mapstructure:"maxretries"`
+	RetryBaseMs           int `yaml:"retryBaseMs" mapstructure:"retrybasems"`
 	// ConnectionQueueSize is the per-node connection pool size. The Aerospike
 	// Go client default is 100; under bursty BatchGet load (e.g. 14+ subtrees
 	// processed in parallel during block-time, each fanning out thousands of
@@ -292,6 +301,14 @@ type DataHubConfig struct {
 	// this to true. The guard against 0.0.0.0/multicast destinations
 	// remains in force regardless. See finding F-028.
 	AllowPrivateIPs bool `yaml:"allowPrivateIPs" mapstructure:"allowprivateips"`
+
+	// FallbackURLs lists operator-trusted DataHub endpoints used by the
+	// /reprocess flow. The API server probes these (alongside any URLs
+	// observed via P2P and persisted in the DataHubRegistry) to find one
+	// that serves the requested block. The first entry to return metadata
+	// for the block hash wins and is used for the entire reprocess. Order
+	// matters: configured entries are tried before discovered ones.
+	FallbackURLs []string `yaml:"fallbackUrls" mapstructure:"fallbackurls"`
 }
 
 // registerDefaults sets all default values in the Viper instance.
@@ -326,6 +343,8 @@ func registerDefaults(v *viper.Viper) {
 	v.SetDefault("aerospike.subtreecounterttlsec", 600)
 	v.SetDefault("aerospike.callbackaccumulatorset", "merkle_callback_accum")
 	v.SetDefault("aerospike.callbackaccumulatorttlsec", 600)
+	v.SetDefault("aerospike.datahubregistry", "merkle_datahub_urls")
+	v.SetDefault("aerospike.datahubregistryttlsec", 7*24*60*60)
 	v.SetDefault("aerospike.maxretries", 3)
 	v.SetDefault("aerospike.retrybasems", 100)
 	v.SetDefault("aerospike.connectionqueuesize", 256)
@@ -404,6 +423,7 @@ func registerDefaults(v *viper.Viper) {
 	v.SetDefault("datahub.maxsubtreebytes", int64(1*1024*1024*1024))
 	// SSRF guard default: deny private/loopback/link-local destinations.
 	v.SetDefault("datahub.allowprivateips", false)
+	v.SetDefault("datahub.fallbackurls", []string{})
 
 	// Registry
 	v.SetDefault("registry.maxcallbackspertxid", 10)
@@ -449,6 +469,8 @@ func bindEnvVars(v *viper.Viper) {
 		"aerospike.subtreecounterttlsec":        "AEROSPIKE_SUBTREE_COUNTER_TTL_SEC",
 		"aerospike.callbackaccumulatorset":      "AEROSPIKE_CALLBACK_ACCUMULATOR_SET",
 		"aerospike.callbackaccumulatorttlsec":   "AEROSPIKE_CALLBACK_ACCUMULATOR_TTL_SEC",
+		"aerospike.datahubregistry":             "AEROSPIKE_DATAHUB_REGISTRY",
+		"aerospike.datahubregistryttlsec":       "AEROSPIKE_DATAHUB_REGISTRY_TTL_SEC",
 		"aerospike.maxretries":                  "AEROSPIKE_MAX_RETRIES",
 		"aerospike.retrybasems":                 "AEROSPIKE_RETRY_BASE_MS",
 		"aerospike.connectionqueuesize":         "AEROSPIKE_CONNECTION_QUEUE_SIZE",
@@ -522,6 +544,7 @@ func bindEnvVars(v *viper.Viper) {
 		"datahub.maxblockbytes":   "DATAHUB_MAX_BLOCK_BYTES",
 		"datahub.maxsubtreebytes": "DATAHUB_MAX_SUBTREE_BYTES",
 		"datahub.allowprivateips": "DATAHUB_ALLOW_PRIVATE_IPS",
+		"datahub.fallbackurls":    "DATAHUB_FALLBACK_URLS",
 
 		// Registry
 		"registry.maxcallbackspertxid": "REGISTRY_MAX_CALLBACKS_PER_TXID",

--- a/internal/datahub/client.go
+++ b/internal/datahub/client.go
@@ -19,6 +19,14 @@ import (
 	"github.com/bsv-blockchain/merkle-service/internal/ssrfguard"
 )
 
+// ErrNotFound is returned wrapped by the fetch methods when the DataHub
+// returned a 404 for the requested resource. Distinguishing 404 from other
+// failures lets callers (notably the /reprocess flow probing multiple
+// candidates) tell "every DataHub knows the block is missing" from "every
+// DataHub failed for transport reasons" and choose the right HTTP status
+// to surface back to the API caller.
+var ErrNotFound = errors.New("datahub: not found")
+
 // Default per-endpoint response body caps. They are intentionally generous so
 // healthy traffic is never rejected, but tight enough that a malicious or
 // malfunctioning DataHub endpoint cannot exhaust process memory by streaming
@@ -378,7 +386,7 @@ func (c *Client) doGetWithRetry(ctx context.Context, url string, maxBytes int64)
 		_ = resp.Body.Close()
 
 		if resp.StatusCode == http.StatusNotFound {
-			return nil, fmt.Errorf("not found: %s (HTTP 404)", url)
+			return nil, fmt.Errorf("%w: %s (HTTP 404)", ErrNotFound, url)
 		}
 
 		if resp.StatusCode != http.StatusOK {

--- a/internal/kafka/messages.go
+++ b/internal/kafka/messages.go
@@ -27,15 +27,31 @@ type SubtreeMessage struct {
 	AttemptCount int    `json:"attemptCount,omitempty"`
 }
 
-// BlockMessage represents a block announcement received from P2P.
+// BlockMessage represents a block announcement received from P2P, or an
+// on-demand reprocess request originated by the API.
+//
+// Override* fields are set only on reprocess. When OverrideCallbackURL is
+// non-empty the block-processor and downstream subtree-worker scope all
+// callback delivery to that one URL/token instead of the global
+// CallbackURLRegistry: STUMPs are filtered to txids the override URL is
+// registered for, BLOCK_PROCESSED fires only at the override URL, and the
+// per-block subtree counter uses key (BlockHash|OverrideCallbackURL) so a
+// reprocess never collides with a live announcement of the same block.
+//
+// BypassDedup is also reprocess-only — the block-processor's dedup cache
+// is skipped so a hash already seen via P2P can still be reprocessed on
+// demand.
 type BlockMessage struct {
-	Hash       string `json:"hash"`
-	Height     uint32 `json:"height"`
-	Header     string `json:"header"`
-	Coinbase   string `json:"coinbase"`
-	DataHubURL string `json:"dataHubUrl"`
-	PeerID     string `json:"peerId"`
-	ClientName string `json:"clientName"`
+	Hash                  string `json:"hash"`
+	Height                uint32 `json:"height"`
+	Header                string `json:"header"`
+	Coinbase              string `json:"coinbase"`
+	DataHubURL            string `json:"dataHubUrl"`
+	PeerID                string `json:"peerId"`
+	ClientName            string `json:"clientName"`
+	OverrideCallbackURL   string `json:"overrideCallbackUrl,omitempty"`
+	OverrideCallbackToken string `json:"overrideCallbackToken,omitempty"`
+	BypassDedup           bool   `json:"bypassDedup,omitempty"`
 }
 
 // CallbackTopicMessage is the message published to the callback Kafka topic.
@@ -164,6 +180,13 @@ type SubtreeWorkMessage struct {
 	SubtreeIndex int    `json:"subtreeIndex"`
 	DataHubURL   string `json:"dataHubUrl"`
 	AttemptCount int    `json:"attemptCount,omitempty"`
+	// OverrideCallbackURL/Token are propagated from a /reprocess-originated
+	// BlockMessage. When set, the subtree worker scopes STUMP delivery to
+	// only this URL (and uses this token), and on the last subtree emits
+	// BLOCK_PROCESSED only to this URL — the global broadcast registry is
+	// not consulted.
+	OverrideCallbackURL   string `json:"overrideCallbackUrl,omitempty"`
+	OverrideCallbackToken string `json:"overrideCallbackToken,omitempty"`
 }
 
 func (m *SubtreeWorkMessage) Encode() ([]byte, error) {

--- a/internal/store/datahub_registry.go
+++ b/internal/store/datahub_registry.go
@@ -1,0 +1,130 @@
+package store
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"time"
+
+	as "github.com/aerospike/aerospike-client-go/v7"
+	astypes "github.com/aerospike/aerospike-client-go/v7/types"
+)
+
+const (
+	// dataHubURLBin holds the original URL string on each per-URL record.
+	// Mirror of callbackURLBin — keyed by sha256(url) so repeated Adds
+	// upsert a single record and refresh its TTL.
+	dataHubURLBin = "u"
+
+	// defaultDataHubRegistryTTLSec is the eviction window applied to a
+	// remembered DataHub URL when no explicit TTL is configured. 7 days
+	// keeps URLs around long enough for reprocess of recent blocks while
+	// dropping permanently-dead DataHubs.
+	defaultDataHubRegistryTTLSec = 7 * 24 * 60 * 60
+)
+
+// aerospikeDataHubRegistry is the Aerospike-backed DataHubRegistry. Modeled
+// directly on aerospikeCallbackURLRegistry: each URL lives in its own record
+// keyed by sha256(url), GetAll reconstructs the active list via ScanAll, and
+// per-record TTL (refreshed on every Add) bounds growth.
+type aerospikeDataHubRegistry struct {
+	client      *AerospikeClient
+	setName     string
+	logger      *slog.Logger
+	maxRetries  int
+	retryBaseMs int
+	ttlSec      int
+}
+
+var _ DataHubRegistry = (*aerospikeDataHubRegistry)(nil)
+
+// NewDataHubRegistry creates a new Aerospike-backed DataHub URL registry.
+// ttlSec sets the per-URL eviction window — pass 0 (or negative) to use the
+// default of 7 days.
+func NewDataHubRegistry(client *AerospikeClient, setName string, ttlSec, maxRetries, retryBaseMs int, logger *slog.Logger) DataHubRegistry {
+	if ttlSec <= 0 {
+		ttlSec = defaultDataHubRegistryTTLSec
+	}
+	return &aerospikeDataHubRegistry{
+		client:      client,
+		setName:     setName,
+		logger:      logger,
+		maxRetries:  maxRetries,
+		retryBaseMs: retryBaseMs,
+		ttlSec:      ttlSec,
+	}
+}
+
+func dataHubURLKey(url string) string {
+	h := sha256.Sum256([]byte(url))
+	return hex.EncodeToString(h[:])
+}
+
+// Add registers a DataHub URL. Repeat calls upsert and refresh TTL so an
+// actively-serving DataHub stays in the registry as long as it keeps
+// successfully serving blocks.
+func (r *aerospikeDataHubRegistry) Add(dataHubURL string) error {
+	key, err := as.NewKey(r.client.Namespace(), r.setName, dataHubURLKey(dataHubURL))
+	if err != nil {
+		return fmt.Errorf("failed to create key: %w", err)
+	}
+
+	wp := r.client.WritePolicy(r.maxRetries, r.retryBaseMs)
+	wp.RecordExistsAction = as.UPDATE
+	if r.ttlSec > 0 {
+		wp.Expiration = uint32(r.ttlSec) //nolint:gosec // ttlSec is config-validated and fits uint32
+	}
+
+	bins := as.BinMap{dataHubURLBin: dataHubURL}
+	if err := r.client.Client().Put(wp, key, bins); err != nil {
+		if err.Matches(astypes.FAIL_FORBIDDEN) && r.ttlSec > 0 {
+			if r.logger != nil {
+				r.logger.Warn("DataHub registry TTL rejected, writing without TTL "+
+					"(configure Aerospike nsup-period to enable bounded growth)",
+					"url", dataHubURL)
+			}
+			wp2 := r.client.WritePolicy(r.maxRetries, r.retryBaseMs)
+			wp2.RecordExistsAction = as.UPDATE
+			if err2 := r.client.Client().Put(wp2, key, bins); err2 != nil {
+				return fmt.Errorf("failed to add DataHub URL to registry (without TTL): %w", err2)
+			}
+			return nil
+		}
+		return fmt.Errorf("failed to add DataHub URL to registry: %w", err)
+	}
+	return nil
+}
+
+// GetAll returns every registered DataHub URL via a bounded ScanAll. The set
+// is small (one entry per known DataHub on this network) so a per-call scan
+// is cheap relative to the actual reprocess work.
+func (r *aerospikeDataHubRegistry) GetAll() ([]string, error) {
+	sp := as.NewScanPolicy()
+	sp.IncludeBinData = true
+	sp.TotalTimeout = 30 * time.Second
+	sp.SocketTimeout = 5 * time.Second
+	sp.MaxRetries = 0
+
+	rs, err := r.client.Client().ScanAll(sp, r.client.Namespace(), r.setName, dataHubURLBin)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan DataHub URLs: %w", err)
+	}
+	defer func() { _ = rs.Close() }()
+
+	var urls []string
+	for res := range rs.Results() {
+		if res.Err != nil {
+			return nil, fmt.Errorf("scan error reading DataHub URLs: %w", res.Err)
+		}
+		if res.Record == nil {
+			continue
+		}
+		url, ok := res.Record.Bins[dataHubURLBin].(string)
+		if !ok || url == "" {
+			continue
+		}
+		urls = append(urls, url)
+	}
+	return urls, nil
+}

--- a/internal/store/factory.go
+++ b/internal/store/factory.go
@@ -76,6 +76,11 @@ func newAerospikeRegistry(_ context.Context, cfg *config.Config, logger *slog.Lo
 			cfg.Aerospike.CallbackURLRegistryTTLSec,
 			cfg.Aerospike.MaxRetries, cfg.Aerospike.RetryBaseMs, logger,
 		),
+		DataHubRegistry: NewDataHubRegistry(
+			asClient, cfg.Aerospike.DataHubRegistry,
+			cfg.Aerospike.DataHubRegistryTTLSec,
+			cfg.Aerospike.MaxRetries, cfg.Aerospike.RetryBaseMs, logger,
+		),
 		CallbackAccumulator: NewCallbackAccumulatorStore(
 			asClient, cfg.Aerospike.CallbackAccumulatorSet, cfg.Aerospike.CallbackAccumulatorTTLSec,
 			cfg.Aerospike.MaxRetries, cfg.Aerospike.RetryBaseMs, logger,

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -59,6 +59,17 @@ type CallbackURLRegistry interface {
 	GetAll() ([]CallbackEntry, error)
 }
 
+// DataHubRegistry remembers every DataHub URL the block processor has
+// successfully fetched block metadata from. The /reprocess endpoint reads
+// this set (combined with operator-configured fallbacks) to find a DataHub
+// that can serve a past block when the API caller doesn't know which
+// DataHubs are live on the network. Add upserts and refreshes a per-URL TTL
+// so dead URLs eventually drop off.
+type DataHubRegistry interface {
+	Add(dataHubURL string) error
+	GetAll() ([]string, error)
+}
+
 // CallbackAccumulatorStore aggregates per-block, per-URL callback data across
 // subtrees, then hands it off atomically for dispatch via ReadAndDelete.
 type CallbackAccumulatorStore interface {

--- a/internal/store/registry.go
+++ b/internal/store/registry.go
@@ -10,6 +10,7 @@ type Registry struct {
 	Subtree             SubtreeStore
 	CallbackDedup       CallbackDedupStore
 	CallbackURLRegistry CallbackURLRegistry
+	DataHubRegistry     DataHubRegistry
 	CallbackAccumulator CallbackAccumulatorStore
 	SeenCounter         SeenCounterStore
 	SubtreeCounter      SubtreeCounterStore

--- a/internal/store/sql/datahub_registry.go
+++ b/internal/store/sql/datahub_registry.go
@@ -1,0 +1,68 @@
+package sql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	storepkg "github.com/bsv-blockchain/merkle-service/internal/store"
+)
+
+// dataHubRegistry stores the set of DataHub URLs the block processor has
+// successfully fetched from. /reprocess uses GetAll to build a candidate
+// list when no caller-supplied DataHub is available. Same recency model as
+// callback_urls — rows whose last_seen_at falls outside the retention window
+// are evicted by the sweeper.
+type dataHubRegistry struct {
+	db        *sql.DB
+	d         *dialect
+	retention time.Duration
+}
+
+var _ storepkg.DataHubRegistry = (*dataHubRegistry)(nil)
+
+func newDataHubRegistry(db *sql.DB, d *dialect, retention time.Duration) *dataHubRegistry {
+	if retention <= 0 {
+		retention = defaultCallbackURLRetention
+	}
+	return &dataHubRegistry{db: db, d: d, retention: retention}
+}
+
+func (r *dataHubRegistry) Add(dataHubURL string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
+		"INSERT INTO datahub_urls (datahub_url, last_seen_at) VALUES (%s, %s) "+
+			"ON CONFLICT (datahub_url) DO UPDATE SET last_seen_at = %s",
+		r.d.placeholder(1), r.d.now, r.d.now)
+	_, err := r.db.ExecContext(ctx, q, dataHubURL)
+	return err
+}
+
+func (r *dataHubRegistry) GetAll() ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cutoff := -int(r.retention / time.Second)
+	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
+		"SELECT datahub_url FROM datahub_urls "+
+			"WHERE last_seen_at IS NULL OR last_seen_at >= %s "+
+			"ORDER BY datahub_url",
+		r.d.intervalSeconds(cutoff))
+
+	rows, err := r.db.QueryContext(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	defer ensureRowsClosed(rows)
+	var out []string
+	for rows.Next() {
+		var url string
+		if err := rows.Scan(&url); err != nil {
+			return nil, err
+		}
+		out = append(out, url)
+	}
+	return out, rows.Err()
+}

--- a/internal/store/sql/migrations/0005_datahub_urls.sql
+++ b/internal/store/sql/migrations/0005_datahub_urls.sql
@@ -1,0 +1,17 @@
+-- 0005: DataHub URL registry for the /reprocess flow.
+--
+-- block-processor records every DataHub URL it successfully fetches block
+-- metadata from. The /reprocess endpoint reads this set (alongside operator
+-- fallbacks from cfg.DataHub.FallbackURLs) to find a DataHub that can serve
+-- a past block when the API caller doesn't know which DataHubs are live.
+--
+-- Same recency-based eviction model as callback_urls: Add upserts last_seen_at,
+-- the sweeper drops rows older than the retention window so a DataHub that
+-- permanently goes away eventually disappears from the registry.
+
+CREATE TABLE IF NOT EXISTS datahub_urls (
+    datahub_url   TEXT PRIMARY KEY,
+    last_seen_at  ${TIMESTAMPTZ}
+);
+
+CREATE INDEX ${IF_NOT_EXISTS_INDEX} idx_datahub_urls_last_seen_at ON datahub_urls (last_seen_at);

--- a/internal/store/sql/sql.go
+++ b/internal/store/sql/sql.go
@@ -81,6 +81,7 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger) (*storepk
 		Stump:               storepkg.NewStumpStore(blob, uint64(cfg.Subtree.StumpDAHOffset), logger), //nolint:gosec // config-validated int
 		CallbackDedup:       newCallbackDedup(db, d),
 		CallbackURLRegistry: newCallbackURLRegistry(db, d, urlRetention),
+		DataHubRegistry:     newDataHubRegistry(db, d, urlRetention),
 		CallbackAccumulator: newCallbackAccumulator(db, d, cfg.Aerospike.CallbackAccumulatorTTLSec),
 		SeenCounter:         newSeenCounter(db, d, cfg.Callback.SeenThreshold),
 		SubtreeCounter:      newSubtreeCounter(db, d, cfg.Aerospike.SubtreeCounterTTLSec),

--- a/internal/store/sql/sweeper.go
+++ b/internal/store/sql/sweeper.go
@@ -121,7 +121,30 @@ func (s *sweeper) sweepOnce(ctx context.Context) {
 		} else if rows > 0 && s.logger != nil {
 			s.logger.Debug("ttl sweeper: expired callback URLs deleted", "rows", rows)
 		}
+		rows, err = s.sweepDataHubURLs(ctx)
+		if err != nil {
+			if s.logger != nil {
+				s.logger.Warn("ttl sweeper: datahub_urls delete failed", "error", err)
+			}
+		} else if rows > 0 && s.logger != nil {
+			s.logger.Debug("ttl sweeper: expired DataHub URLs deleted", "rows", rows)
+		}
 	}
+}
+
+// sweepDataHubURLs deletes DataHub URLs whose last_seen_at is older than the
+// configured retention. Same recency model as sweepCallbackURLs.
+func (s *sweeper) sweepDataHubURLs(ctx context.Context) (int64, error) {
+	cutoff := -int(s.urlRetention / time.Second)
+	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
+		"DELETE FROM datahub_urls WHERE last_seen_at IS NOT NULL AND last_seen_at < %s",
+		s.d.intervalSeconds(cutoff))
+	res, err := s.db.ExecContext(ctx, q)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
 }
 
 // sweepCallbackURLs deletes URLs whose last_seen_at is older than the


### PR DESCRIPTION
This pull request introduces the new `/reprocess` API endpoint, which enables on-demand reprocessing of a past block. The endpoint allows clients to trigger STUMP and BLOCK_PROCESSED callback delivery for a specific block and callback URL, with robust validation, SSRF protection, and DataHub discovery logic. The implementation includes request validation, DataHub probing, and Kafka integration for asynchronous processing. Documentation has been updated to describe the new endpoint and its behavior.

**New `/reprocess` endpoint implementation and integration:**

* Added the `POST /reprocess` endpoint to the API, including request/response types, input validation (block hash, callback URL/token), SSRF protection, and error handling. The endpoint triggers block reprocessing for a specific `blockHash` and `callbackUrl`, and enqueues the job for asynchronous delivery.
* Implemented DataHub discovery and probing logic: operator-configured fallback URLs are prioritized, followed by dynamically discovered DataHubs, with deduplication and robust error handling to distinguish between not found, transport, and configuration errors.
* Integrated the new endpoint into the API server initialization in `main.go` for both `api-server` and `merkle-service`, wiring up dependencies such as the DataHub client, Kafka producer, and DataHub registry. [[1]](diffhunk://#diff-9a806b47e2c7033d8cd996647dab85acf24df2026be1ffe009df197a35956002R9-R10) [[2]](diffhunk://#diff-9a806b47e2c7033d8cd996647dab85acf24df2026be1ffe009df197a35956002R34-R58) [[3]](diffhunk://#diff-c368fe0d5f68ac46ac2912b459d6c0cc5f8b03c96ef640dc0e5f5915f2a1b717R11) [[4]](diffhunk://#diff-c368fe0d5f68ac46ac2912b459d6c0cc5f8b03c96ef640dc0e5f5915f2a1b717R49-R64) [[5]](diffhunk://#diff-213ebda8c947a599411016e0494aeed174919565b51a80ba3e17edf09cab6dd2L31-R31)

**Documentation:**

* Updated `docs/api.md` to document the new `/reprocess` endpoint, including request/response schema, error codes, scoping, ordering, idempotency, and a usage example.

**Supporting changes:**

* Added necessary imports and dependency wiring for `datahub`, `kafka`, and related modules in API and service entrypoints. [[1]](diffhunk://#diff-9a806b47e2c7033d8cd996647dab85acf24df2026be1ffe009df197a35956002R9-R10) [[2]](diffhunk://#diff-c368fe0d5f68ac46ac2912b459d6c0cc5f8b03c96ef640dc0e5f5915f2a1b717R11)
* Updated the block processor to accept the DataHub registry as a dependency for reprocessing support. [[1]](diffhunk://#diff-213ebda8c947a599411016e0494aeed174919565b51a80ba3e17edf09cab6dd2L31-R31) [[2]](diffhunk://#diff-c368fe0d5f68ac46ac2912b459d6c0cc5f8b03c96ef640dc0e5f5915f2a1b717R49-R64)