### PR TITLE
Add prometheus metrics

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -37,15 +37,15 @@ func main() {
 	var metricsSrv *metrics.Server
 	if cfg.Metrics.Enabled {
 		metricsSrv = metrics.NewServer(cfg.Metrics, logger)
-		if err := metricsSrv.Init(nil); err != nil {
-			log.Fatal("failed to init metrics server: ", err)
+		if initErr := metricsSrv.Init(nil); initErr != nil {
+			log.Fatal("failed to init metrics server: ", initErr)
 		}
-		if err := metricsSrv.Start(ctx); err != nil {
-			log.Fatal("failed to start metrics server: ", err)
+		if startErr := metricsSrv.Start(ctx); startErr != nil {
+			log.Fatal("failed to start metrics server: ", startErr)
 		}
 		defer func() {
-			if err := metricsSrv.Stop(); err != nil {
-				logger.Error("failed to stop metrics server", "error", err)
+			if stopErr := metricsSrv.Stop(); stopErr != nil {
+				logger.Error("failed to stop metrics server", "error", stopErr)
 			}
 		}()
 	}

--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bsv-blockchain/merkle-service/internal/config"
 	"github.com/bsv-blockchain/merkle-service/internal/datahub"
 	"github.com/bsv-blockchain/merkle-service/internal/kafka"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
 	_ "github.com/bsv-blockchain/merkle-service/internal/store/sql" // register SQL backend
@@ -31,6 +32,23 @@ func main() {
 
 	server := api.NewServer(cfg.API, registry.Registration, registry.CallbackURLRegistry, registry.Health, logger)
 	server.SetAllowPrivateCallbackIPs(cfg.Callback.AllowPrivateIPs)
+	server.SetBackend(cfg.Store.Backend)
+
+	var metricsSrv *metrics.Server
+	if cfg.Metrics.Enabled {
+		metricsSrv = metrics.NewServer(cfg.Metrics, logger)
+		if err := metricsSrv.Init(nil); err != nil {
+			log.Fatal("failed to init metrics server: ", err)
+		}
+		if err := metricsSrv.Start(ctx); err != nil {
+			log.Fatal("failed to start metrics server: ", err)
+		}
+		defer func() {
+			if err := metricsSrv.Stop(); err != nil {
+				logger.Error("failed to stop metrics server", "error", err)
+			}
+		}()
+	}
 
 	// /reprocess deps. The DataHub client honors the same SSRF posture as the
 	// block-processor so /reprocess can't be coerced into probing

--- a/cmd/block-processor/main.go
+++ b/cmd/block-processor/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bsv-blockchain/merkle-service/internal/block"
 	"github.com/bsv-blockchain/merkle-service/internal/config"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
 	_ "github.com/bsv-blockchain/merkle-service/internal/store/sql" // register SQL backend
@@ -31,6 +32,22 @@ func main() {
 		registry.Registration, registry.Subtree, registry.CallbackURLRegistry, registry.DataHubRegistry, registry.SubtreeCounter,
 		logger,
 	)
+
+	var metricsSrv *metrics.Server
+	if cfg.Metrics.Enabled {
+		metricsSrv = metrics.NewServer(cfg.Metrics, logger)
+		if err := metricsSrv.Init(nil); err != nil {
+			log.Fatal("failed to init metrics server: ", err)
+		}
+		if err := metricsSrv.Start(ctx); err != nil {
+			log.Fatal("failed to start metrics server: ", err)
+		}
+		defer func() {
+			if err := metricsSrv.Stop(); err != nil {
+				logger.Error("failed to stop metrics server", "error", err)
+			}
+		}()
+	}
 
 	if err := processor.Init(nil); err != nil {
 		log.Fatal("failed to init block processor: ", err)

--- a/cmd/callback-delivery/main.go
+++ b/cmd/callback-delivery/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bsv-blockchain/merkle-service/internal/callback"
 	"github.com/bsv-blockchain/merkle-service/internal/config"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
 	_ "github.com/bsv-blockchain/merkle-service/internal/store/sql" // register SQL backend
@@ -27,6 +28,22 @@ func main() {
 	defer func() { _ = registry.Close() }()
 
 	deliverySvc := callback.NewDeliveryService(cfg, registry.CallbackDedup, registry.Stump)
+
+	var metricsSrv *metrics.Server
+	if cfg.Metrics.Enabled {
+		metricsSrv = metrics.NewServer(cfg.Metrics, logger)
+		if err := metricsSrv.Init(nil); err != nil {
+			log.Fatal("failed to init metrics server: ", err)
+		}
+		if err := metricsSrv.Start(ctx); err != nil {
+			log.Fatal("failed to start metrics server: ", err)
+		}
+		defer func() {
+			if err := metricsSrv.Stop(); err != nil {
+				logger.Error("failed to stop metrics server", "error", err)
+			}
+		}()
+	}
 
 	if err := deliverySvc.Init(nil); err != nil {
 		log.Fatal("failed to init callback delivery service: ", err)

--- a/cmd/merkle-service/main.go
+++ b/cmd/merkle-service/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bsv-blockchain/merkle-service/internal/config"
 	"github.com/bsv-blockchain/merkle-service/internal/datahub"
 	"github.com/bsv-blockchain/merkle-service/internal/kafka"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 	"github.com/bsv-blockchain/merkle-service/internal/p2p"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
@@ -47,6 +48,7 @@ func main() {
 
 	apiServer := api.NewServer(cfg.API, registry.Registration, registry.CallbackURLRegistry, registry.Health, logger)
 	apiServer.SetAllowPrivateCallbackIPs(cfg.Callback.AllowPrivateIPs)
+	apiServer.SetBackend(cfg.Store.Backend)
 	apiDataHubClient := datahub.NewClientWithSSRFGuard(
 		cfg.DataHub.TimeoutSec,
 		cfg.DataHub.MaxRetries,
@@ -79,7 +81,11 @@ func main() {
 	subtreeWorker := block.NewSubtreeWorkerService(cfg.Kafka, cfg.Block, cfg.DataHub, registry.Registration, registry.Subtree, registry.Stump, registry.CallbackURLRegistry, registry.SubtreeCounter, logger)
 	callbackDelivery := callback.NewDeliveryService(cfg, registry.CallbackDedup, registry.Stump)
 
-	services := []service.Service{apiServer, p2pClient, subtreeFetcher, blockProcessor, subtreeWorker, callbackDelivery}
+	services := []service.Service{}
+	if cfg.Metrics.Enabled {
+		services = append(services, metrics.NewServer(cfg.Metrics, logger))
+	}
+	services = append(services, apiServer, p2pClient, subtreeFetcher, blockProcessor, subtreeWorker, callbackDelivery)
 	for _, svc := range services {
 		if err := svc.Init(nil); err != nil {
 			log.Fatal("failed to init service: ", err)

--- a/cmd/p2p-client/main.go
+++ b/cmd/p2p-client/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bsv-blockchain/merkle-service/internal/config"
 	"github.com/bsv-blockchain/merkle-service/internal/kafka"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 	"github.com/bsv-blockchain/merkle-service/internal/p2p"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
@@ -83,6 +84,22 @@ func run() error {
 	// P2P session.
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer cancel()
+
+	var metricsSrv *metrics.Server
+	if cfg.Metrics.Enabled {
+		metricsSrv = metrics.NewServer(cfg.Metrics, logger)
+		if err := metricsSrv.Init(nil); err != nil {
+			return err
+		}
+		if err := metricsSrv.Start(ctx); err != nil {
+			return err
+		}
+		defer func() {
+			if err := metricsSrv.Stop(); err != nil {
+				logger.Error("failed to stop metrics server", "error", err)
+			}
+		}()
+	}
 
 	runErr := client.Run(ctx)
 	if stopErr := client.Stop(); stopErr != nil {

--- a/cmd/subtree-fetcher/main.go
+++ b/cmd/subtree-fetcher/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/bsv-blockchain/merkle-service/internal/config"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
 	_ "github.com/bsv-blockchain/merkle-service/internal/store/sql" // register SQL backend
@@ -27,6 +28,22 @@ func main() {
 	defer func() { _ = registry.Close() }()
 
 	processor := subtree.NewProcessor(cfg, registry.Registration, registry.SeenCounter, registry.Subtree)
+
+	var metricsSrv *metrics.Server
+	if cfg.Metrics.Enabled {
+		metricsSrv = metrics.NewServer(cfg.Metrics, logger)
+		if err := metricsSrv.Init(nil); err != nil {
+			log.Fatal("failed to init metrics server: ", err)
+		}
+		if err := metricsSrv.Start(ctx); err != nil {
+			log.Fatal("failed to start metrics server: ", err)
+		}
+		defer func() {
+			if err := metricsSrv.Stop(); err != nil {
+				logger.Error("failed to stop metrics server", "error", err)
+			}
+		}()
+	}
 
 	if err := processor.Init(nil); err != nil {
 		log.Fatal("failed to init subtree processor: ", err)

--- a/cmd/subtree-worker/main.go
+++ b/cmd/subtree-worker/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bsv-blockchain/merkle-service/internal/block"
 	"github.com/bsv-blockchain/merkle-service/internal/config"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
 	_ "github.com/bsv-blockchain/merkle-service/internal/store/sql" // register SQL backend
@@ -31,6 +32,22 @@ func main() {
 		registry.Registration, registry.Subtree, registry.Stump, registry.CallbackURLRegistry, registry.SubtreeCounter,
 		logger,
 	)
+
+	var metricsSrv *metrics.Server
+	if cfg.Metrics.Enabled {
+		metricsSrv = metrics.NewServer(cfg.Metrics, logger)
+		if err := metricsSrv.Init(nil); err != nil {
+			log.Fatal("failed to init metrics server: ", err)
+		}
+		if err := metricsSrv.Start(ctx); err != nil {
+			log.Fatal("failed to start metrics server: ", err)
+		}
+		defer func() {
+			if err := metricsSrv.Stop(); err != nil {
+				logger.Error("failed to stop metrics server", "error", err)
+			}
+		}()
+	}
 
 	if err := worker.Init(nil); err != nil {
 		log.Fatal("failed to init subtree worker: ", err)

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/jackc/pgx/v5 v5.9.2
+	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/viper v1.21.0
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0
@@ -141,6 +142,7 @@ require (
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/koron/go-ssdp v0.9.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/labstack/echo/v4 v4.15.2 // indirect
 	github.com/labstack/gommon v0.5.0 // indirect
 	github.com/lib/pq v1.12.3 // indirect
@@ -220,7 +222,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/polydawn/refmt v0.89.1-0.20231129105047-37766d95467a // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0
 	golang.org/x/sync v0.20.0
-	golang.org/x/sys v0.44.0
+	golang.org/x/sys v0.45.0
 	modernc.org/sqlite v1.50.1
 )
 
@@ -273,7 +273,7 @@ require (
 	go.uber.org/zap v1.28.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.51.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a // indirect
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/net v0.54.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -873,8 +873,8 @@ golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
-golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
-golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -1045,8 +1045,8 @@ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
-golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/telemetry v0.0.0-20260508192327-42602be52be6 h1:HjU6IWBiAgRIdAJ9/y1rwCn+UELEmwV+VsTLzj/W4sE=
 golang.org/x/telemetry v0.0.0-20260508192327-42602be52be6/go.mod h1:Eqhaxk/wZsWEH8CRxLwj6xzEJbz7k1EFGqx7nyCoabE=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/bsv-blockchain/merkle-service/internal/datahub"
 	"github.com/bsv-blockchain/merkle-service/internal/kafka"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 	"github.com/bsv-blockchain/merkle-service/internal/ssrfguard"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
 )
@@ -116,7 +117,10 @@ func (s *Server) handleWatch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Store registration
-	if err := s.regStore.Add(req.TxID, req.CallbackURL, req.CallbackToken); err != nil {
+	addStart := time.Now()
+	err := s.regStore.Add(req.TxID, req.CallbackURL, req.CallbackToken)
+	metrics.ObserveDB(s.backendLabel(), metrics.StoreRegistration, metrics.OpAdd, addStart, err)
+	if err != nil {
 		// F-050: surface the per-txid callback cap as a 429 so the caller can
 		// distinguish a quota error from a transient backend failure and back
 		// off accordingly. The body still uses the standard ErrorResponse shape.
@@ -137,8 +141,11 @@ func (s *Server) handleWatch(w http.ResponseWriter, r *http.Request) {
 	// alongside so BLOCK_PROCESSED fan-out (which iterates urlRegistry rather
 	// than the per-txid map) can attach the same Authorization header.
 	if s.urlRegistry != nil {
-		if err := s.urlRegistry.Add(req.CallbackURL, req.CallbackToken); err != nil {
-			s.Logger.Warn("failed to add callback URL to registry", "url", req.CallbackURL, "error", err)
+		regStart := time.Now()
+		regErr := s.urlRegistry.Add(req.CallbackURL, req.CallbackToken)
+		metrics.ObserveDB(s.backendLabel(), metrics.StoreCallbackURLRegistry, metrics.OpAdd, regStart, regErr)
+		if regErr != nil {
+			s.Logger.Warn("failed to add callback URL to registry", "url", req.CallbackURL, "error", regErr)
 		}
 	}
 
@@ -181,7 +188,9 @@ func (s *Server) handleLookup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	getStart := time.Now()
 	entries, err := s.regStore.Get(txid)
+	metrics.ObserveDB(s.backendLabel(), metrics.StoreRegistration, metrics.OpGet, getStart, err)
 	if err != nil {
 		s.Logger.Error("failed to lookup registration", "txid", txid, "error", err)
 		writeJSON(w, http.StatusInternalServerError, ErrorResponse{Error: "internal server error"})

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -97,7 +97,8 @@ func (s *Server) handleWatch(w http.ResponseWriter, r *http.Request) {
 		default:
 			msg = "invalid callbackUrl: must be a valid HTTP/HTTPS URL with a public host"
 		}
-		s.Logger.Warn("rejected callback URL registration",
+		s.Logger.Warn(
+			"rejected callback URL registration",
 			"reason", err.Error(),
 			"txid", req.TxID,
 		)
@@ -271,7 +272,8 @@ func (s *Server) handleReprocess(w http.ResponseWriter, r *http.Request) {
 		default:
 			msg = "invalid callbackUrl: must be a valid HTTP/HTTPS URL with a public host"
 		}
-		s.Logger.Warn("rejected reprocess callback URL",
+		s.Logger.Warn(
+			"rejected reprocess callback URL",
 			"reason", err.Error(),
 			"blockHash", req.BlockHash,
 		)
@@ -298,7 +300,8 @@ func (s *Server) handleReprocess(w http.ResponseWriter, r *http.Request) {
 
 	resolvedURL, height, subtreeHashes, status, probeErr := s.probeDataHubsForBlock(r.Context(), candidates, fallbackCount, req.BlockHash)
 	if probeErr != nil {
-		s.Logger.Warn("reprocess: no DataHub served block",
+		s.Logger.Warn(
+			"reprocess: no DataHub served block",
 			"blockHash", req.BlockHash,
 			"candidates", len(candidates),
 			"status", status,
@@ -346,7 +349,8 @@ func (s *Server) handleReprocess(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.Logger.Info("reprocess enqueued",
+	s.Logger.Info(
+		"reprocess enqueued",
 		"blockHash", req.BlockHash,
 		"dataHubUrl", resolvedURL,
 		"callbackUrl", req.CallbackURL,
@@ -394,7 +398,8 @@ func (s *Server) clearReprocessDedup(blockHash, callbackURL string, subtreeHashe
 	cleared := 0
 	for _, e := range entries {
 		if err := s.dedupStore.Delete(e.key, callbackURL, e.typeName); err != nil {
-			s.Logger.Warn("reprocess: failed to clear callback dedup entry",
+			s.Logger.Warn(
+				"reprocess: failed to clear callback dedup entry",
 				"blockHash", blockHash,
 				"callbackUrl", callbackURL,
 				"type", e.typeName,
@@ -406,7 +411,8 @@ func (s *Server) clearReprocessDedup(blockHash, callbackURL string, subtreeHashe
 		cleared++
 	}
 
-	s.Logger.Info("reprocess: cleared callback dedup entries",
+	s.Logger.Info(
+		"reprocess: cleared callback dedup entries",
 		"blockHash", blockHash,
 		"callbackUrl", callbackURL,
 		"clearedCount", cleared,
@@ -500,7 +506,8 @@ func (s *Server) probeDataHubsForBlock(parentCtx context.Context, candidates []s
 		if !errors.Is(ferr, datahub.ErrNotFound) {
 			allNotFound = false
 		}
-		s.Logger.Debug("reprocess probe failed",
+		s.Logger.Debug(
+			"reprocess probe failed",
 			"dataHubUrl", url,
 			"blockHash", blockHash,
 			"notFound", errors.Is(ferr, datahub.ErrNotFound),

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -221,7 +221,8 @@ func middlewareLogger(logger *slog.Logger) func(next http.Handler) http.Handler 
 
 			next.ServeHTTP(ww, r)
 
-			logger.Info("request",
+			logger.Info(
+				"request",
 				"method", r.Method,
 				"path", r.URL.Path,
 				"status", ww.Status(),

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bsv-blockchain/merkle-service/internal/config"
 	"github.com/bsv-blockchain/merkle-service/internal/datahub"
 	"github.com/bsv-blockchain/merkle-service/internal/kafka"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
 )
@@ -40,6 +41,9 @@ type Server struct {
 	// delivery that exhausted its retry chain and went to DLQ
 	// (bsv-blockchain/merkle-service#122).
 	dedupStore store.CallbackDedupStore
+	// backend is the configured store backend label ("aerospike"/"sql")
+	// used to tag DB metrics emitted from handlers.
+	backend string
 	// fallbackDataHubURLs are operator-configured DataHubs probed by
 	// /reprocess before the dynamically-discovered ones.
 	fallbackDataHubURLs []string
@@ -103,6 +107,25 @@ func (s *Server) SetReprocessDeps(deps *ReprocessDeps) {
 	s.dedupStore = deps.DedupStore
 }
 
+// SetBackend records the store-backend label for DB metrics emitted from
+// API handlers ("aerospike" or "sql").
+func (s *Server) SetBackend(backend string) {
+	if backend == config.BackendSQL {
+		s.backend = metrics.BackendSQL
+	} else {
+		s.backend = metrics.BackendAerospike
+	}
+}
+
+// backendLabel returns the configured store-backend label. Defaults to
+// aerospike when SetBackend hasn't been called.
+func (s *Server) backendLabel() string {
+	if s.backend == "" {
+		return metrics.BackendAerospike
+	}
+	return s.backend
+}
+
 // SetAllowPrivateCallbackIPs toggles the SSRF guard on /watch. When false
 // (the default) callback URLs resolving to private/loopback/link-local
 // destinations are rejected at registration time. Wire this from
@@ -129,6 +152,7 @@ func (s *Server) Init(cfg interface{}) error {
 	s.router.Use(middleware.RequestID)
 	s.router.Use(middleware.RealIP)
 	s.router.Use(middlewareLogger(s.Logger))
+	s.router.Use(metrics.ChiMiddleware)
 	s.router.Use(middleware.Recoverer)
 
 	// Routes

--- a/internal/block/processor.go
+++ b/internal/block/processor.go
@@ -184,7 +184,8 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 		return err
 	}
 
-	p.Logger.Info("processing block announcement",
+	p.Logger.Info(
+		"processing block announcement",
 		"hash", blockMsg.Hash,
 		"height", blockMsg.Height,
 		"dataHubUrl", blockMsg.DataHubURL,
@@ -223,7 +224,8 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 
 	// 5.3: Extract subtree hashes from block metadata.
 	subtreeHashes := meta.Subtrees
-	p.Logger.Info("block metadata fetched",
+	p.Logger.Info(
+		"block metadata fetched",
 		"hash", blockMsg.Hash,
 		"height", meta.Height,
 		"subtreeCount", len(subtreeHashes),
@@ -281,7 +283,8 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 		}
 		data, encErr := workMsg.Encode()
 		if encErr != nil {
-			p.Logger.Error("failed to encode subtree work message",
+			p.Logger.Error(
+				"failed to encode subtree work message",
 				"subtreeHash", stHash,
 				"blockHash", blockMsg.Hash,
 				"subtreeIndex", i,
@@ -303,7 +306,8 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 	counterKey := SubtreeCounterKey(blockMsg.Hash, blockMsg.OverrideCallbackURL)
 	if p.subtreeCounter != nil {
 		if err := p.subtreeCounter.Init(counterKey, len(encoded)); err != nil {
-			p.Logger.Error("failed to init subtree counter",
+			p.Logger.Error(
+				"failed to init subtree counter",
 				"blockHash", blockMsg.Hash,
 				"counterKey", counterKey,
 				"count", len(encoded),
@@ -322,7 +326,8 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 	// duplicate fan-out is safe.
 	for i, ew := range encoded {
 		if err := p.subtreeWorkProducer.PublishWithHashKey(ew.subtreeHash, ew.payload); err != nil {
-			p.Logger.Error("failed to publish subtree work message",
+			p.Logger.Error(
+				"failed to publish subtree work message",
 				"subtreeHash", ew.subtreeHash,
 				"blockHash", blockMsg.Hash,
 				"subtreeIndex", i,
@@ -335,7 +340,8 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 		}
 	}
 
-	p.Logger.Info("dispatched subtree work items",
+	p.Logger.Info(
+		"dispatched subtree work items",
 		"blockHash", blockMsg.Hash,
 		"subtreeCount", len(encoded),
 	)
@@ -420,7 +426,8 @@ func (p *Processor) fetchBlockMetadataWithFailover(
 		cancel()
 		if err == nil {
 			if a.url != announcedURL {
-				p.Logger.Info("block metadata served by failover DataHub",
+				p.Logger.Info(
+					"block metadata served by failover DataHub",
 					"hash", blockHash,
 					"announcedUrl", announcedURL,
 					"resolvedUrl", a.url,
@@ -429,7 +436,8 @@ func (p *Processor) fetchBlockMetadataWithFailover(
 			return meta, a.url, nil
 		}
 		lastErr = err
-		p.Logger.Debug("DataHub failover candidate failed",
+		p.Logger.Debug(
+			"DataHub failover candidate failed",
 			"hash", blockHash,
 			"url", a.url,
 			"notFound", errors.Is(err, datahub.ErrNotFound),

--- a/internal/block/subtree_processor.go
+++ b/internal/block/subtree_processor.go
@@ -10,6 +10,7 @@ import (
 	subtreepkg "github.com/bsv-blockchain/go-subtree"
 
 	"github.com/bsv-blockchain/merkle-service/internal/datahub"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
 	"github.com/bsv-blockchain/merkle-service/internal/stump"
 )
@@ -198,13 +199,18 @@ func ProcessBlockSubtree(
 	}
 
 	// 6.7: Build STUMP.
+	buildStart := time.Now()
 	s := stump.Build(blockHeight, leaves, internalNodes, registeredIndices)
 	if s == nil {
+		metrics.ObserveBumpBuild(time.Since(buildStart), len(leaves), len(registeredIndices), 0, true)
 		return nil, nil
 	}
+	metrics.ObserveBumpBuild(time.Since(buildStart), len(leaves), len(registeredIndices), int(s.TreeHeight), false)
 
 	// 6.8: Encode STUMP to BRC-0074 binary.
+	encodeStart := time.Now()
 	stumpData := s.Encode()
+	metrics.ObserveBumpEncode(time.Since(encodeStart), len(stumpData))
 
 	// 6.9: Group txids by callback URL.
 	callbackGroups := stump.GroupByCallback(registrationsByTxID)

--- a/internal/block/subtree_processor.go
+++ b/internal/block/subtree_processor.go
@@ -83,7 +83,8 @@ func ProcessBlockSubtree(
 	// 6.2: Retrieve subtree data from blob store, falling back to DataHub.
 	rawData, err := subtreeStore.GetSubtree(subtreeHash)
 	if err != nil || rawData == nil {
-		logger.Debug("subtree not in blob store, fetching from DataHub",
+		logger.Debug(
+			"subtree not in blob store, fetching from DataHub",
 			"subtreeHash", subtreeHash,
 			"blockHash", blockHash,
 		)
@@ -227,7 +228,8 @@ func ProcessBlockSubtree(
 		}
 	}
 
-	logger.Info("processed block subtree",
+	logger.Info(
+		"processed block subtree",
 		"subtreeHash", subtreeHash,
 		"blockHash", blockHash,
 		"registeredTxids", len(registrations),

--- a/internal/block/subtree_worker.go
+++ b/internal/block/subtree_worker.go
@@ -95,7 +95,8 @@ func (s *SubtreeWorkerService) Init(_ interface{}) error {
 	if s.blockCfg.RegCacheMaxMB > 0 {
 		regCache, err := cache.NewRegistrationCache(s.blockCfg.RegCacheMaxMB, s.Logger)
 		if err != nil {
-			s.Logger.Warn("failed to create block registration cache, proceeding without",
+			s.Logger.Warn(
+				"failed to create block registration cache, proceeding without",
 				"error", err,
 				"maxMB", s.blockCfg.RegCacheMaxMB,
 			)
@@ -156,7 +157,8 @@ func (s *SubtreeWorkerService) Init(_ interface{}) error {
 	}
 	s.consumer = consumer
 
-	s.Logger.Info("subtree worker service initialized",
+	s.Logger.Info(
+		"subtree worker service initialized",
 		"subtreeWorkTopic", s.kafkaCfg.SubtreeWorkTopic,
 		"subtreeWorkDLQTopic", dlqTopic,
 		"maxAttempts", s.maxAttempts(),
@@ -250,7 +252,8 @@ func (s *SubtreeWorkerService) maxAttempts() int {
 func (s *SubtreeWorkerService) handleMessage(ctx context.Context, msg *sarama.ConsumerMessage) error {
 	workMsg, err := kafka.DecodeSubtreeWorkMessage(msg.Value)
 	if err != nil {
-		s.Logger.Error("failed to decode subtree work message, dropping",
+		s.Logger.Error(
+			"failed to decode subtree work message, dropping",
 			"offset", msg.Offset,
 			"partition", msg.Partition,
 			"error", err,
@@ -260,7 +263,8 @@ func (s *SubtreeWorkerService) handleMessage(ctx context.Context, msg *sarama.Co
 		return nil
 	}
 
-	s.Logger.Debug("processing subtree work item",
+	s.Logger.Debug(
+		"processing subtree work item",
 		"subtreeHash", workMsg.SubtreeHash,
 		"blockHash", workMsg.BlockHash,
 		"blockHeight", workMsg.BlockHeight,
@@ -331,7 +335,8 @@ func (s *SubtreeWorkerService) handleTransientFailure(workMsg *kafka.SubtreeWork
 	maxAttempts := s.maxAttempts()
 
 	if nextAttempt >= maxAttempts {
-		s.Logger.Error("subtree work item exceeded max attempts, routing to DLQ",
+		s.Logger.Error(
+			"subtree work item exceeded max attempts, routing to DLQ",
 			"subtreeHash", workMsg.SubtreeHash,
 			"blockHash", workMsg.BlockHash,
 			"subtreeIndex", workMsg.SubtreeIndex,
@@ -358,7 +363,8 @@ func (s *SubtreeWorkerService) handleTransientFailure(workMsg *kafka.SubtreeWork
 		// will repeat, but that's preferable to silently acking with the
 		// counter still > 0 and BLOCK_PROCESSED never firing (F-013).
 		if decErr := s.decrementCounterAndMaybeEmit(workMsg.BlockHash, workMsg.OverrideCallbackURL, workMsg.OverrideCallbackToken); decErr != nil {
-			s.Logger.Error("ALERT: subtree counter decrement failed on DLQ path; BLOCK_PROCESSED delayed until counter store recovers",
+			s.Logger.Error(
+				"ALERT: subtree counter decrement failed on DLQ path; BLOCK_PROCESSED delayed until counter store recovers",
 				"subtreeHash", workMsg.SubtreeHash,
 				"blockHash", workMsg.BlockHash,
 				"subtreeIndex", workMsg.SubtreeIndex,
@@ -370,7 +376,8 @@ func (s *SubtreeWorkerService) handleTransientFailure(workMsg *kafka.SubtreeWork
 		return nil
 	}
 
-	s.Logger.Warn("subtree work item transient failure, re-publishing for retry",
+	s.Logger.Warn(
+		"subtree work item transient failure, re-publishing for retry",
 		"subtreeHash", workMsg.SubtreeHash,
 		"blockHash", workMsg.BlockHash,
 		"subtreeIndex", workMsg.SubtreeIndex,
@@ -422,7 +429,8 @@ func (s *SubtreeWorkerService) decrementCounterAndMaybeEmit(blockHash, overrideU
 	counterKey := SubtreeCounterKey(blockHash, overrideURL)
 	remaining, err := s.subtreeCounter.Decrement(counterKey)
 	if err != nil {
-		s.Logger.Error("failed to decrement subtree counter",
+		s.Logger.Error(
+			"failed to decrement subtree counter",
 			"blockHash", blockHash,
 			"counterKey", counterKey,
 			"error", err,
@@ -436,7 +444,8 @@ func (s *SubtreeWorkerService) decrementCounterAndMaybeEmit(blockHash, overrideU
 	// not silently lost. Receiver-side dedup handles the duplicate.
 	if remaining <= 0 {
 		if emitErr := s.emitBlockProcessed(blockHash, overrideURL, overrideToken); emitErr != nil {
-			s.Logger.Error("failed to emit BLOCK_PROCESSED; work item will be redelivered",
+			s.Logger.Error(
+				"failed to emit BLOCK_PROCESSED; work item will be redelivered",
 				"blockHash", blockHash,
 				"remaining", remaining,
 				"error", emitErr,
@@ -460,7 +469,8 @@ func (s *SubtreeWorkerService) decrementCounterAndMaybeEmit(blockHash, overrideU
 // decrementing the counter — see F-012.
 func (s *SubtreeWorkerService) publishSubtreeCallbacks(workMsg *kafka.SubtreeWorkMessage, result *SubtreeResult) error {
 	if s.stumpStore == nil {
-		s.Logger.Error("stump store not configured; cannot publish STUMP callbacks",
+		s.Logger.Error(
+			"stump store not configured; cannot publish STUMP callbacks",
 			"blockHash", workMsg.BlockHash,
 			"subtreeIndex", workMsg.SubtreeIndex,
 		)
@@ -472,7 +482,8 @@ func (s *SubtreeWorkerService) publishSubtreeCallbacks(workMsg *kafka.SubtreeWor
 	if err != nil {
 		// Without a ref, downstream delivery can't fetch the STUMP — skip this
 		// subtree's callbacks entirely rather than publishing broken messages.
-		s.Logger.Error("failed to store STUMP blob; skipping subtree callbacks",
+		s.Logger.Error(
+			"failed to store STUMP blob; skipping subtree callbacks",
 			"blockHash", workMsg.BlockHash,
 			"subtreeIndex", workMsg.SubtreeIndex,
 			"callbackURLs", len(result.CallbackGroups),
@@ -605,7 +616,8 @@ func emitBlockProcessedCallbacks(
 		}
 		data, encErr := msg.Encode()
 		if encErr != nil {
-			logger.Error("failed to encode BLOCK_PROCESSED message",
+			logger.Error(
+				"failed to encode BLOCK_PROCESSED message",
 				"callbackURL", entry.URL,
 				"error", encErr,
 			)
@@ -615,7 +627,8 @@ func emitBlockProcessedCallbacks(
 			continue
 		}
 		if pubErr := producer.PublishWithHashKey(msg.PartitionKey(), data); pubErr != nil {
-			logger.Error("failed to publish BLOCK_PROCESSED callback",
+			logger.Error(
+				"failed to publish BLOCK_PROCESSED callback",
 				"callbackURL", entry.URL,
 				"error", pubErr,
 			)
@@ -626,7 +639,8 @@ func emitBlockProcessedCallbacks(
 	}
 
 	if firstErr == nil {
-		logger.Info("emitted BLOCK_PROCESSED callbacks",
+		logger.Info(
+			"emitted BLOCK_PROCESSED callbacks",
 			"blockHash", blockHash,
 			"callbackURLs", len(entries),
 		)

--- a/internal/block/subtree_worker_handle_message_test.go
+++ b/internal/block/subtree_worker_handle_message_test.go
@@ -130,6 +130,7 @@ func (s *stubStumpStore) Put(data []byte, blockHeight uint64) (string, error) {
 	s.lastRef = "stump-ref-stub"
 	return s.lastRef, nil
 }
+
 func (s *stubStumpStore) Get(ref string) ([]byte, error) { return nil, errors.New("not implemented") }
 func (s *stubStumpStore) Delete(ref string) error        { return nil }
 

--- a/internal/callback/delivery.go
+++ b/internal/callback/delivery.go
@@ -169,7 +169,8 @@ func (d *DeliveryService) Init(_ interface{}) error {
 	}
 	d.consumer = consumer
 
-	d.Logger.Info("callback delivery service initialized",
+	d.Logger.Info(
+		"callback delivery service initialized",
 		"callbackTopic", d.cfg.Kafka.CallbackTopic,
 		"callbackDlqTopic", d.cfg.Kafka.CallbackDLQTopic,
 		"maxRetries", d.cfg.Callback.MaxRetries,
@@ -234,7 +235,8 @@ func (d *DeliveryService) Stop() error {
 
 	d.SetStarted(false)
 	d.Cancel()
-	d.Logger.Info("callback delivery service stopped",
+	d.Logger.Info(
+		"callback delivery service stopped",
 		"messagesProcessed", int64(testutil.ToFloat64(metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeDelivered))),
 		"messagesRetried", int64(testutil.ToFloat64(metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeRetryScheduled))),
 		"messagesFailed", int64(testutil.ToFloat64(metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeDLQ))),
@@ -276,7 +278,8 @@ func (d *DeliveryService) handleMessage(ctx context.Context, msg *sarama.Consume
 		// A poison-pill message that cannot be decoded should not block the
 		// partition forever. Log and ack so the consumer can advance — the
 		// raw bytes are still inspectable via Kafka's retention.
-		d.Logger.Error("failed to decode callback message, skipping",
+		d.Logger.Error(
+			"failed to decode callback message, skipping",
 			"offset", msg.Offset,
 			"partition", msg.Partition,
 			"error", err,
@@ -321,7 +324,8 @@ func (d *DeliveryService) handleMessage(ctx context.Context, msg *sarama.Consume
 // message reaches a durable terminal state; a non-nil return means the
 // Kafka offset must NOT be marked so the message is re-consumed.
 func (d *DeliveryService) processDelivery(ctx context.Context, cbMsg *kafka.CallbackTopicMessage) error {
-	d.Logger.Debug("processing callback message",
+	d.Logger.Debug(
+		"processing callback message",
 		"callbackUrl", cbMsg.CallbackURL,
 		"txid", cbMsg.TxID,
 		"type", cbMsg.Type,
@@ -359,7 +363,8 @@ func (d *DeliveryService) processDelivery(ctx context.Context, cbMsg *kafka.Call
 				// clear the stale dedup state — see
 				// bsv-blockchain/merkle-service#122 for the full
 				// post-DLQ failure mode.
-				d.Logger.Info("skipping duplicate callback delivery",
+				d.Logger.Info(
+					"skipping duplicate callback delivery",
 					"dedupKey", dedupKey,
 					"callbackUrl", cbMsg.CallbackURL,
 					"type", cbMsg.Type,
@@ -394,7 +399,8 @@ func (d *DeliveryService) processDelivery(ctx context.Context, cbMsg *kafka.Call
 		}
 		metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeDelivered).Inc()
 		metrics.ObserveCallbackRetryAttempt(cbMsg.RetryCount)
-		d.Logger.Debug("callback delivered successfully",
+		d.Logger.Debug(
+			"callback delivered successfully",
 			"callbackUrl", cbMsg.CallbackURL,
 			"txid", cbMsg.TxID,
 			"type", cbMsg.Type,
@@ -403,7 +409,8 @@ func (d *DeliveryService) processDelivery(ctx context.Context, cbMsg *kafka.Call
 		return nil
 	}
 
-	d.Logger.Warn("callback delivery failed",
+	d.Logger.Warn(
+		"callback delivery failed",
 		"callbackUrl", cbMsg.CallbackURL,
 		"txid", cbMsg.TxID,
 		"type", cbMsg.Type,
@@ -422,7 +429,8 @@ func (d *DeliveryService) scheduleRetryOrDLQ(cbMsg *kafka.CallbackTopicMessage, 
 	// Permanent failures (e.g. STUMP blob expired) skip the retry budget and
 	// go straight to the DLQ — retrying cannot recover them.
 	if isPermanentDeliveryError(cause) {
-		d.Logger.Error("callback permanently failed, publishing to DLQ",
+		d.Logger.Error(
+			"callback permanently failed, publishing to DLQ",
 			"callbackUrl", cbMsg.CallbackURL,
 			"txid", cbMsg.TxID,
 			"type", cbMsg.Type,
@@ -436,7 +444,8 @@ func (d *DeliveryService) scheduleRetryOrDLQ(cbMsg *kafka.CallbackTopicMessage, 
 
 	// Retry budget exhausted: route to DLQ.
 	if cbMsg.RetryCount >= d.cfg.Callback.MaxRetries {
-		d.Logger.Error("callback retries exhausted, publishing to DLQ",
+		d.Logger.Error(
+			"callback retries exhausted, publishing to DLQ",
 			"callbackUrl", cbMsg.CallbackURL,
 			"txid", cbMsg.TxID,
 			"type", cbMsg.Type,
@@ -454,7 +463,8 @@ func (d *DeliveryService) scheduleRetryOrDLQ(cbMsg *kafka.CallbackTopicMessage, 
 	backoffSec := d.cfg.Callback.BackoffBaseSec * cbMsg.RetryCount
 	cbMsg.NextRetryAt = time.Now().Add(time.Duration(backoffSec) * time.Second)
 
-	d.Logger.Info("scheduling callback retry via Kafka republish",
+	d.Logger.Info(
+		"scheduling callback retry via Kafka republish",
 		"callbackUrl", cbMsg.CallbackURL,
 		"txid", cbMsg.TxID,
 		"retryCount", cbMsg.RetryCount,
@@ -483,7 +493,8 @@ func (d *DeliveryService) republishForRetry(cbMsg *kafka.CallbackTopicMessage, r
 		return fmt.Errorf("encode callback message for retry republish (%s): %w", reason, err)
 	}
 	if err := d.retryProducer.PublishWithHashKey(cbMsg.PartitionKey(), data); err != nil {
-		d.Logger.Error("retry republish failed, leaving Kafka offset uncommitted",
+		d.Logger.Error(
+			"retry republish failed, leaving Kafka offset uncommitted",
 			"callbackUrl", cbMsg.CallbackURL,
 			"txid", cbMsg.TxID,
 			"retryCount", cbMsg.RetryCount,
@@ -510,7 +521,8 @@ func (d *DeliveryService) publishToDLQDurably(cbMsg *kafka.CallbackTopicMessage)
 		}
 		if err := d.publishToDLQ(cbMsg); err != nil {
 			lastErr = err
-			d.Logger.Warn("DLQ publish attempt failed",
+			d.Logger.Warn(
+				"DLQ publish attempt failed",
 				"attempt", i+1,
 				"callbackUrl", cbMsg.CallbackURL,
 				"txid", cbMsg.TxID,
@@ -521,7 +533,8 @@ func (d *DeliveryService) publishToDLQDurably(cbMsg *kafka.CallbackTopicMessage)
 		metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeDLQ).Inc()
 		return nil
 	}
-	d.Logger.Error("DLQ publish exhausted all retries, leaving Kafka offset uncommitted",
+	d.Logger.Error(
+		"DLQ publish exhausted all retries, leaving Kafka offset uncommitted",
 		"callbackUrl", cbMsg.CallbackURL,
 		"txid", cbMsg.TxID,
 		"type", cbMsg.Type,
@@ -542,7 +555,8 @@ func (d *DeliveryService) heartbeat(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			d.Logger.Info("callback delivery heartbeat",
+			d.Logger.Info(
+				"callback delivery heartbeat",
 				"messagesProcessed", int64(testutil.ToFloat64(metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeDelivered))),
 				"messagesRetried", int64(testutil.ToFloat64(metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeRetryScheduled))),
 				"messagesFailed", int64(testutil.ToFloat64(metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeDLQ))),
@@ -623,7 +637,8 @@ func (d *DeliveryService) deliverCallback(ctx context.Context, msg *kafka.Callba
 	start := time.Now()
 	resp, err := d.httpClient.Do(req)
 	if err != nil {
-		d.Logger.Debug("callback http transport error",
+		d.Logger.Debug(
+			"callback http transport error",
 			"callbackUrl", msg.CallbackURL,
 			"durationMs", time.Since(start).Milliseconds(),
 			"idempotencyKey", idempotencyKey,
@@ -643,7 +658,8 @@ func (d *DeliveryService) deliverCallback(ctx context.Context, msg *kafka.Callba
 	}
 
 	bodyBytes, truncated := readBodyCapped(resp.Body, 4*1024)
-	d.Logger.Debug("callback http error response",
+	d.Logger.Debug(
+		"callback http error response",
 		"callbackUrl", msg.CallbackURL,
 		"status", resp.StatusCode,
 		"statusText", resp.Status,

--- a/internal/callback/delivery.go
+++ b/internal/callback/delivery.go
@@ -14,14 +14,15 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"syscall"
 	"time"
 
 	"github.com/IBM/sarama"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 
 	"github.com/bsv-blockchain/merkle-service/internal/config"
 	"github.com/bsv-blockchain/merkle-service/internal/kafka"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
 	"github.com/bsv-blockchain/merkle-service/internal/ssrfguard"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
@@ -106,11 +107,6 @@ type DeliveryService struct {
 	httpClient    *http.Client
 	dedupStore    CallbackDeduper
 	stumpStore    store.StumpStore
-
-	messagesProcessed atomic.Int64
-	messagesRetried   atomic.Int64
-	messagesFailed    atomic.Int64
-	messagesDedupe    atomic.Int64
 }
 
 // NewDeliveryService creates a new callback DeliveryService. stumpStore is
@@ -239,9 +235,9 @@ func (d *DeliveryService) Stop() error {
 	d.SetStarted(false)
 	d.Cancel()
 	d.Logger.Info("callback delivery service stopped",
-		"messagesProcessed", d.messagesProcessed.Load(),
-		"messagesRetried", d.messagesRetried.Load(),
-		"messagesFailed", d.messagesFailed.Load(),
+		"messagesProcessed", int64(testutil.ToFloat64(metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeDelivered))),
+		"messagesRetried", int64(testutil.ToFloat64(metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeRetryScheduled))),
+		"messagesFailed", int64(testutil.ToFloat64(metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeDLQ))),
 	)
 	return firstErr
 }
@@ -257,9 +253,9 @@ func (d *DeliveryService) Health() service.HealthStatus {
 		Name:   d.Name,
 		Status: status,
 		Details: map[string]string{
-			"messagesProcessed": fmt.Sprintf("%d", d.messagesProcessed.Load()),
-			"messagesRetried":   fmt.Sprintf("%d", d.messagesRetried.Load()),
-			"messagesFailed":    fmt.Sprintf("%d", d.messagesFailed.Load()),
+			"messagesProcessed": fmt.Sprintf("%d", int64(testutil.ToFloat64(metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeDelivered)))),
+			"messagesRetried":   fmt.Sprintf("%d", int64(testutil.ToFloat64(metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeRetryScheduled)))),
+			"messagesFailed":    fmt.Sprintf("%d", int64(testutil.ToFloat64(metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeDLQ)))),
 		},
 	}
 }
@@ -285,6 +281,8 @@ func (d *DeliveryService) handleMessage(ctx context.Context, msg *sarama.Consume
 			"partition", msg.Partition,
 			"error", err,
 		)
+		metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeDecodeError).Inc()
+		metrics.IncKafkaConsumerError(msg.Topic, metrics.KafkaErrorDecode)
 		return nil
 	}
 
@@ -335,7 +333,15 @@ func (d *DeliveryService) processDelivery(ctx context.Context, cbMsg *kafka.Call
 	if d.dedupStore != nil {
 		dedupKey := dedupKeyForMessage(cbMsg)
 		if dedupKey != "" {
+			checkStart := time.Now()
 			exists, err := d.dedupStore.Exists(dedupKey, cbMsg.CallbackURL, string(cbMsg.Type))
+			checkOutcome := metrics.OutcomeMiss
+			if err != nil {
+				checkOutcome = metrics.OutcomeError
+			} else if exists {
+				checkOutcome = metrics.OutcomeHit
+			}
+			metrics.ObserveCallbackDedupCheck(checkOutcome, time.Since(checkStart))
 			if err != nil {
 				// Previous behavior was "proceed with delivery" — but if a
 				// prior attempt had succeeded and Aerospike is briefly
@@ -360,7 +366,7 @@ func (d *DeliveryService) processDelivery(ctx context.Context, cbMsg *kafka.Call
 					"blockHash", cbMsg.BlockHash,
 					"subtreeIndex", cbMsg.SubtreeIndex,
 				)
-				d.messagesDedupe.Add(1)
+				metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeDedupHit).Inc()
 				return nil
 			}
 		}
@@ -375,13 +381,19 @@ func (d *DeliveryService) processDelivery(ctx context.Context, cbMsg *kafka.Call
 		if d.dedupStore != nil {
 			dedupKey := dedupKeyForMessage(cbMsg)
 			if dedupKey != "" {
+				recordStart := time.Now()
 				ttl := time.Duration(d.cfg.Callback.DedupTTLSec) * time.Second
-				if recErr := d.dedupStore.Record(dedupKey, cbMsg.CallbackURL, string(cbMsg.Type), ttl); recErr != nil {
+				recErr := d.dedupStore.Record(dedupKey, cbMsg.CallbackURL, string(cbMsg.Type), ttl)
+				recordOutcome := metrics.OutcomeSuccess
+				if recErr != nil {
+					recordOutcome = metrics.OutcomeError
 					d.Logger.Error("failed to record callback dedup", "error", recErr, "dedupKey", dedupKey, "callbackUrl", cbMsg.CallbackURL)
 				}
+				metrics.ObserveCallbackDedupRecord(recordOutcome, time.Since(recordStart))
 			}
 		}
-		d.messagesProcessed.Add(1)
+		metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeDelivered).Inc()
+		metrics.ObserveCallbackRetryAttempt(cbMsg.RetryCount)
 		d.Logger.Debug("callback delivered successfully",
 			"callbackUrl", cbMsg.CallbackURL,
 			"txid", cbMsg.TxID,
@@ -480,7 +492,7 @@ func (d *DeliveryService) republishForRetry(cbMsg *kafka.CallbackTopicMessage, r
 		)
 		return fmt.Errorf("retry republish (%s): %w", reason, err)
 	}
-	d.messagesRetried.Add(1)
+	metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeRetryScheduled).Inc()
 	return nil
 }
 
@@ -506,7 +518,7 @@ func (d *DeliveryService) publishToDLQDurably(cbMsg *kafka.CallbackTopicMessage)
 			)
 			continue
 		}
-		d.messagesFailed.Add(1)
+		metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeDLQ).Inc()
 		return nil
 	}
 	d.Logger.Error("DLQ publish exhausted all retries, leaving Kafka offset uncommitted",
@@ -531,10 +543,10 @@ func (d *DeliveryService) heartbeat(ctx context.Context) {
 			return
 		case <-ticker.C:
 			d.Logger.Info("callback delivery heartbeat",
-				"messagesProcessed", d.messagesProcessed.Load(),
-				"messagesRetried", d.messagesRetried.Load(),
-				"messagesFailed", d.messagesFailed.Load(),
-				"messagesDedupe", d.messagesDedupe.Load(),
+				"messagesProcessed", int64(testutil.ToFloat64(metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeDelivered))),
+				"messagesRetried", int64(testutil.ToFloat64(metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeRetryScheduled))),
+				"messagesFailed", int64(testutil.ToFloat64(metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeDLQ))),
+				"messagesDedupe", int64(testutil.ToFloat64(metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeDedupHit))),
 			)
 		}
 	}
@@ -561,11 +573,22 @@ func (d *DeliveryService) deliverCallback(ctx context.Context, msg *kafka.Callba
 		if d.stumpStore == nil {
 			return errPermanentDelivery(fmt.Errorf("stump store not configured for STUMP delivery"))
 		}
+		stumpStart := time.Now()
 		stumpBytes, err := d.stumpStore.Get(msg.StumpRef)
+		stumpOutcome := metrics.OutcomeSuccess
+		if err != nil {
+			if errors.Is(err, store.ErrStumpNotFound) {
+				stumpOutcome = metrics.OutcomeNotFound
+			} else {
+				stumpOutcome = metrics.OutcomeError
+			}
+		}
+		metrics.ObserveCallbackStumpFetch(stumpOutcome, time.Since(stumpStart))
 		if err != nil {
 			if errors.Is(err, store.ErrStumpNotFound) {
 				// Blob expired (DAH) or never written — no amount of retry will
 				// produce it. Fail permanently so processDelivery routes to DLQ.
+				metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeStumpNotFound).Inc()
 				return errPermanentDelivery(fmt.Errorf("stump blob missing for ref %s: %w", msg.StumpRef, err))
 			}
 			return fmt.Errorf("fetching stump ref %s: %w", msg.StumpRef, err)
@@ -609,9 +632,11 @@ func (d *DeliveryService) deliverCallback(ctx context.Context, msg *kafka.Callba
 			"subtreeIndex", msg.SubtreeIndex,
 			"error", err,
 		)
+		metrics.ObserveCallbackDelivery(msg.CallbackURL, 0, len(body), time.Since(start), err)
 		return fmt.Errorf("HTTP request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
+	metrics.ObserveCallbackDelivery(msg.CallbackURL, resp.StatusCode, len(body), time.Since(start), nil)
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return nil
@@ -652,6 +677,7 @@ func (d *DeliveryService) deliverCallback(ctx context.Context, msg *kafka.Callba
 	// every block for the full retry budget. 408/429 stay retryable because
 	// they are explicit "try again later" signals.
 	if isNonRetryable4xx(resp.StatusCode) {
+		metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomePermanent4xx).Inc()
 		return errPermanentDelivery(statusErr)
 	}
 	return statusErr

--- a/internal/callback/delivery_handle_message_test.go
+++ b/internal/callback/delivery_handle_message_test.go
@@ -12,9 +12,18 @@ import (
 	"time"
 
 	"github.com/IBM/sarama"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 
 	"github.com/bsv-blockchain/merkle-service/internal/kafka"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 )
+
+// callbackCount returns the current value of the named outcome counter.
+// Tests assert on the delta against a pre-call snapshot so cross-test
+// pollution from the shared metrics registry doesn't break expectations.
+func callbackCount(outcome string) int64 {
+	return int64(testutil.ToFloat64(metrics.CallbackMessagesTotal.WithLabelValues(outcome)))
+}
 
 // These tests cover the durability contract that handleMessage must obey
 // after F-021: returning nil ONLY when the message has reached a durable
@@ -55,6 +64,7 @@ func TestHandleMessage_HappyPathReturnsNilAfterDelivery(t *testing.T) {
 		TxID:        "tx-happy",
 	}
 
+	before := callbackCount(metrics.OutcomeDelivered)
 	if err := ds.handleMessage(context.Background(), encodeConsumerMessage(t, msg)); err != nil {
 		t.Fatalf("expected nil, got error: %v", err)
 	}
@@ -67,8 +77,8 @@ func TestHandleMessage_HappyPathReturnsNilAfterDelivery(t *testing.T) {
 	if got := len(dlqMock.getMessages()); got != 0 {
 		t.Errorf("expected 0 DLQ publishes for happy path, got %d", got)
 	}
-	if ds.messagesProcessed.Load() != 1 {
-		t.Errorf("expected messagesProcessed=1, got %d", ds.messagesProcessed.Load())
+	if delta := callbackCount(metrics.OutcomeDelivered) - before; delta != 1 {
+		t.Errorf("expected delivered counter delta=1, got %d", delta)
 	}
 }
 
@@ -133,6 +143,7 @@ func TestHandleMessage_HTTPFailureRetriesExhausted_RoutesToDLQBeforeAck(t *testi
 		RetryCount:  3,
 	}
 
+	before := callbackCount(metrics.OutcomeDLQ)
 	if err := ds.handleMessage(context.Background(), encodeConsumerMessage(t, msg)); err != nil {
 		t.Fatalf("expected nil after successful DLQ publish, got error: %v", err)
 	}
@@ -144,8 +155,8 @@ func TestHandleMessage_HTTPFailureRetriesExhausted_RoutesToDLQBeforeAck(t *testi
 	if len(dlqMsgs) != 1 {
 		t.Fatalf("expected 1 DLQ publish, got %d", len(dlqMsgs))
 	}
-	if ds.messagesFailed.Load() != 1 {
-		t.Errorf("expected messagesFailed=1, got %d", ds.messagesFailed.Load())
+	if delta := callbackCount(metrics.OutcomeDLQ) - before; delta != 1 {
+		t.Errorf("expected DLQ counter delta=1, got %d", delta)
 	}
 }
 
@@ -172,12 +183,13 @@ func TestHandleMessage_DLQPublishFailureReturnsError(t *testing.T) {
 		RetryCount:  3,
 	}
 
+	before := callbackCount(metrics.OutcomeDLQ)
 	err := ds.handleMessage(context.Background(), encodeConsumerMessage(t, msg))
 	if err == nil {
 		t.Fatal("expected handleMessage to return non-nil error when DLQ publish fails")
 	}
-	if ds.messagesFailed.Load() != 0 {
-		t.Errorf("expected messagesFailed=0 (DLQ never durably accepted), got %d", ds.messagesFailed.Load())
+	if delta := callbackCount(metrics.OutcomeDLQ) - before; delta != 0 {
+		t.Errorf("expected DLQ counter delta=0 (DLQ never durably accepted), got %d", delta)
 	}
 }
 

--- a/internal/callback/delivery_test.go
+++ b/internal/callback/delivery_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/bsv-blockchain/merkle-service/internal/config"
 	"github.com/bsv-blockchain/merkle-service/internal/kafka"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
 )
 
@@ -465,6 +466,7 @@ func TestProcessDelivery_RetriesViaKafkaRepublish(t *testing.T) {
 		RetryCount:   0,
 	}
 
+	retriedBefore := callbackCount(metrics.OutcomeRetryScheduled)
 	if err := ds.processDelivery(context.Background(), msg); err != nil {
 		t.Fatalf("processDelivery returned error: %v", err)
 	}
@@ -480,8 +482,8 @@ func TestProcessDelivery_RetriesViaKafkaRepublish(t *testing.T) {
 	if republished.NextRetryAt.IsZero() {
 		t.Error("expected republished NextRetryAt to be set")
 	}
-	if ds.messagesRetried.Load() != 1 {
-		t.Errorf("expected messagesRetried=1, got %d", ds.messagesRetried.Load())
+	if delta := callbackCount(metrics.OutcomeRetryScheduled) - retriedBefore; delta != 1 {
+		t.Errorf("expected retry counter delta=1, got %d", delta)
 	}
 }
 
@@ -506,6 +508,7 @@ func TestProcessDelivery_RetryRepublishFailureSurfacesError(t *testing.T) {
 		SubtreeIndex: 1,
 	}
 
+	before := callbackCount(metrics.OutcomeRetryScheduled)
 	err := ds.processDelivery(context.Background(), msg)
 	if err == nil {
 		t.Fatal("expected error from processDelivery when retry republish fails")
@@ -513,8 +516,8 @@ func TestProcessDelivery_RetryRepublishFailureSurfacesError(t *testing.T) {
 	if got := len(retryMock.getMessages()); got != 0 {
 		t.Errorf("expected 0 retry messages captured (mock failed), got %d", got)
 	}
-	if ds.messagesRetried.Load() != 0 {
-		t.Errorf("expected messagesRetried=0 when republish fails, got %d", ds.messagesRetried.Load())
+	if delta := callbackCount(metrics.OutcomeRetryScheduled) - before; delta != 0 {
+		t.Errorf("expected retry counter delta=0 when republish fails, got %d", delta)
 	}
 }
 
@@ -536,6 +539,7 @@ func TestProcessDelivery_PublishesToDLQAfterMaxRetries(t *testing.T) {
 		RetryCount:   3, // Already at max retries.
 	}
 
+	before := callbackCount(metrics.OutcomeDLQ)
 	if err := ds.processDelivery(context.Background(), msg); err != nil {
 		t.Fatalf("processDelivery returned error: %v", err)
 	}
@@ -549,8 +553,8 @@ func TestProcessDelivery_PublishesToDLQAfterMaxRetries(t *testing.T) {
 	if len(dlqMsgs) != 1 {
 		t.Fatalf("expected 1 DLQ message, got %d", len(dlqMsgs))
 	}
-	if ds.messagesFailed.Load() != 1 {
-		t.Errorf("expected messagesFailed=1, got %d", ds.messagesFailed.Load())
+	if delta := callbackCount(metrics.OutcomeDLQ) - before; delta != 1 {
+		t.Errorf("expected DLQ counter delta=1, got %d", delta)
 	}
 }
 
@@ -576,6 +580,7 @@ func TestProcessDelivery_DLQPublishFailureSurfacesError(t *testing.T) {
 		SubtreeIndex: 1,
 	}
 
+	before := callbackCount(metrics.OutcomeDLQ)
 	start := time.Now()
 	err := ds.processDelivery(context.Background(), msg)
 	if err == nil {
@@ -584,8 +589,8 @@ func TestProcessDelivery_DLQPublishFailureSurfacesError(t *testing.T) {
 	if elapsed := time.Since(start); elapsed > 5*time.Second {
 		t.Errorf("DLQ retries took too long: %v", elapsed)
 	}
-	if ds.messagesFailed.Load() != 0 {
-		t.Errorf("expected messagesFailed=0 when DLQ publish never succeeded, got %d", ds.messagesFailed.Load())
+	if delta := callbackCount(metrics.OutcomeDLQ) - before; delta != 0 {
+		t.Errorf("expected DLQ counter delta=0 when DLQ publish never succeeded, got %d", delta)
 	}
 }
 
@@ -612,6 +617,7 @@ func TestProcessDelivery_MissingStumpBlobGoesStraightToDLQ(t *testing.T) {
 		RetryCount:   0,
 	}
 
+	before := callbackCount(metrics.OutcomeDLQ)
 	if err := ds.processDelivery(context.Background(), msg); err != nil {
 		t.Fatalf("processDelivery returned error: %v", err)
 	}
@@ -623,8 +629,8 @@ func TestProcessDelivery_MissingStumpBlobGoesStraightToDLQ(t *testing.T) {
 	if len(dlqMsgs) != 1 {
 		t.Fatalf("expected 1 DLQ message, got %d", len(dlqMsgs))
 	}
-	if ds.messagesFailed.Load() != 1 {
-		t.Errorf("expected messagesFailed=1, got %d", ds.messagesFailed.Load())
+	if delta := callbackCount(metrics.OutcomeDLQ) - before; delta != 1 {
+		t.Errorf("expected DLQ counter delta=1, got %d", delta)
 	}
 }
 
@@ -643,12 +649,13 @@ func TestProcessDelivery_SuccessIncrementsCounter(t *testing.T) {
 		TxID:        "tx-counter",
 	}
 
+	before := callbackCount(metrics.OutcomeDelivered)
 	if err := ds.processDelivery(context.Background(), msg); err != nil {
 		t.Fatalf("processDelivery returned error: %v", err)
 	}
 
-	if ds.messagesProcessed.Load() != 1 {
-		t.Errorf("expected messagesProcessed=1, got %d", ds.messagesProcessed.Load())
+	if delta := callbackCount(metrics.OutcomeDelivered) - before; delta != 1 {
+		t.Errorf("expected delivered counter delta=1, got %d", delta)
 	}
 }
 
@@ -671,6 +678,7 @@ func TestProcessDelivery_DedupSkipsDuplicate(t *testing.T) {
 		SubtreeIndex: 3,
 	}
 
+	before := callbackCount(metrics.OutcomeDedupHit)
 	if err := ds.processDelivery(context.Background(), msg); err != nil {
 		t.Fatalf("processDelivery returned error: %v", err)
 	}
@@ -678,8 +686,8 @@ func TestProcessDelivery_DedupSkipsDuplicate(t *testing.T) {
 	if requestCount.Load() != 0 {
 		t.Errorf("expected no HTTP requests for dedup hit, got %d", requestCount.Load())
 	}
-	if ds.messagesDedupe.Load() != 1 {
-		t.Errorf("expected messagesDedupe=1, got %d", ds.messagesDedupe.Load())
+	if delta := callbackCount(metrics.OutcomeDedupHit) - before; delta != 1 {
+		t.Errorf("expected dedup_hit counter delta=1, got %d", delta)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,21 @@ type Config struct {
 	BlobStore BlobStoreConfig `yaml:"blobStore" mapstructure:"blobstore"`
 	DataHub   DataHubConfig   `yaml:"datahub"   mapstructure:"datahub"`
 	Registry  RegistryConfig  `yaml:"registry"  mapstructure:"registry"`
+	Metrics   MetricsConfig   `yaml:"metrics"   mapstructure:"metrics"`
+}
+
+// MetricsConfig controls the Prometheus /metrics exporter. Each binary that
+// runs services (api-server, block-processor, callback-delivery,
+// subtree-fetcher, subtree-worker, p2p-client, all-in-one) starts a dedicated
+// metrics HTTP server on Port. In all-in-one mode a single server is shared
+// across the in-process services via the package-level metrics.Registry.
+//
+// Operators running multiple sub-binaries on the same host MUST override Port
+// per-binary to avoid bind conflicts.
+type MetricsConfig struct {
+	Enabled bool   `yaml:"enabled" mapstructure:"enabled"`
+	Port    int    `yaml:"port"    mapstructure:"port"`
+	Path    string `yaml:"path"    mapstructure:"path"`
 }
 
 // RegistryConfig holds policy for the txid -> callback URL registration store.
@@ -452,6 +467,11 @@ func registerDefaults(v *viper.Viper) {
 
 	// Registry
 	v.SetDefault("registry.maxcallbackspertxid", 10)
+
+	// Metrics
+	v.SetDefault("metrics.enabled", true)
+	v.SetDefault("metrics.port", 9090)
+	v.SetDefault("metrics.path", "/metrics")
 }
 
 // bindEnvVars explicitly binds environment variable names to Viper keys.
@@ -575,6 +595,11 @@ func bindEnvVars(v *viper.Viper) {
 
 		// Registry
 		"registry.maxcallbackspertxid": "REGISTRY_MAX_CALLBACKS_PER_TXID",
+
+		// Metrics
+		"metrics.enabled": "METRICS_ENABLED",
+		"metrics.port":    "METRICS_PORT",
+		"metrics.path":    "METRICS_PATH",
 	}
 
 	for key, env := range bindings {

--- a/internal/datahub/client.go
+++ b/internal/datahub/client.go
@@ -331,7 +331,8 @@ func (c *Client) recordPeerOutcome(dataHubURL string, err error) {
 // distinguish SSRF rejection from transport failures.
 func (c *Client) validateDataHubURL(rawURL string) error {
 	if err := ssrfguard.ValidateURL(rawURL, c.allowPrivateIPs, nil); err != nil {
-		c.logger.Warn("rejecting DataHub URL by SSRF policy",
+		c.logger.Warn(
+			"rejecting DataHub URL by SSRF policy",
 			"url", rawURL,
 			"allowPrivateIPs", c.allowPrivateIPs,
 			"error", err,
@@ -402,7 +403,8 @@ func (c *Client) doGetWithRetry(ctx context.Context, url string, maxBytes int64)
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
 			lastErr = err
-			c.logger.Warn("DataHub request failed, retrying",
+			c.logger.Warn(
+				"DataHub request failed, retrying",
 				"url", url,
 				"attempt", attempt+1,
 				"error", err,
@@ -418,7 +420,8 @@ func (c *Client) doGetWithRetry(ctx context.Context, url string, maxBytes int64)
 			_, _ = io.CopyN(io.Discard, resp.Body, 1024)
 			_ = resp.Body.Close()
 			lastErr = fmt.Errorf("response Content-Length %d exceeds cap of %d bytes", resp.ContentLength, maxBytes)
-			c.logger.Warn("DataHub returned oversize Content-Length, retrying",
+			c.logger.Warn(
+				"DataHub returned oversize Content-Length, retrying",
 				"url", url,
 				"contentLength", resp.ContentLength,
 				"cap", maxBytes,
@@ -449,7 +452,8 @@ func (c *Client) doGetWithRetry(ctx context.Context, url string, maxBytes int64)
 			// Truncate the error body so a hostile server can't bloat our log
 			// lines either; readCapped already bounded it to maxBytes.
 			lastErr = fmt.Errorf("HTTP %d from %s: %s", resp.StatusCode, url, string(body))
-			c.logger.Warn("DataHub returned error, retrying",
+			c.logger.Warn(
+				"DataHub returned error, retrying",
 				"url", url,
 				"status", resp.StatusCode,
 				"attempt", attempt+1,
@@ -459,7 +463,8 @@ func (c *Client) doGetWithRetry(ctx context.Context, url string, maxBytes int64)
 
 		if readErr != nil {
 			lastErr = readErr
-			c.logger.Warn("DataHub response body read failed, retrying",
+			c.logger.Warn(
+				"DataHub response body read failed, retrying",
 				"url", url,
 				"attempt", attempt+1,
 				"error", readErr,

--- a/internal/kafka/consumer.go
+++ b/internal/kafka/consumer.go
@@ -213,7 +213,8 @@ func (h *consumerGroupHandler) ConsumeClaim(session sarama.ConsumerGroupSession,
 			metrics.ObserveKafkaHandle(msg.Topic, outcome, time.Since(start))
 			if err != nil {
 				metrics.IncKafkaConsumerError(msg.Topic, metrics.KafkaErrorHandler)
-				h.logger.Error("failed to handle message, stopping claim to preserve offset",
+				h.logger.Error(
+					"failed to handle message, stopping claim to preserve offset",
 					"topic", msg.Topic,
 					"partition", msg.Partition,
 					"offset", msg.Offset,

--- a/internal/kafka/consumer.go
+++ b/internal/kafka/consumer.go
@@ -2,12 +2,16 @@ package kafka
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/IBM/sarama"
+
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 )
 
 // exitFunc is the process-termination hook used when the consumer goroutine
@@ -42,6 +46,7 @@ func newConsumerConfig() *sarama.Config {
 // Consumer wraps a Sarama consumer group.
 type Consumer struct {
 	group   sarama.ConsumerGroup
+	groupID string
 	topics  []string
 	handler MessageHandler
 	logger  *slog.Logger
@@ -71,6 +76,7 @@ func NewConsumer(brokers []string, groupID string, topics []string, handler Mess
 
 	return &Consumer{
 		group:   group,
+		groupID: groupID,
 		topics:  topics,
 		handler: handler,
 		logger:  logger,
@@ -97,6 +103,12 @@ func (c *Consumer) Start(ctx context.Context) error {
 				if !ok {
 					return
 				}
+				var consumerErr *sarama.ConsumerError
+				topic := ""
+				if errors.As(err, &consumerErr) {
+					topic = consumerErr.Topic
+				}
+				metrics.IncKafkaConsumerError(topic, metrics.KafkaErrorBroker)
 				c.logger.Error("sarama consumer group error", "error", err)
 			}
 		}
@@ -119,6 +131,7 @@ func (c *Consumer) Start(ctx context.Context) error {
 		for {
 			handler := &consumerGroupHandler{
 				handler: c.handler,
+				groupID: c.groupID,
 				logger:  c.logger,
 				ready:   c.ready,
 			}
@@ -149,6 +162,7 @@ func (c *Consumer) Stop() error {
 // consumerGroupHandler implements sarama.ConsumerGroupHandler.
 type consumerGroupHandler struct {
 	handler MessageHandler
+	groupID string
 	logger  *slog.Logger
 	ready   chan struct{}
 }
@@ -186,7 +200,19 @@ func (h *consumerGroupHandler) ConsumeClaim(session sarama.ConsumerGroupSession,
 			if !ok {
 				return nil
 			}
-			if err := h.handler(session.Context(), msg); err != nil {
+			metrics.ObserveKafkaConsumed(msg.Topic, h.groupID, len(msg.Value))
+			gauge := metrics.KafkaInFlight(msg.Topic, h.groupID)
+			gauge.Inc()
+			start := time.Now()
+			err := h.handler(session.Context(), msg)
+			gauge.Dec()
+			outcome := metrics.OutcomeSuccess
+			if err != nil {
+				outcome = metrics.OutcomeHandlerError
+			}
+			metrics.ObserveKafkaHandle(msg.Topic, outcome, time.Since(start))
+			if err != nil {
+				metrics.IncKafkaConsumerError(msg.Topic, metrics.KafkaErrorHandler)
 				h.logger.Error("failed to handle message, stopping claim to preserve offset",
 					"topic", msg.Topic,
 					"partition", msg.Partition,

--- a/internal/kafka/producer.go
+++ b/internal/kafka/producer.go
@@ -5,8 +5,11 @@ import (
 	"encoding/binary"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/IBM/sarama"
+
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 )
 
 // Producer wraps a Sarama sync producer with topic and partition configuration.
@@ -50,7 +53,9 @@ func (p *Producer) Publish(key string, value []byte) error {
 		Value: sarama.ByteEncoder(value),
 	}
 
+	start := time.Now()
 	partition, offset, err := p.producer.SendMessage(msg)
+	metrics.ObserveKafkaProduce(p.topic, len(value), time.Since(start), err)
 	if err != nil {
 		return fmt.Errorf("failed to publish to %s: %w", p.topic, err)
 	}

--- a/internal/metrics/api.go
+++ b/internal/metrics/api.go
@@ -19,7 +19,7 @@ var (
 			Name: "merkle_http_requests_total",
 			Help: "Total HTTP requests served by the API server.",
 		},
-		[]string{"route", "method", "status"},
+		[]string{labelRoute, labelMethod, labelStatus},
 	)
 
 	httpRequestDuration = prometheus.NewHistogramVec(
@@ -28,7 +28,7 @@ var (
 			Help:    "HTTP request duration in seconds.",
 			Buckets: HTTPBuckets,
 		},
-		[]string{"route", "method", "status"},
+		[]string{labelRoute, labelMethod, labelStatus},
 	)
 
 	httpRequestsInFlight = prometheus.NewGaugeVec(
@@ -36,7 +36,7 @@ var (
 			Name: "merkle_http_requests_in_flight",
 			Help: "HTTP requests currently being served.",
 		},
-		[]string{"route", "method"},
+		[]string{labelRoute, labelMethod},
 	)
 
 	httpRequestSize = prometheus.NewHistogramVec(
@@ -45,7 +45,7 @@ var (
 			Help:    "HTTP request body size in bytes.",
 			Buckets: MsgSizeBuckets,
 		},
-		[]string{"route", "method"},
+		[]string{labelRoute, labelMethod},
 	)
 
 	httpResponseSize = prometheus.NewHistogramVec(
@@ -54,7 +54,7 @@ var (
 			Help:    "HTTP response body size in bytes.",
 			Buckets: MsgSizeBuckets,
 		},
-		[]string{"route", "method"},
+		[]string{labelRoute, labelMethod},
 	)
 )
 

--- a/internal/metrics/api.go
+++ b/internal/metrics/api.go
@@ -1,0 +1,120 @@
+package metrics
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// HTTP RED metrics for the API server. Route labels are sourced from
+// chi.RouteContext(...).RoutePattern(), never r.URL.Path, so /api/lookup/{txid}
+// stays as one series instead of one per txid.
+
+var (
+	httpRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "merkle_http_requests_total",
+			Help: "Total HTTP requests served by the API server.",
+		},
+		[]string{"route", "method", "status"},
+	)
+
+	httpRequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "merkle_http_request_duration_seconds",
+			Help:    "HTTP request duration in seconds.",
+			Buckets: HTTPBuckets,
+		},
+		[]string{"route", "method", "status"},
+	)
+
+	httpRequestsInFlight = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "merkle_http_requests_in_flight",
+			Help: "HTTP requests currently being served.",
+		},
+		[]string{"route", "method"},
+	)
+
+	httpRequestSize = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "merkle_http_request_size_bytes",
+			Help:    "HTTP request body size in bytes.",
+			Buckets: MsgSizeBuckets,
+		},
+		[]string{"route", "method"},
+	)
+
+	httpResponseSize = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "merkle_http_response_size_bytes",
+			Help:    "HTTP response body size in bytes.",
+			Buckets: MsgSizeBuckets,
+		},
+		[]string{"route", "method"},
+	)
+)
+
+func init() {
+	Registry.MustRegister(
+		httpRequestsTotal,
+		httpRequestDuration,
+		httpRequestsInFlight,
+		httpRequestSize,
+		httpResponseSize,
+	)
+}
+
+// ChiMiddleware records RED metrics for every HTTP request. Insert it
+// after middleware.RealIP and before middleware.Recoverer in the chain so
+// it sees the final response status (Recoverer turns panics into 500s).
+//
+// The route label uses chi.RouteContext(ctx).RoutePattern() captured AFTER
+// the inner handler runs — chi sets the matched pattern during routing.
+// When the request doesn't match any registered route (404 from chi), we
+// label it "unmatched" to keep cardinality bounded.
+func ChiMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// In-flight gauge uses the pre-routing label "in_progress" because
+		// the route pattern isn't known yet — we count by method only.
+		// Increment with route="" and resolve after; cardinality of the
+		// transient state is bounded by the worker pool.
+		inflightLabel := "in_progress"
+		method := r.Method
+		httpRequestsInFlight.WithLabelValues(inflightLabel, method).Inc()
+		defer httpRequestsInFlight.WithLabelValues(inflightLabel, method).Dec()
+
+		start := time.Now()
+		ww := chimiddleware.NewWrapResponseWriter(w, r.ProtoMajor)
+		next.ServeHTTP(ww, r)
+
+		route := routePattern(r)
+		status := StatusClass(ww.Status(), nil)
+		duration := time.Since(start).Seconds()
+
+		httpRequestsTotal.WithLabelValues(route, method, status).Inc()
+		httpRequestDuration.WithLabelValues(route, method, status).Observe(duration)
+		if r.ContentLength > 0 {
+			httpRequestSize.WithLabelValues(route, method).Observe(float64(r.ContentLength))
+		}
+		if n := ww.BytesWritten(); n > 0 {
+			httpResponseSize.WithLabelValues(route, method).Observe(float64(n))
+		}
+	})
+}
+
+// routePattern extracts the chi route template (e.g. "/api/lookup/{txid}")
+// for use as a bounded route label. Falls back to "unmatched" when chi
+// couldn't resolve the path so a flood of 404 probes doesn't explode
+// cardinality.
+func routePattern(r *http.Request) string {
+	if ctx := chi.RouteContext(r.Context()); ctx != nil {
+		if p := ctx.RoutePattern(); p != "" {
+			return p
+		}
+	}
+	return "unmatched"
+}

--- a/internal/metrics/api_test.go
+++ b/internal/metrics/api_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -8,6 +9,19 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
+
+func mustGet(t *testing.T, url string) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	_ = resp.Body.Close()
+}
 
 // TestChiMiddleware_RoutePatternLabel asserts the chi route-pattern path is
 // used for the route label, NOT the raw request URL. This is the load-bearing
@@ -31,17 +45,9 @@ func TestChiMiddleware_RoutePatternLabel(t *testing.T) {
 		"/api/lookup/aaaa000000000000000000000000000000000000000000000000000000000002",
 		"/api/lookup/aaaa000000000000000000000000000000000000000000000000000000000003",
 	} {
-		resp, err := http.Get(srv.URL + p) //nolint:gosec,noctx
-		if err != nil {
-			t.Fatalf("GET %s: %v", p, err)
-		}
-		_ = resp.Body.Close()
+		mustGet(t, srv.URL+p)
 	}
-	resp, err := http.Get(srv.URL + "/health") //nolint:gosec,noctx
-	if err != nil {
-		t.Fatalf("GET /health: %v", err)
-	}
-	_ = resp.Body.Close()
+	mustGet(t, srv.URL+"/health")
 
 	if got := testutil.ToFloat64(httpRequestsTotal.WithLabelValues("/api/lookup/{txid}", "GET", "2xx")); got != 3 {
 		t.Errorf("expected 3 hits on /api/lookup/{txid}, got %v", got)
@@ -51,11 +57,7 @@ func TestChiMiddleware_RoutePatternLabel(t *testing.T) {
 	}
 
 	// 404 path → "unmatched" route label so probes can't blow up cardinality.
-	resp, err = http.Get(srv.URL + "/does-not-exist") //nolint:gosec,noctx
-	if err != nil {
-		t.Fatalf("GET 404: %v", err)
-	}
-	_ = resp.Body.Close()
+	mustGet(t, srv.URL+"/does-not-exist")
 	if got := testutil.ToFloat64(httpRequestsTotal.WithLabelValues("unmatched", "GET", "4xx")); got != 1 {
 		t.Errorf("expected 1 hit on unmatched route, got %v", got)
 	}

--- a/internal/metrics/api_test.go
+++ b/internal/metrics/api_test.go
@@ -1,0 +1,62 @@
+package metrics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// TestChiMiddleware_RoutePatternLabel asserts the chi route-pattern path is
+// used for the route label, NOT the raw request URL. This is the load-bearing
+// guarantee that lookups by txid don't explode cardinality.
+func TestChiMiddleware_RoutePatternLabel(t *testing.T) {
+	r := chi.NewRouter()
+	r.Use(ChiMiddleware)
+	r.Get("/api/lookup/{txid}", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	r.Get("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	// Same route template, three distinct txids — must collapse to one series.
+	for _, p := range []string{
+		"/api/lookup/aaaa000000000000000000000000000000000000000000000000000000000001",
+		"/api/lookup/aaaa000000000000000000000000000000000000000000000000000000000002",
+		"/api/lookup/aaaa000000000000000000000000000000000000000000000000000000000003",
+	} {
+		resp, err := http.Get(srv.URL + p) //nolint:gosec,noctx
+		if err != nil {
+			t.Fatalf("GET %s: %v", p, err)
+		}
+		_ = resp.Body.Close()
+	}
+	resp, err := http.Get(srv.URL + "/health") //nolint:gosec,noctx
+	if err != nil {
+		t.Fatalf("GET /health: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if got := testutil.ToFloat64(httpRequestsTotal.WithLabelValues("/api/lookup/{txid}", "GET", "2xx")); got != 3 {
+		t.Errorf("expected 3 hits on /api/lookup/{txid}, got %v", got)
+	}
+	if got := testutil.ToFloat64(httpRequestsTotal.WithLabelValues("/health", "GET", "2xx")); got != 1 {
+		t.Errorf("expected 1 hit on /health, got %v", got)
+	}
+
+	// 404 path → "unmatched" route label so probes can't blow up cardinality.
+	resp, err = http.Get(srv.URL + "/does-not-exist") //nolint:gosec,noctx
+	if err != nil {
+		t.Fatalf("GET 404: %v", err)
+	}
+	_ = resp.Body.Close()
+	if got := testutil.ToFloat64(httpRequestsTotal.WithLabelValues("unmatched", "GET", "4xx")); got != 1 {
+		t.Errorf("expected 1 hit on unmatched route, got %v", got)
+	}
+}

--- a/internal/metrics/buckets.go
+++ b/internal/metrics/buckets.go
@@ -1,0 +1,33 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Histogram buckets tuned to the workloads they observe. ExponentialBucketsRange
+// panics if its arguments are malformed — that's a programming error, surfaced
+// at startup, not a runtime concern.
+var (
+	// DBBuckets covers 100µs..30s. Aerospike fast-path hits land in the low
+	// buckets; the upper end captures pathological backpressure.
+	DBBuckets = prometheus.ExponentialBucketsRange(0.0001, 30, 12)
+
+	// BumpBuckets mirrors DBBuckets. STUMP builds are CPU-bound; tiny
+	// blocks finish in sub-ms, while a 33M-txid subtree can take seconds.
+	BumpBuckets = prometheus.ExponentialBucketsRange(0.0001, 30, 12)
+
+	// HTTPBuckets is the Prometheus default (caps at 10s) extended to 30s
+	// to catch slow callback receivers and /reprocess probe chains. The
+	// 30s upper bound is strictly greater than DefBuckets' top so the
+	// histogram bucket list stays sorted.
+	HTTPBuckets = append(append([]float64{}, prometheus.DefBuckets...), 30)
+
+	// MsgSizeBuckets covers 64B..16MB — small callback envelopes through
+	// the 10MB Sarama producer cap.
+	MsgSizeBuckets = prometheus.ExponentialBucketsRange(64, 16*1024*1024, 12)
+
+	// DataHubBuckets covers 1ms..60s. Large subtree fetches with retry
+	// overhead can occupy the upper end.
+	DataHubBuckets = prometheus.ExponentialBucketsRange(0.001, 60, 14)
+
+	// CountBuckets covers 1..1M — txid counts, leaf counts, batch sizes.
+	CountBuckets = prometheus.ExponentialBucketsRange(1, 1_000_000, 12)
+)

--- a/internal/metrics/bump.go
+++ b/internal/metrics/bump.go
@@ -13,7 +13,7 @@ var (
 			Help:    "Duration of STUMP build operations.",
 			Buckets: BumpBuckets,
 		},
-		[]string{"outcome"},
+		[]string{labelOutcome},
 	)
 
 	bumpEncodeDuration = prometheus.NewHistogram(

--- a/internal/metrics/bump.go
+++ b/internal/metrics/bump.go
@@ -1,0 +1,99 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	bumpBuildDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "merkle_bump_build_duration_seconds",
+			Help:    "Duration of STUMP build operations.",
+			Buckets: BumpBuckets,
+		},
+		[]string{"outcome"},
+	)
+
+	bumpEncodeDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "merkle_bump_encode_duration_seconds",
+			Help:    "Duration of STUMP encode operations.",
+			Buckets: BumpBuckets,
+		},
+	)
+
+	bumpEncodedSize = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "merkle_bump_encoded_size_bytes",
+			Help:    "Size of encoded STUMP payloads.",
+			Buckets: MsgSizeBuckets,
+		},
+	)
+
+	bumpTreeHeight = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "merkle_bump_tree_height",
+			Help:    "STUMP merkle tree height.",
+			Buckets: prometheus.LinearBuckets(0, 1, 33),
+		},
+	)
+
+	bumpRegisteredIndices = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "merkle_bump_registered_indices_count",
+			Help:    "Number of registered leaf indices included in each STUMP.",
+			Buckets: CountBuckets,
+		},
+	)
+
+	bumpLeavesCount = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "merkle_bump_leaves_count",
+			Help:    "Number of leaves in the merkle tree per STUMP build.",
+			Buckets: CountBuckets,
+		},
+	)
+)
+
+func init() {
+	Registry.MustRegister(
+		bumpBuildDuration,
+		bumpEncodeDuration,
+		bumpEncodedSize,
+		bumpTreeHeight,
+		bumpRegisteredIndices,
+		bumpLeavesCount,
+	)
+}
+
+// ObserveBumpBuild records a STUMP build's duration plus the input/output
+// shape. Pass empty=true when Build returned nil (no registered indices)
+// so the outcome label reflects the no-op fast path separately from a
+// real build.
+func ObserveBumpBuild(d time.Duration, leaves, registered, treeHeight int, empty bool) {
+	outcome := OutcomeSuccess
+	if empty {
+		outcome = OutcomeEmpty
+	}
+	bumpBuildDuration.WithLabelValues(outcome).Observe(d.Seconds())
+	if leaves > 0 {
+		bumpLeavesCount.Observe(float64(leaves))
+	}
+	if registered > 0 {
+		bumpRegisteredIndices.Observe(float64(registered))
+	}
+	if treeHeight >= 0 {
+		bumpTreeHeight.Observe(float64(treeHeight))
+	}
+}
+
+// ObserveBumpEncode records a STUMP encode operation's duration and the
+// size of the resulting payload.
+func ObserveBumpEncode(d time.Duration, size int) {
+	bumpEncodeDuration.Observe(d.Seconds())
+	if size > 0 {
+		bumpEncodedSize.Observe(float64(size))
+	}
+}

--- a/internal/metrics/callback.go
+++ b/internal/metrics/callback.go
@@ -1,0 +1,122 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	CallbackMessagesTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "merkle_callback_messages_total",
+			Help: "Callback delivery messages classified by outcome.",
+		},
+		[]string{"outcome"},
+	)
+
+	callbackDeliveryDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "merkle_callback_delivery_duration_seconds",
+			Help:    "HTTP POST duration for callback deliveries, by callback host and status class.",
+			Buckets: HTTPBuckets,
+		},
+		[]string{"callback_host", "status_class"},
+	)
+
+	callbackPayloadSize = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "merkle_callback_payload_size_bytes",
+			Help:    "Size of the JSON body POSTed to a callback URL.",
+			Buckets: MsgSizeBuckets,
+		},
+		[]string{"callback_host"},
+	)
+
+	callbackRetryAttempt = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "merkle_callback_retry_attempt",
+			Help:    "RetryCount observed at the moment a callback delivery succeeded.",
+			Buckets: prometheus.LinearBuckets(0, 1, 11),
+		},
+	)
+
+	callbackDedupCheckDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "merkle_callback_dedup_check_duration_seconds",
+			Help:    "Duration of the dedup Exists check.",
+			Buckets: DBBuckets,
+		},
+		[]string{"outcome"},
+	)
+
+	callbackDedupRecordDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "merkle_callback_dedup_record_duration_seconds",
+			Help:    "Duration of the dedup Record write after a successful delivery.",
+			Buckets: DBBuckets,
+		},
+		[]string{"outcome"},
+	)
+
+	callbackStumpFetchDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "merkle_callback_stump_fetch_duration_seconds",
+			Help:    "Duration of STUMP blob fetches from the claim-check store.",
+			Buckets: DBBuckets,
+		},
+		[]string{"outcome"},
+	)
+)
+
+func init() {
+	Registry.MustRegister(
+		CallbackMessagesTotal,
+		callbackDeliveryDuration,
+		callbackPayloadSize,
+		callbackRetryAttempt,
+		callbackDedupCheckDuration,
+		callbackDedupRecordDuration,
+		callbackStumpFetchDuration,
+	)
+}
+
+// ObserveCallbackDelivery records the HTTP POST duration + status class for
+// a callback delivery, plus the request payload size. Pass the raw status
+// code from the HTTP response (or 0 with err non-nil for transport
+// failures).
+func ObserveCallbackDelivery(callbackURL string, statusCode int, payloadSize int, d time.Duration, err error) {
+	host := HostLabel(callbackURL)
+	statusClass := StatusClass(statusCode, err)
+	callbackDeliveryDuration.WithLabelValues(host, statusClass).Observe(d.Seconds())
+	if payloadSize > 0 {
+		callbackPayloadSize.WithLabelValues(host).Observe(float64(payloadSize))
+	}
+}
+
+// ObserveCallbackRetryAttempt records the RetryCount distribution at the
+// moment a delivery succeeded.
+func ObserveCallbackRetryAttempt(retryCount int) {
+	if retryCount < 0 {
+		retryCount = 0
+	}
+	callbackRetryAttempt.Observe(float64(retryCount))
+}
+
+// ObserveCallbackDedupCheck records the duration + outcome of a dedup
+// Exists check. outcome ∈ {hit, miss, error}.
+func ObserveCallbackDedupCheck(outcome string, d time.Duration) {
+	callbackDedupCheckDuration.WithLabelValues(outcome).Observe(d.Seconds())
+}
+
+// ObserveCallbackDedupRecord records the duration + outcome of a dedup
+// Record write. outcome ∈ {success, error}.
+func ObserveCallbackDedupRecord(outcome string, d time.Duration) {
+	callbackDedupRecordDuration.WithLabelValues(outcome).Observe(d.Seconds())
+}
+
+// ObserveCallbackStumpFetch records the duration + outcome of a STUMP blob
+// fetch. outcome ∈ {success, not_found, error}.
+func ObserveCallbackStumpFetch(outcome string, d time.Duration) {
+	callbackStumpFetchDuration.WithLabelValues(outcome).Observe(d.Seconds())
+}

--- a/internal/metrics/callback.go
+++ b/internal/metrics/callback.go
@@ -12,7 +12,7 @@ var (
 			Name: "merkle_callback_messages_total",
 			Help: "Callback delivery messages classified by outcome.",
 		},
-		[]string{"outcome"},
+		[]string{labelOutcome},
 	)
 
 	callbackDeliveryDuration = prometheus.NewHistogramVec(
@@ -21,7 +21,7 @@ var (
 			Help:    "HTTP POST duration for callback deliveries, by callback host and status class.",
 			Buckets: HTTPBuckets,
 		},
-		[]string{"callback_host", "status_class"},
+		[]string{labelCallbackHost, labelStatusClass},
 	)
 
 	callbackPayloadSize = prometheus.NewHistogramVec(
@@ -30,7 +30,7 @@ var (
 			Help:    "Size of the JSON body POSTed to a callback URL.",
 			Buckets: MsgSizeBuckets,
 		},
-		[]string{"callback_host"},
+		[]string{labelCallbackHost},
 	)
 
 	callbackRetryAttempt = prometheus.NewHistogram(
@@ -47,7 +47,7 @@ var (
 			Help:    "Duration of the dedup Exists check.",
 			Buckets: DBBuckets,
 		},
-		[]string{"outcome"},
+		[]string{labelOutcome},
 	)
 
 	callbackDedupRecordDuration = prometheus.NewHistogramVec(
@@ -56,7 +56,7 @@ var (
 			Help:    "Duration of the dedup Record write after a successful delivery.",
 			Buckets: DBBuckets,
 		},
-		[]string{"outcome"},
+		[]string{labelOutcome},
 	)
 
 	callbackStumpFetchDuration = prometheus.NewHistogramVec(
@@ -65,7 +65,7 @@ var (
 			Help:    "Duration of STUMP blob fetches from the claim-check store.",
 			Buckets: DBBuckets,
 		},
-		[]string{"outcome"},
+		[]string{labelOutcome},
 	)
 )
 
@@ -85,7 +85,7 @@ func init() {
 // a callback delivery, plus the request payload size. Pass the raw status
 // code from the HTTP response (or 0 with err non-nil for transport
 // failures).
-func ObserveCallbackDelivery(callbackURL string, statusCode int, payloadSize int, d time.Duration, err error) {
+func ObserveCallbackDelivery(callbackURL string, statusCode, payloadSize int, d time.Duration, err error) {
 	host := HostLabel(callbackURL)
 	statusClass := StatusClass(statusCode, err)
 	callbackDeliveryDuration.WithLabelValues(host, statusClass).Observe(d.Seconds())

--- a/internal/metrics/database.go
+++ b/internal/metrics/database.go
@@ -1,0 +1,269 @@
+package metrics
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log/slog"
+	"time"
+
+	as "github.com/aerospike/aerospike-client-go/v7"
+	astypes "github.com/aerospike/aerospike-client-go/v7/types"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Backend label values.
+const (
+	BackendAerospike = "aerospike"
+	BackendSQL       = "sql"
+)
+
+// Store label values. Keep this list aligned with the store packages —
+// new stores should add a constant here so reviewers can audit the enum.
+const (
+	StoreRegistration        = "registration"
+	StoreCallbackDedup       = "callback_dedup"
+	StoreCallbackURLRegistry = "callback_url_registry"
+	StoreSeenCounter         = "seen_counter"
+	StoreSubtreeCounter      = "subtree_counter"
+	StoreCallbackAccumulator = "callback_accumulator"
+	StoreDataHubRegistry     = "datahub_registry"
+	StoreStump               = "stump"
+	StoreSubtreeBlob         = "subtree_blob"
+)
+
+// Operation label values.
+const (
+	OpGet            = "get"
+	OpBatchGet       = "batchget"
+	OpPut            = "put"
+	OpAdd            = "add"
+	OpIncrement      = "increment"
+	OpDecrement      = "decrement"
+	OpExists         = "exists"
+	OpRecord         = "record"
+	OpDelete         = "delete"
+	OpSweep          = "sweep"
+	OpGetAll         = "get_all"
+	OpUpdateTTL      = "update_ttl"
+	OpBatchUpdateTTL = "batch_update_ttl"
+)
+
+var (
+	dbOpDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "merkle_db_operation_duration_seconds",
+			Help:    "Database operation duration in seconds.",
+			Buckets: DBBuckets,
+		},
+		[]string{"backend", "store", "op", "outcome"},
+	)
+
+	dbOpTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "merkle_db_operations_total",
+			Help: "Total database operations.",
+		},
+		[]string{"backend", "store", "op", "outcome"},
+	)
+
+	dbBatchSize = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "merkle_db_batch_size",
+			Help:    "Number of keys per batch database operation.",
+			Buckets: CountBuckets,
+		},
+		[]string{"store", "op"},
+	)
+
+	dbSQLPoolOpen = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "merkle_db_sql_pool_open",
+		Help: "Open SQL connections (in use + idle).",
+	})
+
+	dbSQLPoolIdle = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "merkle_db_sql_pool_idle",
+		Help: "Idle SQL connections.",
+	})
+
+	dbSQLPoolInUse = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "merkle_db_sql_pool_in_use",
+		Help: "SQL connections currently checked out.",
+	})
+
+	dbSQLPoolWaitCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "merkle_db_sql_pool_wait_count_total",
+		Help: "Cumulative count of connection waits.",
+	})
+
+	dbSQLPoolWaitDuration = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "merkle_db_sql_pool_wait_duration_seconds_total",
+		Help: "Cumulative time spent waiting for a connection, in seconds.",
+	})
+
+	dbSweeperDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "merkle_db_sweeper_duration_seconds",
+			Help:    "TTL sweeper run duration in seconds.",
+			Buckets: DBBuckets,
+		},
+		[]string{"store"},
+	)
+
+	dbSweeperRowsDeleted = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "merkle_db_sweeper_rows_deleted_total",
+			Help: "Rows deleted by the TTL sweeper.",
+		},
+		[]string{"store"},
+	)
+)
+
+func init() {
+	Registry.MustRegister(
+		dbOpDuration,
+		dbOpTotal,
+		dbBatchSize,
+		dbSQLPoolOpen,
+		dbSQLPoolIdle,
+		dbSQLPoolInUse,
+		dbSQLPoolWaitCount,
+		dbSQLPoolWaitDuration,
+		dbSweeperDuration,
+		dbSweeperRowsDeleted,
+	)
+}
+
+// DBTimer captures the start of a DB operation. Use StartDB / End in the
+// store implementations:
+//
+//	t := metrics.StartDB(metrics.BackendAerospike, metrics.StoreRegistration, metrics.OpBatchGet)
+//	defer func() { t.End(retErr) }()
+//
+// The defer pattern keeps every code path covered (including panics, though
+// Recoverer in the API layer is the catcher of last resort).
+type DBTimer struct {
+	backend, store, op string
+	start              time.Time
+}
+
+// StartDB begins timing a DB op.
+func StartDB(backend, store, op string) DBTimer {
+	return DBTimer{backend: backend, store: store, op: op, start: time.Now()}
+}
+
+// End records the elapsed time + outcome for the DB op. Pass the named
+// return error from the caller — outcome is derived by ClassifyDBError.
+func (t DBTimer) End(err error) {
+	outcome := ClassifyDBError(t.backend, err)
+	d := time.Since(t.start).Seconds()
+	dbOpDuration.WithLabelValues(t.backend, t.store, t.op, outcome).Observe(d)
+	dbOpTotal.WithLabelValues(t.backend, t.store, t.op, outcome).Inc()
+}
+
+// ObserveDB records a DB operation's duration and outcome, derived from the
+// time elapsed since start and the returned error. Useful when StartDB+End
+// can't be wrapped around a single statement (e.g. multi-statement code
+// blocks) — pass `time.Now()` captured before the operation began.
+func ObserveDB(backend, store, op string, start time.Time, err error) {
+	outcome := ClassifyDBError(backend, err)
+	d := time.Since(start).Seconds()
+	dbOpDuration.WithLabelValues(backend, store, op, outcome).Observe(d)
+	dbOpTotal.WithLabelValues(backend, store, op, outcome).Inc()
+}
+
+// ObserveDBBatchSize records the number of keys in a batch operation.
+// Call at the entry of BatchGet / BatchUpdateTTL etc.
+func ObserveDBBatchSize(store, op string, n int) {
+	if n <= 0 {
+		return
+	}
+	dbBatchSize.WithLabelValues(store, op).Observe(float64(n))
+}
+
+// ObserveSweep records a TTL sweeper iteration's duration and the number
+// of rows it deleted.
+func ObserveSweep(store string, d time.Duration, rowsDeleted int) {
+	dbSweeperDuration.WithLabelValues(store).Observe(d.Seconds())
+	if rowsDeleted > 0 {
+		dbSweeperRowsDeleted.WithLabelValues(store).Add(float64(rowsDeleted))
+	}
+}
+
+// ClassifyDBError maps a backend-specific error into the bounded outcome
+// enum. Aerospike not-found errors and timeouts surface as their own
+// labels so they're alertable separately from generic errors.
+func ClassifyDBError(backend string, err error) string {
+	if err == nil {
+		return OutcomeSuccess
+	}
+	if backend == BackendAerospike {
+		var asErr *as.AerospikeError
+		if errors.As(err, &asErr) {
+			if asErr.Matches(astypes.KEY_NOT_FOUND_ERROR) {
+				return OutcomeNotFound
+			}
+			if asErr.Matches(astypes.TIMEOUT) {
+				return OutcomeTimeout
+			}
+		}
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return OutcomeNotFound
+	}
+	if isTimeoutErr(err) {
+		return OutcomeTimeout
+	}
+	return OutcomeError
+}
+
+// RunSQLPoolSampler periodically reads db.Stats() and updates the pool
+// gauges + wait counters. Run as a goroutine bound to a cancelable
+// context — when ctx is canceled the sampler exits.
+//
+// Wait counters use delta-add semantics: db.Stats() reports cumulative
+// values that can wrap or reset on driver replacement; the sampler only
+// adds positive deltas so the Prometheus counter remains monotonic.
+func RunSQLPoolSampler(ctx context.Context, db *sql.DB, interval time.Duration, logger *slog.Logger) {
+	if interval <= 0 {
+		interval = 15 * time.Second
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+
+	var lastWaitCount int64
+	var lastWaitDuration time.Duration
+
+	sample := func() {
+		stats := db.Stats()
+		dbSQLPoolOpen.Set(float64(stats.OpenConnections))
+		dbSQLPoolIdle.Set(float64(stats.Idle))
+		dbSQLPoolInUse.Set(float64(stats.InUse))
+
+		if stats.WaitCount > lastWaitCount {
+			dbSQLPoolWaitCount.Add(float64(stats.WaitCount - lastWaitCount))
+			lastWaitCount = stats.WaitCount
+		} else if stats.WaitCount < lastWaitCount {
+			lastWaitCount = stats.WaitCount
+		}
+		if stats.WaitDuration > lastWaitDuration {
+			dbSQLPoolWaitDuration.Add((stats.WaitDuration - lastWaitDuration).Seconds())
+			lastWaitDuration = stats.WaitDuration
+		} else if stats.WaitDuration < lastWaitDuration {
+			lastWaitDuration = stats.WaitDuration
+		}
+	}
+
+	sample()
+	for {
+		select {
+		case <-ctx.Done():
+			if logger != nil {
+				logger.Debug("SQL pool sampler stopped")
+			}
+			return
+		case <-t.C:
+			sample()
+		}
+	}
+}

--- a/internal/metrics/database.go
+++ b/internal/metrics/database.go
@@ -56,7 +56,7 @@ var (
 			Help:    "Database operation duration in seconds.",
 			Buckets: DBBuckets,
 		},
-		[]string{"backend", "store", "op", "outcome"},
+		[]string{labelBackend, labelStore, labelOp, labelOutcome},
 	)
 
 	dbOpTotal = prometheus.NewCounterVec(
@@ -64,7 +64,7 @@ var (
 			Name: "merkle_db_operations_total",
 			Help: "Total database operations.",
 		},
-		[]string{"backend", "store", "op", "outcome"},
+		[]string{labelBackend, labelStore, labelOp, labelOutcome},
 	)
 
 	dbBatchSize = prometheus.NewHistogramVec(
@@ -73,7 +73,7 @@ var (
 			Help:    "Number of keys per batch database operation.",
 			Buckets: CountBuckets,
 		},
-		[]string{"store", "op"},
+		[]string{labelStore, labelOp},
 	)
 
 	dbSQLPoolOpen = prometheus.NewGauge(prometheus.GaugeOpts{
@@ -107,7 +107,7 @@ var (
 			Help:    "TTL sweeper run duration in seconds.",
 			Buckets: DBBuckets,
 		},
-		[]string{"store"},
+		[]string{labelStore},
 	)
 
 	dbSweeperRowsDeleted = prometheus.NewCounterVec(
@@ -115,7 +115,7 @@ var (
 			Name: "merkle_db_sweeper_rows_deleted_total",
 			Help: "Rows deleted by the TTL sweeper.",
 		},
-		[]string{"store"},
+		[]string{labelStore},
 	)
 )
 

--- a/internal/metrics/kafka.go
+++ b/internal/metrics/kafka.go
@@ -14,10 +14,10 @@ const (
 
 // Kafka error kind labels.
 const (
-	KafkaErrorDecode       = "decode"
-	KafkaErrorHandler      = "handler_error"
-	KafkaErrorRebalance    = "rebalance"
-	KafkaErrorBroker       = "broker"
+	KafkaErrorDecode    = "decode"
+	KafkaErrorHandler   = "handler_error"
+	KafkaErrorRebalance = "rebalance"
+	KafkaErrorBroker    = "broker"
 )
 
 var (
@@ -26,7 +26,7 @@ var (
 			Name: "merkle_kafka_messages_produced_total",
 			Help: "Messages produced to Kafka, by topic and outcome.",
 		},
-		[]string{"topic", "outcome"},
+		[]string{labelTopic, labelOutcome},
 	)
 
 	kafkaProduceDuration = prometheus.NewHistogramVec(
@@ -35,7 +35,7 @@ var (
 			Help:    "Producer SendMessage duration by topic and outcome.",
 			Buckets: DBBuckets,
 		},
-		[]string{"topic", "outcome"},
+		[]string{labelTopic, labelOutcome},
 	)
 
 	kafkaProducedMessageSize = prometheus.NewHistogramVec(
@@ -44,7 +44,7 @@ var (
 			Help:    "Size of produced Kafka messages by topic.",
 			Buckets: MsgSizeBuckets,
 		},
-		[]string{"topic"},
+		[]string{labelTopic},
 	)
 
 	kafkaMessagesConsumed = prometheus.NewCounterVec(
@@ -52,7 +52,7 @@ var (
 			Name: "merkle_kafka_messages_consumed_total",
 			Help: "Messages consumed from Kafka, by topic and consumer group.",
 		},
-		[]string{"topic", "group"},
+		[]string{labelTopic, labelGroup},
 	)
 
 	kafkaConsumeHandleDuration = prometheus.NewHistogramVec(
@@ -61,7 +61,7 @@ var (
 			Help:    "Duration of consumer message handler by topic and outcome.",
 			Buckets: DataHubBuckets,
 		},
-		[]string{"topic", "outcome"},
+		[]string{labelTopic, labelOutcome},
 	)
 
 	kafkaConsumerErrors = prometheus.NewCounterVec(
@@ -69,7 +69,7 @@ var (
 			Name: "merkle_kafka_consumer_errors_total",
 			Help: "Consumer-side error events by topic and error kind.",
 		},
-		[]string{"topic", "kind"},
+		[]string{labelTopic, labelKind},
 	)
 
 	kafkaMessageSize = prometheus.NewHistogramVec(
@@ -78,7 +78,7 @@ var (
 			Help:    "Kafka message payload size by topic and direction.",
 			Buckets: MsgSizeBuckets,
 		},
-		[]string{"topic", "direction"},
+		[]string{labelTopic, labelDirection},
 	)
 
 	kafkaInFlightMessages = prometheus.NewGaugeVec(
@@ -86,7 +86,7 @@ var (
 			Name: "merkle_kafka_in_flight_messages",
 			Help: "Messages currently being handled per topic + group.",
 		},
-		[]string{"topic", "group"},
+		[]string{labelTopic, labelGroup},
 	)
 )
 

--- a/internal/metrics/kafka.go
+++ b/internal/metrics/kafka.go
@@ -1,0 +1,149 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Kafka direction labels for the shared message-size histogram.
+const (
+	KafkaDirectionIn  = "in"
+	KafkaDirectionOut = "out"
+)
+
+// Kafka error kind labels.
+const (
+	KafkaErrorDecode       = "decode"
+	KafkaErrorHandler      = "handler_error"
+	KafkaErrorRebalance    = "rebalance"
+	KafkaErrorBroker       = "broker"
+)
+
+var (
+	kafkaMessagesProduced = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "merkle_kafka_messages_produced_total",
+			Help: "Messages produced to Kafka, by topic and outcome.",
+		},
+		[]string{"topic", "outcome"},
+	)
+
+	kafkaProduceDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "merkle_kafka_produce_duration_seconds",
+			Help:    "Producer SendMessage duration by topic and outcome.",
+			Buckets: DBBuckets,
+		},
+		[]string{"topic", "outcome"},
+	)
+
+	kafkaProducedMessageSize = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "merkle_kafka_produced_message_size_bytes",
+			Help:    "Size of produced Kafka messages by topic.",
+			Buckets: MsgSizeBuckets,
+		},
+		[]string{"topic"},
+	)
+
+	kafkaMessagesConsumed = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "merkle_kafka_messages_consumed_total",
+			Help: "Messages consumed from Kafka, by topic and consumer group.",
+		},
+		[]string{"topic", "group"},
+	)
+
+	kafkaConsumeHandleDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "merkle_kafka_consume_handle_duration_seconds",
+			Help:    "Duration of consumer message handler by topic and outcome.",
+			Buckets: DataHubBuckets,
+		},
+		[]string{"topic", "outcome"},
+	)
+
+	kafkaConsumerErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "merkle_kafka_consumer_errors_total",
+			Help: "Consumer-side error events by topic and error kind.",
+		},
+		[]string{"topic", "kind"},
+	)
+
+	kafkaMessageSize = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "merkle_kafka_message_size_bytes",
+			Help:    "Kafka message payload size by topic and direction.",
+			Buckets: MsgSizeBuckets,
+		},
+		[]string{"topic", "direction"},
+	)
+
+	kafkaInFlightMessages = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "merkle_kafka_in_flight_messages",
+			Help: "Messages currently being handled per topic + group.",
+		},
+		[]string{"topic", "group"},
+	)
+)
+
+func init() {
+	Registry.MustRegister(
+		kafkaMessagesProduced,
+		kafkaProduceDuration,
+		kafkaProducedMessageSize,
+		kafkaMessagesConsumed,
+		kafkaConsumeHandleDuration,
+		kafkaConsumerErrors,
+		kafkaMessageSize,
+		kafkaInFlightMessages,
+	)
+}
+
+// ObserveKafkaProduce records the outcome, duration, and payload size of
+// a single Kafka publish.
+func ObserveKafkaProduce(topic string, size int, d time.Duration, err error) {
+	outcome := OutcomeSuccess
+	if err != nil {
+		outcome = OutcomeError
+	}
+	kafkaMessagesProduced.WithLabelValues(topic, outcome).Inc()
+	kafkaProduceDuration.WithLabelValues(topic, outcome).Observe(d.Seconds())
+	if err == nil && size > 0 {
+		kafkaProducedMessageSize.WithLabelValues(topic).Observe(float64(size))
+		kafkaMessageSize.WithLabelValues(topic, KafkaDirectionOut).Observe(float64(size))
+	}
+}
+
+// ObserveKafkaConsumed records a message consumed from a topic + group
+// and its payload size.
+func ObserveKafkaConsumed(topic, group string, size int) {
+	kafkaMessagesConsumed.WithLabelValues(topic, group).Inc()
+	if size > 0 {
+		kafkaMessageSize.WithLabelValues(topic, KafkaDirectionIn).Observe(float64(size))
+	}
+}
+
+// ObserveKafkaHandle records the duration + outcome of a consumer
+// message-handler invocation.
+func ObserveKafkaHandle(topic, outcome string, d time.Duration) {
+	kafkaConsumeHandleDuration.WithLabelValues(topic, outcome).Observe(d.Seconds())
+}
+
+// IncKafkaConsumerError increments the consumer-side error counter for the
+// given topic and error kind.
+func IncKafkaConsumerError(topic, kind string) {
+	if topic == "" {
+		topic = Unknown
+	}
+	kafkaConsumerErrors.WithLabelValues(topic, kind).Inc()
+}
+
+// KafkaInFlight returns the in-flight gauge for the given topic + group so
+// callers can Inc / Dec around handler execution.
+func KafkaInFlight(topic, group string) prometheus.Gauge {
+	return kafkaInFlightMessages.WithLabelValues(topic, group)
+}

--- a/internal/metrics/labels.go
+++ b/internal/metrics/labels.go
@@ -1,0 +1,116 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// Outcome label constants. Use these everywhere the `outcome` label is set
+// so the values stay a bounded enum and don't drift across packages.
+const (
+	OutcomeSuccess           = "success"
+	OutcomeError             = "error"
+	OutcomeTimeout           = "timeout"
+	OutcomeNotFound          = "not_found"
+	OutcomeDLQ               = "dlq"
+	OutcomeRetry             = "retry"
+	OutcomeRetried           = "retried"
+	OutcomeProcessed         = "processed"
+	OutcomeSkippedUnhealthy  = "skipped_unhealthy"
+	OutcomeDecodeError       = "decode_error"
+	OutcomePermanentFailure  = "permanent_failure"
+	OutcomeDelivered         = "delivered"
+	OutcomeDedupHit          = "dedup_hit"
+	OutcomeRetryScheduled    = "retry_scheduled"
+	OutcomeStumpNotFound     = "stump_not_found"
+	OutcomePermanent4xx      = "permanent_4xx"
+	OutcomeHit               = "hit"
+	OutcomeMiss              = "miss"
+	OutcomeEmpty             = "empty"
+	OutcomeHandlerError      = "handler_error"
+)
+
+// Unknown is the fallback label value when an input cannot be classified
+// without risking unbounded cardinality.
+const Unknown = "unknown"
+
+// maxHostLen caps the host label length defensively. A label value longer
+// than the DNS limit cannot be a real hostname; refusing it keeps a single
+// degenerate input from spawning its own metric series.
+const maxHostLen = 253
+
+// HostLabel returns a bounded hostname label for a URL. Lowercased,
+// port-stripped. Returns Unknown ("unknown") for empty input, parse
+// failures, missing host, or absurdly long values.
+//
+// This is the single sanctioned way to derive a label from a URL — never
+// use the full URL, the path, or query string as a label.
+func HostLabel(rawURL string) string {
+	s := strings.TrimSpace(rawURL)
+	if s == "" {
+		return Unknown
+	}
+	if len(s) > 4096 {
+		return Unknown
+	}
+
+	// If the input lacks a scheme, prepend one so url.Parse pulls out
+	// the host instead of treating the whole string as a path.
+	if !strings.Contains(s, "://") {
+		s = "http://" + s
+	}
+
+	u, err := url.Parse(s)
+	if err != nil {
+		return Unknown
+	}
+	host := u.Hostname()
+	if host == "" {
+		return Unknown
+	}
+	host = strings.ToLower(host)
+	if len(host) > maxHostLen {
+		return Unknown
+	}
+	return host
+}
+
+// StatusClass maps an HTTP status code (or an error) to a bounded class
+// label: "2xx", "3xx", "4xx", "5xx", "timeout", "error".
+//
+// When err is non-nil it takes precedence over the code so transport
+// failures don't masquerade as status 0.
+func StatusClass(code int, err error) string {
+	if err != nil {
+		if isTimeoutErr(err) {
+			return OutcomeTimeout
+		}
+		return OutcomeError
+	}
+	switch {
+	case code >= 200 && code < 300:
+		return "2xx"
+	case code >= 300 && code < 400:
+		return "3xx"
+	case code >= 400 && code < 500:
+		return "4xx"
+	case code >= 500 && code < 600:
+		return "5xx"
+	default:
+		return OutcomeError
+	}
+}
+
+func isTimeoutErr(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	return false
+}

--- a/internal/metrics/labels.go
+++ b/internal/metrics/labels.go
@@ -11,31 +11,51 @@ import (
 // Outcome label constants. Use these everywhere the `outcome` label is set
 // so the values stay a bounded enum and don't drift across packages.
 const (
-	OutcomeSuccess           = "success"
-	OutcomeError             = "error"
-	OutcomeTimeout           = "timeout"
-	OutcomeNotFound          = "not_found"
-	OutcomeDLQ               = "dlq"
-	OutcomeRetry             = "retry"
-	OutcomeRetried           = "retried"
-	OutcomeProcessed         = "processed"
-	OutcomeSkippedUnhealthy  = "skipped_unhealthy"
-	OutcomeDecodeError       = "decode_error"
-	OutcomePermanentFailure  = "permanent_failure"
-	OutcomeDelivered         = "delivered"
-	OutcomeDedupHit          = "dedup_hit"
-	OutcomeRetryScheduled    = "retry_scheduled"
-	OutcomeStumpNotFound     = "stump_not_found"
-	OutcomePermanent4xx      = "permanent_4xx"
-	OutcomeHit               = "hit"
-	OutcomeMiss              = "miss"
-	OutcomeEmpty             = "empty"
-	OutcomeHandlerError      = "handler_error"
+	OutcomeSuccess          = "success"
+	OutcomeError            = "error"
+	OutcomeTimeout          = "timeout"
+	OutcomeNotFound         = "not_found"
+	OutcomeDLQ              = "dlq"
+	OutcomeRetry            = "retry"
+	OutcomeRetried          = "retried"
+	OutcomeProcessed        = "processed"
+	OutcomeSkippedUnhealthy = "skipped_unhealthy"
+	OutcomeDecodeError      = "decode_error"
+	OutcomePermanentFailure = "permanent_failure"
+	OutcomeDelivered        = "delivered"
+	OutcomeDedupHit         = "dedup_hit"
+	OutcomeRetryScheduled   = "retry_scheduled"
+	OutcomeStumpNotFound    = "stump_not_found"
+	OutcomePermanent4xx     = "permanent_4xx"
+	OutcomeHit              = "hit"
+	OutcomeMiss             = "miss"
+	OutcomeEmpty            = "empty"
+	OutcomeHandlerError     = "handler_error"
 )
 
 // Unknown is the fallback label value when an input cannot be classified
 // without risking unbounded cardinality.
 const Unknown = "unknown"
+
+// Label name constants. Used as the second argument to NewCounterVec /
+// NewHistogramVec / NewGaugeVec so the spelling stays consistent and the
+// goconst linter doesn't flag repeated string literals.
+const (
+	labelOutcome      = "outcome"
+	labelBackend      = "backend"
+	labelStore        = "store"
+	labelOp           = "op"
+	labelTopic        = "topic"
+	labelGroup        = "group"
+	labelCallbackHost = "callback_host"
+	labelPeerHost     = "peer_host"
+	labelKind         = "kind"
+	labelDirection    = "direction"
+	labelStatusClass  = "status_class"
+	labelRoute        = "route"
+	labelMethod       = "method"
+	labelStatus       = "status"
+)
 
 // maxHostLen caps the host label length defensively. A label value longer
 // than the DNS limit cannot be a real hostname; refusing it keeps a single

--- a/internal/metrics/labels_test.go
+++ b/internal/metrics/labels_test.go
@@ -53,7 +53,7 @@ func TestStatusClass(t *testing.T) {
 		{"599", 599, nil, "5xx"},
 		{"deadline-exceeded", 0, context.DeadlineExceeded, "timeout"},
 		{"plain-error", 0, errors.New("boom"), "error"},
-		{"net-timeout", 0, &fakeTimeoutErr{}, "timeout"},
+		{"net-timeout", 0, &fakeTimeoutError{}, "timeout"},
 		{"unknown-code", 100, nil, "error"},
 	}
 	for _, tc := range cases {
@@ -66,17 +66,17 @@ func TestStatusClass(t *testing.T) {
 	}
 }
 
-type fakeTimeoutErr struct{}
+type fakeTimeoutError struct{}
 
-func (e *fakeTimeoutErr) Error() string { return "i/o timeout" }
-func (e *fakeTimeoutErr) Timeout() bool { return true }
-func (e *fakeTimeoutErr) Temporary() bool {
+func (e *fakeTimeoutError) Error() string { return "i/o timeout" }
+func (e *fakeTimeoutError) Timeout() bool { return true }
+func (e *fakeTimeoutError) Temporary() bool {
 	return false
 }
 
-// Compile-time check that fakeTimeoutErr satisfies net.Error so the
+// Compile-time check that fakeTimeoutError satisfies net.Error so the
 // errors.As branch in isTimeoutErr exercises it.
-var _ net.Error = (*fakeTimeoutErr)(nil)
+var _ net.Error = (*fakeTimeoutError)(nil)
 
 func TestClassifyDBError(t *testing.T) {
 	if got := ClassifyDBError(BackendSQL, nil); got != OutcomeSuccess {

--- a/internal/metrics/labels_test.go
+++ b/internal/metrics/labels_test.go
@@ -1,0 +1,103 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHostLabel(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", "unknown"},
+		{"   ", "unknown"},
+		{"localhost", "localhost"},
+		{"LOCALHOST", "localhost"},
+		{"http://example.com", "example.com"},
+		{"https://Example.COM:8080/path?a=b", "example.com"},
+		{"http://user:pw@host.example:443/p", "host.example"},
+		{"host:8080", "host"},
+		{"http://[::1]:9090/foo", "::1"},
+		{"http://[2001:db8::1]:80", "2001:db8::1"},
+		{"http:// bad host /x", "unknown"},
+		{strings.Repeat("a", 5000), "unknown"},
+		{"http://" + strings.Repeat("a", 300) + ".example.com", "unknown"},
+		{"unix:///run/foo.sock", "unknown"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got := HostLabel(tc.in)
+			if got != tc.want {
+				t.Errorf("HostLabel(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStatusClass(t *testing.T) {
+	cases := []struct {
+		name string
+		code int
+		err  error
+		want string
+	}{
+		{"200", 200, nil, "2xx"},
+		{"302", 302, nil, "3xx"},
+		{"404", 404, nil, "4xx"},
+		{"500", 500, nil, "5xx"},
+		{"599", 599, nil, "5xx"},
+		{"deadline-exceeded", 0, context.DeadlineExceeded, "timeout"},
+		{"plain-error", 0, errors.New("boom"), "error"},
+		{"net-timeout", 0, &fakeTimeoutErr{}, "timeout"},
+		{"unknown-code", 100, nil, "error"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := StatusClass(tc.code, tc.err)
+			if got != tc.want {
+				t.Errorf("StatusClass(%d, %v) = %q, want %q", tc.code, tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+type fakeTimeoutErr struct{}
+
+func (e *fakeTimeoutErr) Error() string { return "i/o timeout" }
+func (e *fakeTimeoutErr) Timeout() bool { return true }
+func (e *fakeTimeoutErr) Temporary() bool {
+	return false
+}
+
+// Compile-time check that fakeTimeoutErr satisfies net.Error so the
+// errors.As branch in isTimeoutErr exercises it.
+var _ net.Error = (*fakeTimeoutErr)(nil)
+
+func TestClassifyDBError(t *testing.T) {
+	if got := ClassifyDBError(BackendSQL, nil); got != OutcomeSuccess {
+		t.Errorf("nil err: got %q, want success", got)
+	}
+	if got := ClassifyDBError(BackendSQL, errors.New("x")); got != OutcomeError {
+		t.Errorf("plain err: got %q, want error", got)
+	}
+	if got := ClassifyDBError(BackendSQL, context.DeadlineExceeded); got != OutcomeTimeout {
+		t.Errorf("deadline: got %q, want timeout", got)
+	}
+}
+
+// TestStatusClass_NetTimeout asserts that a real net.Error timeout (wrapped
+// in the deadline-exceeded context error) classifies correctly. Acts as a
+// cheap smoke test against the real time-based path.
+func TestStatusClass_NetTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	<-ctx.Done()
+	if got := StatusClass(0, ctx.Err()); got != "timeout" {
+		t.Errorf("expected timeout, got %q", got)
+	}
+}

--- a/internal/metrics/registry.go
+++ b/internal/metrics/registry.go
@@ -1,0 +1,31 @@
+// Package metrics provides Prometheus instrumentation for merkle-service.
+//
+// Cardinality policy (load-bearing — reviewers must reject violations):
+//   - URL-derived labels MUST be hostname-only via HostLabel. Never full URL.
+//   - HTTP route labels MUST use chi RoutePattern, never the raw path.
+//   - txid, blockHash, peer ID, and other unbounded identifiers are NEVER labels.
+//   - outcome / op / store / topic labels MUST use the bounded enum constants
+//     declared in this package.
+//
+// All metrics are registered against the private Registry, not
+// prometheus.DefaultRegisterer, so transitively-registered metrics from other
+// packages do not collide with ours and our /metrics endpoint exposes only
+// merkle-service series plus the Go and process collectors.
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+)
+
+// Registry is the private Prometheus registry used by merkle-service. All
+// metric Vars in this package are registered here, and the metrics HTTP
+// handler serves only this registry.
+var Registry = prometheus.NewRegistry()
+
+func init() {
+	Registry.MustRegister(
+		collectors.NewGoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+	)
+}

--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -1,0 +1,102 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/bsv-blockchain/merkle-service/internal/config"
+	"github.com/bsv-blockchain/merkle-service/internal/service"
+)
+
+// Server exposes the Prometheus /metrics endpoint and a /health probe.
+// Implements service.Service so it slots into the existing lifecycle.
+type Server struct {
+	service.BaseService
+
+	cfg        config.MetricsConfig
+	httpServer *http.Server
+}
+
+// NewServer constructs a metrics Server. The server is a no-op when
+// cfg.Enabled is false so callers can wire it into the services slice
+// unconditionally.
+func NewServer(cfg config.MetricsConfig, logger *slog.Logger) *Server {
+	s := &Server{cfg: cfg}
+	s.InitBase("metrics")
+	if logger != nil {
+		s.Logger = logger
+	}
+	return s
+}
+
+// Init prepares the HTTP server. Safe to call when Enabled=false — it
+// simply returns nil without configuring anything; Start is a no-op too.
+func (s *Server) Init(_ interface{}) error {
+	if !s.cfg.Enabled {
+		return nil
+	}
+	path := s.cfg.Path
+	if path == "" {
+		path = "/metrics"
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle(path, promhttp.HandlerFor(Registry, promhttp.HandlerOpts{Registry: Registry}))
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	s.httpServer = &http.Server{
+		Addr:              fmt.Sprintf(":%d", s.cfg.Port),
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+	return nil
+}
+
+// Start runs the HTTP server in a background goroutine.
+func (s *Server) Start(_ context.Context) error {
+	if !s.cfg.Enabled {
+		return nil
+	}
+	s.SetStarted(true)
+	s.Logger.Info("starting metrics server", "port", s.cfg.Port, "path", s.cfg.Path)
+
+	go func() {
+		if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			s.Logger.Error("metrics server error", "error", err)
+		}
+	}()
+	return nil
+}
+
+// Stop shuts the metrics server down with a short grace window.
+func (s *Server) Stop() error {
+	if !s.cfg.Enabled || s.httpServer == nil {
+		return nil
+	}
+	s.Logger.Info("stopping metrics server")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	s.SetStarted(false)
+	return s.httpServer.Shutdown(ctx)
+}
+
+// Health returns the metrics server's health status.
+func (s *Server) Health() service.HealthStatus {
+	status := "healthy"
+	if s.cfg.Enabled && !s.IsStarted() {
+		status = "unhealthy"
+	}
+	return service.HealthStatus{
+		Name:   "metrics",
+		Status: status,
+	}
+}

--- a/internal/metrics/server_test.go
+++ b/internal/metrics/server_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"io"
 	"net"
 	"net/http"
@@ -25,7 +26,8 @@ func TestServer_ServesMetrics(t *testing.T) {
 	if err := srv.Init(nil); err != nil {
 		t.Fatalf("Init: %v", err)
 	}
-	if err := srv.Start(nil); err != nil { //nolint:staticcheck // Start ignores ctx
+	//nolint:staticcheck // Start ignores its ctx arg; test driver passes nil
+	if err := srv.Start(nil); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 	t.Cleanup(func() {
@@ -66,7 +68,8 @@ func TestServer_DisabledIsNoop(t *testing.T) {
 	if err := srv.Init(nil); err != nil {
 		t.Fatalf("Init: %v", err)
 	}
-	if err := srv.Start(nil); err != nil { //nolint:staticcheck
+	//nolint:staticcheck // Start ignores its ctx arg; test driver passes nil
+	if err := srv.Start(nil); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 	if err := srv.Stop(); err != nil {
@@ -79,7 +82,8 @@ func TestServer_DisabledIsNoop(t *testing.T) {
 
 func freePort(t *testing.T) int {
 	t.Helper()
-	l, err := net.Listen("tcp", "127.0.0.1:0")
+	var lc net.ListenConfig
+	l, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
@@ -95,7 +99,11 @@ func mustGetWithRetry(t *testing.T, url string, total time.Duration) string {
 	deadline := time.Now().Add(total)
 	var lastErr error
 	for time.Now().Before(deadline) {
-		resp, err := http.Get(url) //nolint:gosec,noctx // test client, hits localhost only
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+		if err != nil {
+			t.Fatalf("build request: %v", err)
+		}
+		resp, err := http.DefaultClient.Do(req)
 		if err == nil {
 			defer func() { _ = resp.Body.Close() }()
 			b, rerr := io.ReadAll(resp.Body)

--- a/internal/metrics/server_test.go
+++ b/internal/metrics/server_test.go
@@ -1,0 +1,112 @@
+package metrics
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/merkle-service/internal/config"
+)
+
+// TestServer_ServesMetrics spins up the metrics server on an ephemeral port
+// and asserts that /metrics returns text-format Prometheus output containing
+// the expected series names from each subsystem.
+func TestServer_ServesMetrics(t *testing.T) {
+	port := freePort(t)
+	srv := NewServer(config.MetricsConfig{
+		Enabled: true,
+		Port:    port,
+		Path:    "/metrics",
+	}, nil)
+	if err := srv.Init(nil); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if err := srv.Start(nil); err != nil { //nolint:staticcheck // Start ignores ctx
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := srv.Stop(); err != nil {
+			t.Errorf("Stop: %v", err)
+		}
+	})
+
+	// Drive one observation per subsystem so the metric is present in /metrics
+	// output even on a cold registry.
+	SubtreeMessagesTotal.WithLabelValues(OutcomeProcessed).Inc()
+	CallbackMessagesTotal.WithLabelValues(OutcomeDelivered).Inc()
+	ObserveKafkaProduce("test-topic", 100, 1*time.Millisecond, nil)
+	ObserveBumpBuild(1*time.Millisecond, 4, 1, 2, false)
+
+	url := "http://127.0.0.1:" + strconv.Itoa(port) + "/metrics"
+	body := mustGetWithRetry(t, url, 3*time.Second)
+
+	wanted := []string{
+		"merkle_subtree_messages_total",
+		"merkle_callback_messages_total",
+		"merkle_kafka_messages_produced_total",
+		"merkle_bump_build_duration_seconds",
+		"go_goroutines",
+		"process_resident_memory_bytes",
+	}
+	for _, name := range wanted {
+		if !strings.Contains(body, name) {
+			t.Errorf("/metrics output missing %q", name)
+		}
+	}
+}
+
+// TestServer_DisabledIsNoop verifies the Enabled=false branch doesn't bind
+// to a port and Init/Start/Stop succeed silently.
+func TestServer_DisabledIsNoop(t *testing.T) {
+	srv := NewServer(config.MetricsConfig{Enabled: false}, nil)
+	if err := srv.Init(nil); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if err := srv.Start(nil); err != nil { //nolint:staticcheck
+		t.Fatalf("Start: %v", err)
+	}
+	if err := srv.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if srv.IsStarted() {
+		t.Error("disabled server should not report started")
+	}
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = l.Close() }()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+// mustGetWithRetry GETs url, retrying briefly while the server is still
+// coming up in its goroutine. The metrics server starts via
+// http.ListenAndServe in a goroutine so the test can race the bind.
+func mustGetWithRetry(t *testing.T, url string, total time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(total)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url) //nolint:gosec,noctx // test client, hits localhost only
+		if err == nil {
+			defer func() { _ = resp.Body.Close() }()
+			b, rerr := io.ReadAll(resp.Body)
+			if rerr != nil {
+				t.Fatalf("read body: %v", rerr)
+			}
+			return string(b)
+		}
+		lastErr = err
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("GET %s never succeeded: %v", url, lastErr)
+	return ""
+}

--- a/internal/metrics/subtree.go
+++ b/internal/metrics/subtree.go
@@ -1,0 +1,145 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// SEEN callback kind label values.
+const (
+	SeenKindOnNetwork     = "seen_on_network"
+	SeenKindMultipleNodes = "seen_multiple_nodes"
+)
+
+var (
+	SubtreeMessagesTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "merkle_subtree_messages_total",
+			Help: "Subtree messages handled by the subtree-fetcher, classified by outcome.",
+		},
+		[]string{"outcome"},
+	)
+
+	subtreeProcessingDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "merkle_subtree_processing_duration_seconds",
+			Help:    "End-to-end handleMessage duration for the subtree-fetcher.",
+			Buckets: DataHubBuckets,
+		},
+		[]string{"outcome"},
+	)
+
+	subtreeDataHubFetchDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "merkle_subtree_datahub_fetch_duration_seconds",
+			Help:    "Duration of DataHub subtree fetch operations.",
+			Buckets: DataHubBuckets,
+		},
+		[]string{"peer_host", "outcome"},
+	)
+
+	subtreeDataHubFetchBytes = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "merkle_subtree_datahub_fetch_bytes",
+			Help:    "Size of subtree payload fetched from DataHub.",
+			Buckets: MsgSizeBuckets,
+		},
+		[]string{"peer_host"},
+	)
+
+	subtreeTxidCount = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "merkle_subtree_txid_count",
+			Help:    "Number of txids parsed per subtree.",
+			Buckets: CountBuckets,
+		},
+	)
+
+	subtreeRegisteredTxidCount = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "merkle_subtree_registered_txid_count",
+			Help:    "Number of registered txids matched per subtree.",
+			Buckets: CountBuckets,
+		},
+	)
+
+	subtreeEmitSeenDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "merkle_subtree_emit_seen_callbacks_duration_seconds",
+			Help:    "Duration of SEEN callback encode+publish per (callback_host, kind).",
+			Buckets: DBBuckets,
+		},
+		[]string{"callback_host", "kind"},
+	)
+
+	subtreeAttemptCount = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "merkle_subtree_attempt_count",
+			Help:    "Retry attempt count at the moment a subtree message was successfully processed.",
+			Buckets: prometheus.LinearBuckets(0, 1, 11),
+		},
+	)
+)
+
+func init() {
+	Registry.MustRegister(
+		SubtreeMessagesTotal,
+		subtreeProcessingDuration,
+		subtreeDataHubFetchDuration,
+		subtreeDataHubFetchBytes,
+		subtreeTxidCount,
+		subtreeRegisteredTxidCount,
+		subtreeEmitSeenDuration,
+		subtreeAttemptCount,
+	)
+}
+
+// ObserveSubtreeProcessing records the duration + outcome of handleMessage.
+func ObserveSubtreeProcessing(outcome string, d time.Duration) {
+	subtreeProcessingDuration.WithLabelValues(outcome).Observe(d.Seconds())
+	SubtreeMessagesTotal.WithLabelValues(outcome).Inc()
+}
+
+// ObserveSubtreeDataHubFetch records a DataHub fetch's duration + outcome,
+// and the payload size on success (size <= 0 on failure paths).
+func ObserveSubtreeDataHubFetch(peerURL string, d time.Duration, size int, err error) {
+	host := HostLabel(peerURL)
+	outcome := OutcomeSuccess
+	if err != nil {
+		if isTimeoutErr(err) {
+			outcome = OutcomeTimeout
+		} else {
+			outcome = OutcomeError
+		}
+	}
+	subtreeDataHubFetchDuration.WithLabelValues(host, outcome).Observe(d.Seconds())
+	if err == nil && size > 0 {
+		subtreeDataHubFetchBytes.WithLabelValues(host).Observe(float64(size))
+	}
+}
+
+// ObserveSubtreeCounts records txid and registered-txid counts per subtree.
+func ObserveSubtreeCounts(txids, registered int) {
+	if txids > 0 {
+		subtreeTxidCount.Observe(float64(txids))
+	}
+	if registered >= 0 {
+		subtreeRegisteredTxidCount.Observe(float64(registered))
+	}
+}
+
+// ObserveSubtreeEmitSeen records duration of a SEEN callback encode+publish
+// against a single callback host + kind.
+func ObserveSubtreeEmitSeen(callbackURL, kind string, d time.Duration) {
+	subtreeEmitSeenDuration.WithLabelValues(HostLabel(callbackURL), kind).Observe(d.Seconds())
+}
+
+// ObserveSubtreeAttemptCount records the AttemptCount of a subtree message
+// at the moment it successfully completed.
+func ObserveSubtreeAttemptCount(n int) {
+	if n < 0 {
+		n = 0
+	}
+	subtreeAttemptCount.Observe(float64(n))
+}

--- a/internal/metrics/subtree.go
+++ b/internal/metrics/subtree.go
@@ -18,7 +18,7 @@ var (
 			Name: "merkle_subtree_messages_total",
 			Help: "Subtree messages handled by the subtree-fetcher, classified by outcome.",
 		},
-		[]string{"outcome"},
+		[]string{labelOutcome},
 	)
 
 	subtreeProcessingDuration = prometheus.NewHistogramVec(
@@ -27,7 +27,7 @@ var (
 			Help:    "End-to-end handleMessage duration for the subtree-fetcher.",
 			Buckets: DataHubBuckets,
 		},
-		[]string{"outcome"},
+		[]string{labelOutcome},
 	)
 
 	subtreeDataHubFetchDuration = prometheus.NewHistogramVec(
@@ -36,7 +36,7 @@ var (
 			Help:    "Duration of DataHub subtree fetch operations.",
 			Buckets: DataHubBuckets,
 		},
-		[]string{"peer_host", "outcome"},
+		[]string{labelPeerHost, labelOutcome},
 	)
 
 	subtreeDataHubFetchBytes = prometheus.NewHistogramVec(
@@ -45,7 +45,7 @@ var (
 			Help:    "Size of subtree payload fetched from DataHub.",
 			Buckets: MsgSizeBuckets,
 		},
-		[]string{"peer_host"},
+		[]string{labelPeerHost},
 	)
 
 	subtreeTxidCount = prometheus.NewHistogram(
@@ -70,7 +70,7 @@ var (
 			Help:    "Duration of SEEN callback encode+publish per (callback_host, kind).",
 			Buckets: DBBuckets,
 		},
-		[]string{"callback_host", "kind"},
+		[]string{labelCallbackHost, labelKind},
 	)
 
 	subtreeAttemptCount = prometheus.NewHistogram(

--- a/internal/p2p/client.go
+++ b/internal/p2p/client.go
@@ -124,7 +124,8 @@ func (c *Client) Init(_ interface{}) error {
 		return fmt.Errorf("block kafka producer is required")
 	}
 
-	c.Logger.Info("p2p client initialized",
+	c.Logger.Info(
+		"p2p client initialized",
 		"network", c.cfg.Network,
 		"storagePath", c.cfg.StoragePath,
 	)
@@ -162,7 +163,8 @@ func (c *Client) Start(ctx context.Context) error {
 	}
 	c.p2pClient = client
 
-	c.Logger.Info("p2p client created",
+	c.Logger.Info(
+		"p2p client created",
 		"peerID", client.GetID(),
 		"network", client.GetNetwork(),
 		"dhtMode", c.cfg.MsgBus.DHTMode,
@@ -378,7 +380,8 @@ func (c *Client) handleNodeStatusMessage(msg teranode.NodeStatusMessage) {
 
 	raw := pickDataHubURL(msg)
 	if raw == "" {
-		c.Logger.Debug("node_status has no datahub url",
+		c.Logger.Debug(
+			"node_status has no datahub url",
 			"peerID", msg.PeerID,
 			"clientName", msg.ClientName,
 		)
@@ -386,7 +389,8 @@ func (c *Client) handleNodeStatusMessage(msg teranode.NodeStatusMessage) {
 	}
 
 	if err := ssrfguard.ValidateURL(raw, c.allowPrivateIPs, nil); err != nil {
-		c.Logger.Warn("rejected discovered datahub url",
+		c.Logger.Warn(
+			"rejected discovered datahub url",
 			"peerID", msg.PeerID,
 			"url", raw,
 			"error", err,
@@ -402,7 +406,8 @@ func (c *Client) handleNodeStatusMessage(msg teranode.NodeStatusMessage) {
 		return
 	}
 	if err := c.dataHubRegistry.Add(normalized); err != nil {
-		c.Logger.Warn("failed to record discovered datahub url in registry",
+		c.Logger.Warn(
+			"failed to record discovered datahub url in registry",
 			"peerID", msg.PeerID,
 			"url", normalized,
 			"error", err,
@@ -410,7 +415,8 @@ func (c *Client) handleNodeStatusMessage(msg teranode.NodeStatusMessage) {
 		return
 	}
 
-	c.Logger.Debug("registered peer datahub url from node_status",
+	c.Logger.Debug(
+		"registered peer datahub url from node_status",
 		"peerID", msg.PeerID,
 		"clientName", msg.ClientName,
 		"url", normalized,
@@ -447,7 +453,8 @@ func (c *Client) processBlockMessages(ctx context.Context, ch <-chan teranode.Bl
 // ErrPublishExhausted). Encoding errors and transient publish errors are
 // logged and swallowed so the loop can continue on subsequent messages.
 func (c *Client) handleSubtreeMessage(ctx context.Context, msg teranode.SubtreeMessage) error {
-	c.Logger.Debug("received subtree announcement",
+	c.Logger.Debug(
+		"received subtree announcement",
 		"hash", msg.Hash,
 		"dataHubUrl", msg.DataHubURL,
 	)
@@ -461,7 +468,8 @@ func (c *Client) handleSubtreeMessage(ctx context.Context, msg teranode.SubtreeM
 
 	encoded, err := kafkaMsg.Encode()
 	if err != nil {
-		c.Logger.Error("failed to encode subtree message for kafka",
+		c.Logger.Error(
+			"failed to encode subtree message for kafka",
 			"hash", msg.Hash,
 			"error", err,
 		)
@@ -477,7 +485,8 @@ func (c *Client) handleSubtreeMessage(ctx context.Context, msg teranode.SubtreeM
 // ErrPublishExhausted). Encoding errors and transient publish errors are
 // logged and swallowed so the loop can continue on subsequent messages.
 func (c *Client) handleBlockMessage(ctx context.Context, msg teranode.BlockMessage) error {
-	c.Logger.Debug("received block announcement",
+	c.Logger.Debug(
+		"received block announcement",
 		"hash", msg.Hash,
 		"height", msg.Height,
 		"dataHubUrl", msg.DataHubURL,
@@ -495,7 +504,8 @@ func (c *Client) handleBlockMessage(ctx context.Context, msg teranode.BlockMessa
 
 	encoded, err := kafkaMsg.Encode()
 	if err != nil {
-		c.Logger.Error("failed to encode block message for kafka",
+		c.Logger.Error(
+			"failed to encode block message for kafka",
 			"hash", msg.Hash,
 			"error", err,
 		)
@@ -527,7 +537,8 @@ func (c *Client) publishWithRetry(ctx context.Context, producer *kafka.Producer,
 			return nil
 		}
 
-		c.Logger.Error("kafka publish failed",
+		c.Logger.Error(
+			"kafka publish failed",
 			"type", msgType,
 			"key", key,
 			"attempt", attempt,
@@ -536,7 +547,8 @@ func (c *Client) publishWithRetry(ctx context.Context, producer *kafka.Producer,
 		)
 
 		if attempt == maxPublishRetries {
-			c.Logger.Error("kafka publish exhausted all retries, signaling fatal shutdown",
+			c.Logger.Error(
+				"kafka publish exhausted all retries, signaling fatal shutdown",
 				"type", msgType,
 				"key", key,
 				"valueLen", len(value),

--- a/internal/store/aerospike.go
+++ b/internal/store/aerospike.go
@@ -130,7 +130,8 @@ func NewAerospikeClientFromConfig(cfg config.AerospikeConfig, logger *slog.Logge
 		socketTimeoutMs: nz(cfg.SocketTimeoutMs, defaultSocketTimeoutMs),
 	}
 
-	logger.Info("aerospike client initialized",
+	logger.Info(
+		"aerospike client initialized",
 		"seeds", seeds,
 		"port", cfg.Port,
 		"connectionQueueSize", policy.ConnectionQueueSize,

--- a/internal/store/callback_accumulator.go
+++ b/internal/store/callback_accumulator.go
@@ -58,7 +58,8 @@ func (s *aerospikeCallbackAccumulator) Append(blockHash, callbackURL string, txi
 	wp.RecordExistsAction = as.UPDATE
 	wp.Expiration = uint32(s.ttlSec) //nolint:gosec // ttlSec is config-validated and fits uint32
 
-	_, err = s.client.Client().Operate(wp, key,
+	_, err = s.client.Client().Operate(
+		wp, key,
 		as.ListAppendOp(accumEntriesBin, entry),
 	)
 	if err != nil {
@@ -90,7 +91,8 @@ func (s *aerospikeCallbackAccumulator) ReadAndDelete(blockHash string) (map[stri
 	wp := s.client.WritePolicy(s.maxRetries, s.retryBaseMs)
 	wp.RecordExistsAction = as.UPDATE_ONLY
 
-	record, err := s.client.Client().Operate(wp, key,
+	record, err := s.client.Client().Operate(
+		wp, key,
 		as.ListPopRangeFromOp(accumEntriesBin, 0),
 	)
 	if err != nil {

--- a/internal/store/sql/callback_accumulator.go
+++ b/internal/store/sql/callback_accumulator.go
@@ -42,7 +42,8 @@ func (s *callbackAccumulator) Append(blockHash, callbackURL string, txids []stri
 	qParent := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		`INSERT INTO callback_accumulator (block_hash, expires_at) VALUES (%s, %s)
         ON CONFLICT (block_hash) DO UPDATE SET expires_at = EXCLUDED.expires_at`,
-		s.d.placeholder(1), s.d.intervalSeconds(s.ttlSec))
+		s.d.placeholder(1), s.d.intervalSeconds(s.ttlSec),
+	)
 	if _, err := tx.ExecContext(ctx, qParent, blockHash); err != nil {
 		return fmt.Errorf("upsert accumulator: %w", err)
 	}
@@ -50,7 +51,8 @@ func (s *callbackAccumulator) Append(blockHash, callbackURL string, txids []stri
 	qEntry := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		`INSERT INTO callback_accumulator_entries (block_hash, callback_url, subtree_index, txids_json, stump_data)
         VALUES (%s, %s, %s, %s, %s)`,
-		s.d.placeholder(1), s.d.placeholder(2), s.d.placeholder(3), s.d.placeholder(4), s.d.placeholder(5))
+		s.d.placeholder(1), s.d.placeholder(2), s.d.placeholder(3), s.d.placeholder(4), s.d.placeholder(5),
+	)
 	if _, err := tx.ExecContext(ctx, qEntry, blockHash, callbackURL, subtreeIndex, string(txidsJSON), stumpData); err != nil {
 		return fmt.Errorf("insert entry: %w", err)
 	}
@@ -114,7 +116,8 @@ func (s *callbackAccumulator) ReadAndDelete(blockHash string) (map[string]*store
 	// PostgreSQL and SQLite >= 3.35 (modernc.org/sqlite is well past that).
 	qDelEntries := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		`DELETE FROM callback_accumulator_entries WHERE block_hash = %s
-        RETURNING callback_url, subtree_index, txids_json, stump_data`, s.d.placeholder(1))
+        RETURNING callback_url, subtree_index, txids_json, stump_data`, s.d.placeholder(1),
+	)
 	rows, err := tx.QueryContext(ctx, qDelEntries, blockHash)
 	if err != nil {
 		return nil, err

--- a/internal/store/sql/callback_dedup.go
+++ b/internal/store/sql/callback_dedup.go
@@ -33,7 +33,8 @@ func (s *callbackDedup) Exists(txid, callbackURL, statusType string) (bool, erro
 	key := dedupKey(txid, callbackURL, statusType)
 	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		"SELECT 1 FROM callback_dedup WHERE dedup_key = %s AND (expires_at IS NULL OR expires_at > %s)",
-		s.d.placeholder(1), s.d.now)
+		s.d.placeholder(1), s.d.now,
+	)
 	row := s.db.QueryRowContext(ctx, q, key)
 	var x int
 	err := row.Scan(&x)
@@ -57,7 +58,8 @@ func (s *callbackDedup) Delete(txid, callbackURL, statusType string) error {
 	defer cancel()
 	key := dedupKey(txid, callbackURL, statusType)
 	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
-		"DELETE FROM callback_dedup WHERE dedup_key = %s", s.d.placeholder(1))
+		"DELETE FROM callback_dedup WHERE dedup_key = %s", s.d.placeholder(1),
+	)
 	_, err := s.db.ExecContext(ctx, q, key)
 	return err
 }
@@ -75,7 +77,8 @@ func (s *callbackDedup) Record(txid, callbackURL, statusType string, ttl time.Du
 	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		`INSERT INTO callback_dedup (dedup_key, expires_at) VALUES (%s, %s)
         ON CONFLICT (dedup_key) DO UPDATE SET expires_at = EXCLUDED.expires_at`,
-		s.d.placeholder(1), expiresExpr)
+		s.d.placeholder(1), expiresExpr,
+	)
 	_, err := s.db.ExecContext(ctx, q, key)
 	return err
 }

--- a/internal/store/sql/callback_url_registry.go
+++ b/internal/store/sql/callback_url_registry.go
@@ -46,7 +46,8 @@ func (r *callbackURLRegistry) Add(callbackURL, callbackToken string) error {
 	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		"INSERT INTO callback_urls (callback_url, last_seen_at, callback_token) VALUES (%s, %s, %s) "+
 			"ON CONFLICT (callback_url) DO UPDATE SET last_seen_at = %s, callback_token = EXCLUDED.callback_token",
-		r.d.placeholder(1), r.d.now, r.d.placeholder(2), r.d.now)
+		r.d.placeholder(1), r.d.now, r.d.placeholder(2), r.d.now,
+	)
 	_, err := r.db.ExecContext(ctx, q, callbackURL, callbackToken)
 	return err
 }
@@ -63,7 +64,8 @@ func (r *callbackURLRegistry) GetAll() ([]storepkg.CallbackEntry, error) {
 		"SELECT callback_url, callback_token FROM callback_urls "+
 			"WHERE last_seen_at IS NULL OR last_seen_at >= %s "+
 			"ORDER BY callback_url",
-		r.d.intervalSeconds(cutoff))
+		r.d.intervalSeconds(cutoff),
+	)
 
 	rows, err := r.db.QueryContext(ctx, q)
 	if err != nil {

--- a/internal/store/sql/datahub_registry.go
+++ b/internal/store/sql/datahub_registry.go
@@ -35,7 +35,8 @@ func (r *dataHubRegistry) Add(dataHubURL string) error {
 	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		"INSERT INTO datahub_urls (datahub_url, last_seen_at) VALUES (%s, %s) "+
 			"ON CONFLICT (datahub_url) DO UPDATE SET last_seen_at = %s",
-		r.d.placeholder(1), r.d.now, r.d.now)
+		r.d.placeholder(1), r.d.now, r.d.now,
+	)
 	_, err := r.db.ExecContext(ctx, q, dataHubURL)
 	return err
 }
@@ -49,7 +50,8 @@ func (r *dataHubRegistry) GetAll() ([]string, error) {
 		"SELECT datahub_url FROM datahub_urls "+
 			"WHERE last_seen_at IS NULL OR last_seen_at >= %s "+
 			"ORDER BY datahub_url",
-		r.d.intervalSeconds(cutoff))
+		r.d.intervalSeconds(cutoff),
+	)
 
 	rows, err := r.db.QueryContext(ctx, q)
 	if err != nil {

--- a/internal/store/sql/migrate.go
+++ b/internal/store/sql/migrate.go
@@ -163,7 +163,8 @@ func applyMigration(ctx context.Context, db *sql.DB, d *dialect, m migration) er
 	}
 	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		"INSERT INTO schema_migrations (version, applied_at) VALUES (%s, %s)",
-		d.placeholder(1), d.now)
+		d.placeholder(1), d.now,
+	)
 	if _, err := tx.ExecContext(ctx, q, m.version); err != nil {
 		_ = tx.Rollback()
 		return fmt.Errorf("record migration: %w", err)

--- a/internal/store/sql/registration.go
+++ b/internal/store/sql/registration.go
@@ -49,7 +49,8 @@ func (s *registrationStore) Add(txid, callbackURL, callbackToken string) error {
 
 	insertReg := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		"INSERT INTO registrations (txid) VALUES (%s)%s",
-		s.d.placeholder(1), s.d.onConflictDoNothing)
+		s.d.placeholder(1), s.d.onConflictDoNothing,
+	)
 	if _, err := tx.ExecContext(ctx, insertReg, txid); err != nil {
 		return fmt.Errorf("insert registration: %w", err)
 	}
@@ -70,7 +71,8 @@ func (s *registrationStore) Add(txid, callbackURL, callbackToken string) error {
 		// still refreshed via the ON CONFLICT DO UPDATE in the INSERT below.
 		probeQ := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 			"SELECT 1 FROM registration_urls WHERE txid = %s AND callback_url = %s",
-			s.d.placeholder(1), s.d.placeholder(2))
+			s.d.placeholder(1), s.d.placeholder(2),
+		)
 		var exists int
 		switch err := tx.QueryRowContext(ctx, probeQ, txid, callbackURL).Scan(&exists); err {
 		case nil:
@@ -78,7 +80,8 @@ func (s *registrationStore) Add(txid, callbackURL, callbackToken string) error {
 			// this UPDATE a token rotation would never propagate.
 			updateTokenQ := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 				"UPDATE registration_urls SET callback_token = %s WHERE txid = %s AND callback_url = %s",
-				s.d.placeholder(1), s.d.placeholder(2), s.d.placeholder(3))
+				s.d.placeholder(1), s.d.placeholder(2), s.d.placeholder(3),
+			)
 			if _, updateErr := tx.ExecContext(ctx, updateTokenQ, callbackToken, txid, callbackURL); updateErr != nil {
 				return fmt.Errorf("refresh callback token: %w", updateErr)
 			}
@@ -104,7 +107,8 @@ func (s *registrationStore) Add(txid, callbackURL, callbackToken string) error {
 	insertURL := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		"INSERT INTO registration_urls (txid, callback_url, callback_token) VALUES (%s, %s, %s) "+
 			"ON CONFLICT (txid, callback_url) DO UPDATE SET callback_token = EXCLUDED.callback_token",
-		s.d.placeholder(1), s.d.placeholder(2), s.d.placeholder(3))
+		s.d.placeholder(1), s.d.placeholder(2), s.d.placeholder(3),
+	)
 	if _, err := tx.ExecContext(ctx, insertURL, txid, callbackURL, callbackToken); err != nil {
 		return fmt.Errorf("insert registration url: %w", err)
 	}
@@ -116,7 +120,8 @@ func (s *registrationStore) Get(txid string) ([]storepkg.CallbackEntry, error) {
 	defer cancel()
 	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		"SELECT callback_url, callback_token FROM registration_urls WHERE txid = %s ORDER BY callback_url",
-		s.d.placeholder(1))
+		s.d.placeholder(1),
+	)
 	rows, err := s.db.QueryContext(ctx, q, txid)
 	if err != nil {
 		return nil, err
@@ -163,7 +168,8 @@ func (s *registrationStore) BatchGet(txids []string) (map[string][]storepkg.Call
 		}
 		q := fmt.Sprintf(
 			"SELECT txid, callback_url, callback_token FROM registration_urls WHERE txid IN (%s)",
-			strings.Join(placeholders, ", "))
+			strings.Join(placeholders, ", "),
+		)
 		if err := s.batchGetChunk(ctx, q, args, result); err != nil {
 			return nil, err
 		}
@@ -193,7 +199,8 @@ func (s *registrationStore) UpdateTTL(txid string, ttl time.Duration) error {
 	defer cancel()
 	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		"UPDATE registrations SET expires_at = %s WHERE txid = %s",
-		s.d.intervalSeconds(int(ttl.Seconds())), s.d.placeholder(1))
+		s.d.intervalSeconds(int(ttl.Seconds())), s.d.placeholder(1),
+	)
 	_, err := s.db.ExecContext(ctx, q, txid)
 	return err
 }
@@ -221,7 +228,8 @@ func (s *registrationStore) BatchUpdateTTL(txids []string, ttl time.Duration) er
 		}
 		q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 			"UPDATE registrations SET expires_at = %s WHERE txid IN (%s)",
-			intervalExpr, strings.Join(placeholders, ", "))
+			intervalExpr, strings.Join(placeholders, ", "),
+		)
 		if _, err := s.db.ExecContext(ctx, q, args...); err != nil {
 			return err
 		}

--- a/internal/store/sql/seen_counter.go
+++ b/internal/store/sql/seen_counter.go
@@ -48,7 +48,8 @@ func (s *seenCounter) Increment(txid, subtreeID string) (*storepkg.IncrementResu
 	// Ensure the parent counter row exists (no-op if already there).
 	qIns := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		"INSERT INTO seen_counters (txid) VALUES (%s)%s",
-		s.d.placeholder(1), s.d.onConflictDoNothing)
+		s.d.placeholder(1), s.d.onConflictDoNothing,
+	)
 	if _, err = tx.ExecContext(ctx, qIns, txid); err != nil {
 		return nil, fmt.Errorf("insert seen_counters: %w", err)
 	}
@@ -56,7 +57,8 @@ func (s *seenCounter) Increment(txid, subtreeID string) (*storepkg.IncrementResu
 	// Idempotent append of subtreeID.
 	qSub := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		"INSERT INTO seen_counter_subtrees (txid, subtree_id) VALUES (%s, %s)%s",
-		s.d.placeholder(1), s.d.placeholder(2), s.d.onConflictDoNothing)
+		s.d.placeholder(1), s.d.placeholder(2), s.d.onConflictDoNothing,
+	)
 	if _, err = tx.ExecContext(ctx, qSub, txid, subtreeID); err != nil {
 		return nil, fmt.Errorf("insert seen_counter_subtrees: %w", err)
 	}
@@ -99,7 +101,8 @@ func (s *seenCounter) tryFireThreshold(ctx context.Context, tx *sql.Tx, txid str
 			`UPDATE seen_counters
             SET threshold_fired = 1
             WHERE txid = %s AND threshold_fired = 0
-            RETURNING 1`, s.d.placeholder(1))
+            RETURNING 1`, s.d.placeholder(1),
+		)
 		var one int
 		err := tx.QueryRowContext(ctx, q, txid).Scan(&one)
 		if err != nil {
@@ -118,7 +121,8 @@ func (s *seenCounter) tryFireThreshold(ctx context.Context, tx *sql.Tx, txid str
 	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		`UPDATE seen_counters
         SET threshold_fired = 1
-        WHERE txid = %s AND threshold_fired = 0`, s.d.placeholder(1))
+        WHERE txid = %s AND threshold_fired = 0`, s.d.placeholder(1),
+	)
 	res, err := tx.ExecContext(ctx, q, txid)
 	if err != nil {
 		return false, fmt.Errorf("fire threshold (sqlite): %w", err)

--- a/internal/store/sql/sql.go
+++ b/internal/store/sql/sql.go
@@ -11,6 +11,7 @@ import (
 	_ "modernc.org/sqlite"             // pure-go sqlite driver
 
 	"github.com/bsv-blockchain/merkle-service/internal/config"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 	storepkg "github.com/bsv-blockchain/merkle-service/internal/store"
 )
 
@@ -74,6 +75,7 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger) (*storepk
 	sweeperCtx, cancelSweeper := context.WithCancel(context.Background())
 	sw := newSweeper(db, d, sweepInterval, urlRetention, logger)
 	go sw.run(sweeperCtx)
+	go metrics.RunSQLPoolSampler(sweeperCtx, db, 15*time.Second, logger)
 
 	r := &storepkg.Registry{
 		Registration:        newRegistrationStore(db, d, cfg.Registry.MaxCallbacksPerTxID),

--- a/internal/store/sql/sql_test.go
+++ b/internal/store/sql/sql_test.go
@@ -462,7 +462,8 @@ func TestCallbackURLRegistry_RetentionWindow(t *testing.T) {
 	stale := "http://stale"
 	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		"INSERT INTO callback_urls (callback_url, last_seen_at) VALUES (%s, %s)",
-		d.placeholder(1), d.intervalSeconds(-2*int(time.Hour/time.Second)))
+		d.placeholder(1), d.intervalSeconds(-2*int(time.Hour/time.Second)),
+	)
 	if _, err := db.ExecContext(context.Background(), q, stale); err != nil {
 		t.Fatalf("seed stale row: %v", err)
 	}
@@ -508,7 +509,8 @@ func TestCallbackURLRegistry_SweeperEvicts(t *testing.T) {
 	stale := "http://ancient"
 	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		"INSERT INTO callback_urls (callback_url, last_seen_at) VALUES (%s, %s)",
-		d.placeholder(1), d.intervalSeconds(-2*int(time.Hour/time.Second)))
+		d.placeholder(1), d.intervalSeconds(-2*int(time.Hour/time.Second)),
+	)
 	if _, err := db.ExecContext(context.Background(), q, stale); err != nil {
 		t.Fatalf("seed stale row: %v", err)
 	}

--- a/internal/store/sql/subtree_counter.go
+++ b/internal/store/sql/subtree_counter.go
@@ -29,7 +29,8 @@ func (s *subtreeCounter) Init(blockHash string, count int) error {
 	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		`INSERT INTO subtree_counters (block_hash, remaining, expires_at) VALUES (%s, %s, %s)
         ON CONFLICT (block_hash) DO UPDATE SET remaining = EXCLUDED.remaining, expires_at = EXCLUDED.expires_at`,
-		s.d.placeholder(1), s.d.placeholder(2), s.d.intervalSeconds(s.ttlSec))
+		s.d.placeholder(1), s.d.placeholder(2), s.d.intervalSeconds(s.ttlSec),
+	)
 	_, err := s.db.ExecContext(ctx, q, blockHash, count)
 	return err
 }
@@ -76,7 +77,8 @@ func (s *subtreeCounter) Decrement(blockHash string) (int, error) {
 	if isPostgres(s.d) {
 		q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 			"UPDATE subtree_counters SET remaining = remaining - 1 WHERE block_hash = %s RETURNING remaining",
-			s.d.placeholder(1))
+			s.d.placeholder(1),
+		)
 		var remaining int
 		if err := s.db.QueryRowContext(ctx, q, blockHash).Scan(&remaining); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
@@ -118,7 +120,8 @@ func (s *subtreeCounter) Decrement(blockHash string) (int, error) {
 	remaining--
 	qUp := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		"UPDATE subtree_counters SET remaining = %s WHERE block_hash = %s",
-		s.d.placeholder(1), s.d.placeholder(2))
+		s.d.placeholder(1), s.d.placeholder(2),
+	)
 	if _, err := conn.ExecContext(ctx, qUp, remaining, blockHash); err != nil {
 		return 0, err
 	}

--- a/internal/store/sql/sweeper.go
+++ b/internal/store/sql/sweeper.go
@@ -146,7 +146,8 @@ func (s *sweeper) sweepDataHubURLs(ctx context.Context) (int64, error) {
 	cutoff := -int(s.urlRetention / time.Second)
 	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		"DELETE FROM datahub_urls WHERE last_seen_at IS NOT NULL AND last_seen_at < %s",
-		s.d.intervalSeconds(cutoff))
+		s.d.intervalSeconds(cutoff),
+	)
 	res, err := s.db.ExecContext(ctx, q)
 	if err != nil {
 		return 0, err
@@ -163,7 +164,8 @@ func (s *sweeper) sweepCallbackURLs(ctx context.Context) (int64, error) {
 	cutoff := -int(s.urlRetention / time.Second)
 	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		"DELETE FROM callback_urls WHERE last_seen_at IS NOT NULL AND last_seen_at < %s",
-		s.d.intervalSeconds(cutoff))
+		s.d.intervalSeconds(cutoff),
+	)
 	res, err := s.db.ExecContext(ctx, q)
 	if err != nil {
 		return 0, err
@@ -223,11 +225,13 @@ func (s *sweeper) sweepTableBatch(ctx context.Context, t ttlTable, batch int) (i
 	if isPostgres(s.d) {
 		selectQ = fmt.Sprintf(
 			"SELECT %s FROM %s WHERE expires_at IS NOT NULL AND expires_at < now() LIMIT %d",
-			t.parentKey, t.parent, batch)
+			t.parentKey, t.parent, batch,
+		)
 	} else {
 		selectQ = fmt.Sprintf(
 			"SELECT %s FROM %s WHERE expires_at IS NOT NULL AND expires_at < %s LIMIT %d",
-			t.parentKey, t.parent, s.d.now, batch)
+			t.parentKey, t.parent, s.d.now, batch,
+		)
 	}
 	rows, err := tx.QueryContext(ctx, selectQ)
 	if err != nil {
@@ -284,11 +288,13 @@ func (s *sweeper) sweepParentByPhysicalRowID(ctx context.Context, table string, 
 	if isPostgres(s.d) {
 		q = fmt.Sprintf(
 			"DELETE FROM %s WHERE ctid IN (SELECT ctid FROM %s WHERE expires_at IS NOT NULL AND expires_at < now() LIMIT %d)",
-			table, table, batch)
+			table, table, batch,
+		)
 	} else {
 		q = fmt.Sprintf(
 			"DELETE FROM %s WHERE rowid IN (SELECT rowid FROM %s WHERE expires_at IS NOT NULL AND expires_at < %s LIMIT %d)",
-			table, table, s.d.now, batch)
+			table, table, s.d.now, batch,
+		)
 	}
 	res, err := s.db.ExecContext(ctx, q)
 	if err != nil {

--- a/internal/store/sql/sweeper.go
+++ b/internal/store/sql/sweeper.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 )
 
 // ttlTable describes a single TTL-bearing parent table, plus any child tables
@@ -98,7 +100,9 @@ func (s *sweeper) waitStopped() {
 
 func (s *sweeper) sweepOnce(ctx context.Context) {
 	for _, t := range ttlTables {
+		start := time.Now()
 		rows, err := s.sweepTable(ctx, t)
+		metrics.ObserveSweep(t.parent, time.Since(start), int(rows))
 		if err != nil {
 			if s.logger != nil {
 				s.logger.Warn("ttl sweeper: delete failed", "table", t.parent, "error", err)
@@ -113,7 +117,9 @@ func (s *sweeper) sweepOnce(ctx context.Context) {
 	// every Add) so it doesn't fit the expires_at-driven ttlTable shape.
 	// Sweep it separately, gated on a positive retention.
 	if s.urlRetention > 0 {
+		start := time.Now()
 		rows, err := s.sweepCallbackURLs(ctx)
+		metrics.ObserveSweep("callback_urls", time.Since(start), int(rows))
 		if err != nil {
 			if s.logger != nil {
 				s.logger.Warn("ttl sweeper: callback_urls delete failed", "error", err)
@@ -121,7 +127,9 @@ func (s *sweeper) sweepOnce(ctx context.Context) {
 		} else if rows > 0 && s.logger != nil {
 			s.logger.Debug("ttl sweeper: expired callback URLs deleted", "rows", rows)
 		}
+		start = time.Now()
 		rows, err = s.sweepDataHubURLs(ctx)
+		metrics.ObserveSweep("datahub_urls", time.Since(start), int(rows))
 		if err != nil {
 			if s.logger != nil {
 				s.logger.Warn("ttl sweeper: datahub_urls delete failed", "error", err)

--- a/internal/subtree/processor.go
+++ b/internal/subtree/processor.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync/atomic"
 	"time"
 
 	"github.com/IBM/sarama"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 
 	"github.com/bsv-blockchain/merkle-service/internal/cache"
 	"github.com/bsv-blockchain/merkle-service/internal/config"
 	"github.com/bsv-blockchain/merkle-service/internal/datahub"
 	"github.com/bsv-blockchain/merkle-service/internal/kafka"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
 )
@@ -59,11 +60,6 @@ type Processor struct {
 	regCache          RegCache
 	dedupCache        *cache.DedupCache
 	dataHubClient     *datahub.Client
-
-	messagesProcessed        atomic.Int64
-	messagesRetried          atomic.Int64
-	messagesDLQ              atomic.Int64
-	messagesSkippedUnhealthy atomic.Int64
 }
 
 // NewProcessor creates a new subtree Processor.
@@ -234,10 +230,10 @@ func (p *Processor) Stop() error {
 	p.SetStarted(false)
 	p.Cancel()
 	p.Logger.Info("subtree-fetcher stopped",
-		"messagesProcessed", p.messagesProcessed.Load(),
-		"messagesRetried", p.messagesRetried.Load(),
-		"messagesDLQ", p.messagesDLQ.Load(),
-		"messagesSkippedUnhealthy", p.messagesSkippedUnhealthy.Load(),
+		"messagesProcessed", int64(testutil.ToFloat64(metrics.SubtreeMessagesTotal.WithLabelValues(metrics.OutcomeProcessed))),
+		"messagesRetried", int64(testutil.ToFloat64(metrics.SubtreeMessagesTotal.WithLabelValues(metrics.OutcomeRetried))),
+		"messagesDLQ", int64(testutil.ToFloat64(metrics.SubtreeMessagesTotal.WithLabelValues(metrics.OutcomeDLQ))),
+		"messagesSkippedUnhealthy", int64(testutil.ToFloat64(metrics.SubtreeMessagesTotal.WithLabelValues(metrics.OutcomeSkippedUnhealthy))),
 	)
 	return firstErr
 }
@@ -253,8 +249,8 @@ func (p *Processor) Health() service.HealthStatus {
 		Name:   p.Name,
 		Status: status,
 		Details: map[string]string{
-			"messagesProcessed":        fmt.Sprintf("%d", p.messagesProcessed.Load()),
-			"messagesSkippedUnhealthy": fmt.Sprintf("%d", p.messagesSkippedUnhealthy.Load()),
+			"messagesProcessed":        fmt.Sprintf("%d", int64(testutil.ToFloat64(metrics.SubtreeMessagesTotal.WithLabelValues(metrics.OutcomeProcessed)))),
+			"messagesSkippedUnhealthy": fmt.Sprintf("%d", int64(testutil.ToFloat64(metrics.SubtreeMessagesTotal.WithLabelValues(metrics.OutcomeSkippedUnhealthy)))),
 		},
 	}
 }
@@ -277,6 +273,8 @@ func (p *Processor) Health() service.HealthStatus {
 // don't lose data, but they indicate Kafka-side trouble rather than a poison
 // pill.
 func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessage) error {
+	start := time.Now()
+
 	subtreeMsg, err := kafka.DecodeSubtreeMessage(msg.Value)
 	if err != nil {
 		// Malformed bytes at the head of the partition cannot be recovered by
@@ -288,6 +286,8 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 			"partition", msg.Partition,
 			"error", err,
 		)
+		metrics.ObserveSubtreeProcessing(metrics.OutcomeDecodeError, time.Since(start))
+		metrics.IncKafkaConsumerError(msg.Topic, metrics.KafkaErrorDecode)
 		return nil
 	}
 
@@ -300,6 +300,7 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 	// Check dedup cache — skip if already successfully processed.
 	if p.dedupCache != nil && p.dedupCache.Contains(subtreeMsg.Hash) {
 		p.Logger.Debug("skipping duplicate subtree message", "hash", subtreeMsg.Hash)
+		metrics.ObserveSubtreeProcessing(metrics.OutcomeDedupHit, time.Since(start))
 		return nil
 	}
 
@@ -314,12 +315,14 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 			"hash", subtreeMsg.Hash,
 			"dataHubUrl", subtreeMsg.DataHubURL,
 		)
-		p.messagesSkippedUnhealthy.Add(1)
+		metrics.ObserveSubtreeProcessing(metrics.OutcomeSkippedUnhealthy, time.Since(start))
 		return nil
 	}
 
 	// 3.2: Fetch binary subtree data from DataHub.
+	fetchStart := time.Now()
 	rawData, err := p.dataHubClient.FetchSubtreeRaw(ctx, subtreeMsg.DataHubURL, subtreeMsg.Hash)
+	metrics.ObserveSubtreeDataHubFetch(subtreeMsg.DataHubURL, time.Since(fetchStart), len(rawData), err)
 	if err != nil {
 		// A 404 from the announcing peer is permanent for that peer: subtrees
 		// are content-addressable, so retrying the same URL cannot recover.
@@ -328,15 +331,15 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 		// from the same host to short-circuit at the IsHealthy gate above
 		// once the threshold is reached.
 		if errors.Is(err, datahub.ErrNotFound) {
-			return p.handlePermanentFailure(subtreeMsg, "fetching subtree from DataHub", err)
+			return p.handlePermanentFailure(subtreeMsg, "fetching subtree from DataHub", err, start)
 		}
-		return p.handleTransientFailure(subtreeMsg, "fetching subtree from DataHub", err)
+		return p.handleTransientFailure(subtreeMsg, "fetching subtree from DataHub", err, start)
 	}
 
 	// 3.3: Store raw binary data in the subtree blob store.
 	if p.cfg.Subtree.StorageMode == "realtime" {
 		if err = p.subtreeStore.StoreSubtree(subtreeMsg.Hash, rawData, 0); err != nil {
-			return p.handleTransientFailure(subtreeMsg, "storing subtree", err)
+			return p.handleTransientFailure(subtreeMsg, "storing subtree", err, start)
 		}
 	}
 
@@ -344,23 +347,26 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 	// DataHub returns concatenated 32-byte hashes, not full go-subtree Serialize() format.
 	txids, err := datahub.ParseRawTxids(rawData)
 	if err != nil {
-		return p.handleTransientFailure(subtreeMsg, "parsing subtree txids", err)
+		return p.handleTransientFailure(subtreeMsg, "parsing subtree txids", err, start)
 	}
 	p.Logger.Debug("processing subtree txids", "length", len(txids), "hash", subtreeMsg.Hash)
+	metrics.ObserveSubtreeCounts(len(txids), 0)
 
 	if len(txids) == 0 {
 		if p.dedupCache != nil {
 			p.dedupCache.Add(subtreeMsg.Hash)
 		}
-		p.messagesProcessed.Add(1)
+		metrics.ObserveSubtreeAttemptCount(subtreeMsg.AttemptCount)
+		metrics.ObserveSubtreeProcessing(metrics.OutcomeProcessed, time.Since(start))
 		return nil
 	}
 
 	// 4.2-4.4: Check registrations via cache and Aerospike.
 	registeredTxids, err := p.findRegisteredTxids(txids)
 	if err != nil {
-		return p.handleTransientFailure(subtreeMsg, "checking registrations", err)
+		return p.handleTransientFailure(subtreeMsg, "checking registrations", err, start)
 	}
+	metrics.ObserveSubtreeCounts(0, len(registeredTxids))
 
 	// 4.5-4.6: Emit batched callbacks grouped by callbackURL.
 	//
@@ -371,7 +377,7 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 	// consumers permanently lose SEEN notifications during a Kafka
 	// callback-topic outage (F-057).
 	if err := p.emitBatchedSeenCallbacks(registeredTxids, subtreeMsg.Hash); err != nil {
-		return p.handleTransientFailure(subtreeMsg, "publishing batched SEEN callbacks", err)
+		return p.handleTransientFailure(subtreeMsg, "publishing batched SEEN callbacks", err, start)
 	}
 
 	// Mark subtree as successfully processed for dedup.
@@ -379,7 +385,8 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 		p.dedupCache.Add(subtreeMsg.Hash)
 	}
 
-	p.messagesProcessed.Add(1)
+	metrics.ObserveSubtreeAttemptCount(subtreeMsg.AttemptCount)
+	metrics.ObserveSubtreeProcessing(metrics.OutcomeProcessed, time.Since(start))
 	return nil
 }
 
@@ -388,7 +395,7 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 // it on subtree-dlq. Returns nil on successful hand-off so the consumer acks
 // the original offset; returns an error only when the producer itself is
 // broken (partition stall is preferable to silent loss in that case).
-func (p *Processor) handleTransientFailure(subtreeMsg *kafka.SubtreeMessage, stage string, cause error) error {
+func (p *Processor) handleTransientFailure(subtreeMsg *kafka.SubtreeMessage, stage string, cause error, start time.Time) error {
 	nextAttempt := subtreeMsg.AttemptCount + 1
 	maxAttempts := p.cfg.Subtree.MaxAttempts
 	if maxAttempts <= 0 {
@@ -404,7 +411,11 @@ func (p *Processor) handleTransientFailure(subtreeMsg *kafka.SubtreeMessage, sta
 			"error", cause,
 		)
 		subtreeMsg.AttemptCount = nextAttempt
-		return p.publishToDLQ(subtreeMsg)
+		if err := p.publishToDLQ(subtreeMsg); err != nil {
+			return err
+		}
+		metrics.ObserveSubtreeProcessing(metrics.OutcomeDLQ, time.Since(start))
+		return nil
 	}
 
 	p.Logger.Warn("subtree message transient failure, re-publishing for retry",
@@ -422,7 +433,7 @@ func (p *Processor) handleTransientFailure(subtreeMsg *kafka.SubtreeMessage, sta
 	if pubErr := p.retryProducer.Publish(subtreeMsg.Hash, data); pubErr != nil {
 		return fmt.Errorf("re-publishing subtree message for retry: %w", pubErr)
 	}
-	p.messagesRetried.Add(1)
+	metrics.ObserveSubtreeProcessing(metrics.OutcomeRetried, time.Since(start))
 	return nil
 }
 
@@ -434,7 +445,7 @@ func (p *Processor) handleTransientFailure(subtreeMsg *kafka.SubtreeMessage, sta
 // AttemptCount=0 is distinguishable from a transient-exhausted entry.
 // Returns nil on successful hand-off so the consumer acks the original
 // offset.
-func (p *Processor) handlePermanentFailure(subtreeMsg *kafka.SubtreeMessage, stage string, cause error) error {
+func (p *Processor) handlePermanentFailure(subtreeMsg *kafka.SubtreeMessage, stage string, cause error, start time.Time) error {
 	p.Logger.Warn("subtree message permanent failure, routing to DLQ",
 		"hash", subtreeMsg.Hash,
 		"stage", stage,
@@ -442,7 +453,11 @@ func (p *Processor) handlePermanentFailure(subtreeMsg *kafka.SubtreeMessage, sta
 		"attemptCount", subtreeMsg.AttemptCount,
 		"error", cause,
 	)
-	return p.publishToDLQ(subtreeMsg)
+	if err := p.publishToDLQ(subtreeMsg); err != nil {
+		return err
+	}
+	metrics.ObserveSubtreeProcessing(metrics.OutcomePermanentFailure, time.Since(start))
+	return nil
 }
 
 // publishToDLQ encodes subtreeMsg and publishes it to subtree-dlq. The
@@ -459,7 +474,6 @@ func (p *Processor) publishToDLQ(subtreeMsg *kafka.SubtreeMessage) error {
 	if pubErr := p.dlqProducer.Publish(subtreeMsg.Hash, data); pubErr != nil {
 		return fmt.Errorf("publishing subtree message to DLQ: %w", pubErr)
 	}
-	p.messagesDLQ.Add(1)
 	return nil
 }
 
@@ -478,7 +492,10 @@ func (p *Processor) findRegisteredTxids(txids []string) (map[string][]store.Call
 	var registeredFromStore map[string][]store.CallbackEntry
 	if len(uncached) > 0 {
 		var err error
+		metrics.ObserveDBBatchSize(metrics.StoreRegistration, metrics.OpBatchGet, len(uncached))
+		t := metrics.StartDB(p.backendLabel(), metrics.StoreRegistration, metrics.OpBatchGet)
 		registeredFromStore, err = p.registrationStore.BatchGet(uncached)
+		t.End(err)
 		if err != nil {
 			return nil, fmt.Errorf("batch get registrations: %w", err)
 		}
@@ -516,7 +533,10 @@ func (p *Processor) findRegisteredTxids(txids []string) (map[string][]store.Call
 	// re-drives via handleTransientFailure (which leaves the dedup cache
 	// untouched).
 	if len(cachedRegistered) > 0 {
+		metrics.ObserveDBBatchSize(metrics.StoreRegistration, metrics.OpBatchGet, len(cachedRegistered))
+		t := metrics.StartDB(p.backendLabel(), metrics.StoreRegistration, metrics.OpBatchGet)
 		cachedEntries, err := p.registrationStore.BatchGet(cachedRegistered)
+		t.End(err)
 		if err != nil {
 			return nil, fmt.Errorf("batch get callbackURLs for cached txids: %w", err)
 		}
@@ -584,6 +604,7 @@ func (p *Processor) emitBatchedSeenCallbacks(registeredTxids map[string][]store.
 				SubtreeHash:   subtreeID,
 				TxIDs:         chunk,
 			}
+			emitStart := time.Now()
 			data, err := msg.Encode()
 			if err != nil {
 				p.Logger.Error("failed to encode batched SEEN_ON_NETWORK", "callbackURL", callbackURL, "error", err)
@@ -598,6 +619,7 @@ func (p *Processor) emitBatchedSeenCallbacks(registeredTxids map[string][]store.
 					firstErr = fmt.Errorf("publishing SEEN_ON_NETWORK for %s: %w", callbackURL, err)
 				}
 			}
+			metrics.ObserveSubtreeEmitSeen(callbackURL, metrics.SeenKindOnNetwork, time.Since(emitStart))
 		}
 	}
 
@@ -613,7 +635,9 @@ func (p *Processor) emitBatchedSeenCallbacks(registeredTxids map[string][]store.
 	// best-effort increment + threshold callback on this attempt.
 	thresholdGroups := make(map[string][]string) // callbackURL → threshold-reached txids
 	for txid, entries := range registeredTxids {
+		incStart := time.Now()
 		result, err := p.seenCounterStore.Increment(txid, subtreeID)
+		metrics.ObserveDB(p.backendLabel(), metrics.StoreSeenCounter, metrics.OpIncrement, incStart, err)
 		if err != nil {
 			p.Logger.Error("failed to increment seen counter", "txid", txid, "subtreeID", subtreeID, "error", err)
 			if firstErr == nil {
@@ -638,6 +662,7 @@ func (p *Processor) emitBatchedSeenCallbacks(registeredTxids map[string][]store.
 				SubtreeHash:   subtreeID,
 				TxIDs:         chunk,
 			}
+			emitStart := time.Now()
 			data, err := msg.Encode()
 			if err != nil {
 				p.Logger.Error("failed to encode batched SEEN_MULTIPLE_NODES", "callbackURL", callbackURL, "error", err)
@@ -652,10 +677,21 @@ func (p *Processor) emitBatchedSeenCallbacks(registeredTxids map[string][]store.
 					firstErr = fmt.Errorf("publishing SEEN_MULTIPLE_NODES for %s: %w", callbackURL, err)
 				}
 			}
+			metrics.ObserveSubtreeEmitSeen(callbackURL, metrics.SeenKindMultipleNodes, time.Since(emitStart))
 		}
 	}
 
 	return firstErr
+}
+
+// backendLabel returns the store-backend label for DB metrics: "aerospike"
+// or "sql" depending on cfg.Store.Backend. Falls back to "aerospike" (the
+// default) when cfg is nil or unset, matching config.Load() behavior.
+func (p *Processor) backendLabel() string {
+	if p.cfg != nil && p.cfg.Store.Backend == config.BackendSQL {
+		return metrics.BackendSQL
+	}
+	return metrics.BackendAerospike
 }
 
 // callbackBatchChunkSize caps txids per batched callback message so the JSON

--- a/internal/subtree/processor.go
+++ b/internal/subtree/processor.go
@@ -162,7 +162,8 @@ func (p *Processor) Init(_ interface{}) error {
 	}
 	p.consumer = consumer
 
-	p.Logger.Info("subtree-fetcher initialized",
+	p.Logger.Info(
+		"subtree-fetcher initialized",
 		"storageMode", p.cfg.Subtree.StorageMode,
 		"subtreeTopic", p.cfg.Kafka.SubtreeTopic,
 		"subtreeDLQTopic", p.cfg.Kafka.SubtreeDLQTopic,
@@ -229,7 +230,8 @@ func (p *Processor) Stop() error {
 
 	p.SetStarted(false)
 	p.Cancel()
-	p.Logger.Info("subtree-fetcher stopped",
+	p.Logger.Info(
+		"subtree-fetcher stopped",
 		"messagesProcessed", int64(testutil.ToFloat64(metrics.SubtreeMessagesTotal.WithLabelValues(metrics.OutcomeProcessed))),
 		"messagesRetried", int64(testutil.ToFloat64(metrics.SubtreeMessagesTotal.WithLabelValues(metrics.OutcomeRetried))),
 		"messagesDLQ", int64(testutil.ToFloat64(metrics.SubtreeMessagesTotal.WithLabelValues(metrics.OutcomeDLQ))),
@@ -281,7 +283,8 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 		// re-driving — drop the offset by returning nil after logging. A
 		// decode failure is not DLQ-able because we don't have a structured
 		// message to wrap.
-		p.Logger.Error("failed to decode subtree message, dropping",
+		p.Logger.Error(
+			"failed to decode subtree message, dropping",
 			"offset", msg.Offset,
 			"partition", msg.Partition,
 			"error", err,
@@ -291,7 +294,8 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 		return nil
 	}
 
-	p.Logger.Debug("processing subtree announcement",
+	p.Logger.Debug(
+		"processing subtree announcement",
 		"hash", subtreeMsg.Hash,
 		"dataHubUrl", subtreeMsg.DataHubURL,
 		"attemptCount", subtreeMsg.AttemptCount,
@@ -311,7 +315,8 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 	// dead peer from generating a steady stream of retries and DLQ
 	// entries on every announcement.
 	if ph := p.dataHubClient.PeerHealth(); ph != nil && !ph.IsHealthy(subtreeMsg.DataHubURL) {
-		p.Logger.Debug("skipping subtree fetch: peer marked unhealthy",
+		p.Logger.Debug(
+			"skipping subtree fetch: peer marked unhealthy",
 			"hash", subtreeMsg.Hash,
 			"dataHubUrl", subtreeMsg.DataHubURL,
 		)
@@ -403,7 +408,8 @@ func (p *Processor) handleTransientFailure(subtreeMsg *kafka.SubtreeMessage, sta
 	}
 
 	if nextAttempt >= maxAttempts {
-		p.Logger.Error("subtree message exceeded max attempts, routing to DLQ",
+		p.Logger.Error(
+			"subtree message exceeded max attempts, routing to DLQ",
 			"hash", subtreeMsg.Hash,
 			"stage", stage,
 			"attemptCount", subtreeMsg.AttemptCount,
@@ -418,7 +424,8 @@ func (p *Processor) handleTransientFailure(subtreeMsg *kafka.SubtreeMessage, sta
 		return nil
 	}
 
-	p.Logger.Warn("subtree message transient failure, re-publishing for retry",
+	p.Logger.Warn(
+		"subtree message transient failure, re-publishing for retry",
 		"hash", subtreeMsg.Hash,
 		"stage", stage,
 		"attemptCount", subtreeMsg.AttemptCount,
@@ -446,7 +453,8 @@ func (p *Processor) handleTransientFailure(subtreeMsg *kafka.SubtreeMessage, sta
 // Returns nil on successful hand-off so the consumer acks the original
 // offset.
 func (p *Processor) handlePermanentFailure(subtreeMsg *kafka.SubtreeMessage, stage string, cause error, start time.Time) error {
-	p.Logger.Warn("subtree message permanent failure, routing to DLQ",
+	p.Logger.Warn(
+		"subtree message permanent failure, routing to DLQ",
 		"hash", subtreeMsg.Hash,
 		"stage", stage,
 		"dataHubUrl", subtreeMsg.DataHubURL,

--- a/internal/subtree/processor_test.go
+++ b/internal/subtree/processor_test.go
@@ -15,13 +15,22 @@ import (
 
 	"github.com/IBM/sarama"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 
 	"github.com/bsv-blockchain/merkle-service/internal/cache"
 	"github.com/bsv-blockchain/merkle-service/internal/config"
 	"github.com/bsv-blockchain/merkle-service/internal/datahub"
 	"github.com/bsv-blockchain/merkle-service/internal/kafka"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
 )
+
+// subtreeCount returns the current value of the named outcome counter.
+// Tests assert on deltas against a pre-call snapshot since the underlying
+// Prometheus counter is process-global and accumulates across tests.
+func subtreeCount(outcome string) int64 {
+	return int64(testutil.ToFloat64(metrics.SubtreeMessagesTotal.WithLabelValues(outcome)))
+}
 
 const (
 	testTx1 = "tx1"
@@ -1276,8 +1285,10 @@ func TestHandleTransientFailure_RoutesToDLQAtMaxAttempts(t *testing.T) {
 	cause := errors.New("datahub 404")
 
 	// Simulate retries until MaxAttempts is reached.
+	beforeRetried := subtreeCount(metrics.OutcomeRetried)
+	beforeDLQ := subtreeCount(metrics.OutcomeDLQ)
 	for i := 0; i < maxAttempts; i++ {
-		if err := p.handleTransientFailure(subtreeMsg, "fetch", cause); err != nil {
+		if err := p.handleTransientFailure(subtreeMsg, "fetch", cause, time.Now()); err != nil {
 			t.Fatalf("iteration %d: unexpected error: %v", i, err)
 		}
 	}
@@ -1319,11 +1330,11 @@ func TestHandleTransientFailure_RoutesToDLQAtMaxAttempts(t *testing.T) {
 		t.Errorf("DLQ msg Hash: expected %q, got %q", subtreeMsg.Hash, dlqDecoded.Hash)
 	}
 
-	if got := p.messagesRetried.Load(); got != int64(maxAttempts-1) {
-		t.Errorf("messagesRetried: expected %d, got %d", maxAttempts-1, got)
+	if got := subtreeCount(metrics.OutcomeRetried) - beforeRetried; got != int64(maxAttempts-1) {
+		t.Errorf("retried counter delta: expected %d, got %d", maxAttempts-1, got)
 	}
-	if got := p.messagesDLQ.Load(); got != 1 {
-		t.Errorf("messagesDLQ: expected 1, got %d", got)
+	if got := subtreeCount(metrics.OutcomeDLQ) - beforeDLQ; got != 1 {
+		t.Errorf("dlq counter delta: expected 1, got %d", got)
 	}
 }
 
@@ -1344,7 +1355,7 @@ func TestHandleTransientFailure_DefaultsMaxAttemptsWhenUnset(t *testing.T) {
 	p.Logger = logger
 
 	subtreeMsg := &kafka.SubtreeMessage{Hash: "h"}
-	if err := p.handleTransientFailure(subtreeMsg, "fetch", errors.New("x")); err != nil {
+	if err := p.handleTransientFailure(subtreeMsg, "fetch", errors.New("x"), time.Now()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -1622,6 +1633,8 @@ func TestHandleMessage_CallbackPublishFailure_RoutesToRetry(t *testing.T) {
 		t.Fatalf("encode subtree msg: %v", err)
 	}
 
+	beforeProcessed := subtreeCount(metrics.OutcomeProcessed)
+	beforeRetried := subtreeCount(metrics.OutcomeRetried)
 	if err := p.handleMessage(t.Context(), &sarama.ConsumerMessage{Value: value}); err != nil {
 		t.Fatalf("handleMessage: expected nil error (retry path returns nil after re-publishing), got: %v", err)
 	}
@@ -1634,13 +1647,13 @@ func TestHandleMessage_CallbackPublishFailure_RoutesToRetry(t *testing.T) {
 	if got := len(dlqMock.getMessages()); got != 0 {
 		t.Errorf("expected zero DLQ publishes, got %d", got)
 	}
-	// messagesProcessed must NOT have been incremented — the subtree wasn't
+	// processed counter must NOT have advanced — the subtree wasn't
 	// successfully processed end-to-end.
-	if got := p.messagesProcessed.Load(); got != 0 {
-		t.Errorf("expected messagesProcessed=0 after callback failure, got %d", got)
+	if got := subtreeCount(metrics.OutcomeProcessed) - beforeProcessed; got != 0 {
+		t.Errorf("expected processed delta=0 after callback failure, got %d", got)
 	}
-	if got := p.messagesRetried.Load(); got != 1 {
-		t.Errorf("expected messagesRetried=1 after callback failure, got %d", got)
+	if got := subtreeCount(metrics.OutcomeRetried) - beforeRetried; got != 1 {
+		t.Errorf("expected retried delta=1 after callback failure, got %d", got)
 	}
 }
 
@@ -1753,6 +1766,8 @@ func TestHandleMessage_CachedLookupFailure_RoutesToRetryAndSkipsDedup(t *testing
 		t.Fatalf("encode subtree msg: %v", err)
 	}
 
+	beforeProcessed := subtreeCount(metrics.OutcomeProcessed)
+	beforeRetried := subtreeCount(metrics.OutcomeRetried)
 	if err := p.handleMessage(t.Context(), &sarama.ConsumerMessage{Value: value}); err != nil {
 		t.Fatalf("handleMessage: expected nil error (retry path returns nil after re-publishing), got: %v", err)
 	}
@@ -1770,11 +1785,11 @@ func TestHandleMessage_CachedLookupFailure_RoutesToRetryAndSkipsDedup(t *testing
 	if got := len(dlqMock.getMessages()); got != 0 {
 		t.Errorf("expected zero DLQ publishes, got %d", got)
 	}
-	if got := p.messagesProcessed.Load(); got != 0 {
-		t.Errorf("expected messagesProcessed=0 after cached-lookup failure, got %d", got)
+	if got := subtreeCount(metrics.OutcomeProcessed) - beforeProcessed; got != 0 {
+		t.Errorf("expected processed delta=0 after cached-lookup failure, got %d", got)
 	}
-	if got := p.messagesRetried.Load(); got != 1 {
-		t.Errorf("expected messagesRetried=1 after cached-lookup failure, got %d", got)
+	if got := subtreeCount(metrics.OutcomeRetried) - beforeRetried; got != 1 {
+		t.Errorf("expected retried delta=1 after cached-lookup failure, got %d", got)
 	}
 	// No callbacks should have been emitted — we never built a complete map.
 	if got := len(cbMock.getMessages()); got != 0 {
@@ -1910,6 +1925,8 @@ func TestHandleMessage_SeenCounterIncrementFailure_RoutesToRetryAndSkipsDedup(t 
 		t.Fatalf("encode subtree msg: %v", err)
 	}
 
+	beforeProcessed := subtreeCount(metrics.OutcomeProcessed)
+	beforeRetried := subtreeCount(metrics.OutcomeRetried)
 	if err := p.handleMessage(t.Context(), &sarama.ConsumerMessage{Value: value}); err != nil {
 		t.Fatalf("handleMessage: expected nil error (retry path returns nil after re-publishing), got: %v", err)
 	}
@@ -1928,11 +1945,11 @@ func TestHandleMessage_SeenCounterIncrementFailure_RoutesToRetryAndSkipsDedup(t 
 	if got := len(dlqMock.getMessages()); got != 0 {
 		t.Errorf("expected zero DLQ publishes, got %d", got)
 	}
-	if got := p.messagesProcessed.Load(); got != 0 {
-		t.Errorf("expected messagesProcessed=0 after seen-counter failure, got %d", got)
+	if got := subtreeCount(metrics.OutcomeProcessed) - beforeProcessed; got != 0 {
+		t.Errorf("expected processed delta=0 after seen-counter failure, got %d", got)
 	}
-	if got := p.messagesRetried.Load(); got != 1 {
-		t.Errorf("expected messagesRetried=1 after seen-counter failure, got %d", got)
+	if got := subtreeCount(metrics.OutcomeRetried) - beforeRetried; got != 1 {
+		t.Errorf("expected retried delta=1 after seen-counter failure, got %d", got)
 	}
 
 	// Increment was attempted at least once for the registered txid.
@@ -1993,6 +2010,8 @@ func TestHandleMessage_SeenCounterSuccess_UpdatesDedup(t *testing.T) {
 		t.Fatalf("encode subtree msg: %v", err)
 	}
 
+	beforeProcessed := subtreeCount(metrics.OutcomeProcessed)
+	beforeRetried := subtreeCount(metrics.OutcomeRetried)
 	if err := p.handleMessage(t.Context(), &sarama.ConsumerMessage{Value: value}); err != nil {
 		t.Fatalf("handleMessage: expected nil error on success path, got: %v", err)
 	}
@@ -2007,11 +2026,11 @@ func TestHandleMessage_SeenCounterSuccess_UpdatesDedup(t *testing.T) {
 	if got := len(dlqMock.getMessages()); got != 0 {
 		t.Errorf("expected 0 DLQ publishes on success, got %d", got)
 	}
-	if got := p.messagesProcessed.Load(); got != 1 {
-		t.Errorf("expected messagesProcessed=1 on success, got %d", got)
+	if got := subtreeCount(metrics.OutcomeProcessed) - beforeProcessed; got != 1 {
+		t.Errorf("expected processed delta=1 on success, got %d", got)
 	}
-	if got := p.messagesRetried.Load(); got != 0 {
-		t.Errorf("expected messagesRetried=0 on success, got %d", got)
+	if got := subtreeCount(metrics.OutcomeRetried) - beforeRetried; got != 0 {
+		t.Errorf("expected retried delta=0 on success, got %d", got)
 	}
 	// SEEN_ON_NETWORK should have been published (no SEEN_MULTIPLE_NODES
 	// since mockSeenCounter never fires the threshold).
@@ -2069,6 +2088,8 @@ func TestHandleMessage_SkipsUnhealthyPeer(t *testing.T) {
 		t.Fatalf("encode subtree msg: %v", encErr)
 	}
 
+	beforeSkipped := subtreeCount(metrics.OutcomeSkippedUnhealthy)
+	beforeProcessed := subtreeCount(metrics.OutcomeProcessed)
 	if err := p.handleMessage(t.Context(), &sarama.ConsumerMessage{Value: value}); err != nil {
 		t.Fatalf("handleMessage: expected nil (ack-and-drop on unhealthy), got: %v", err)
 	}
@@ -2082,11 +2103,11 @@ func TestHandleMessage_SkipsUnhealthyPeer(t *testing.T) {
 	if got := len(cbMock.getMessages()); got != 0 {
 		t.Errorf("expected 0 callback publishes when peer is unhealthy, got %d", got)
 	}
-	if got := p.messagesSkippedUnhealthy.Load(); got != 1 {
-		t.Errorf("expected messagesSkippedUnhealthy=1, got %d", got)
+	if got := subtreeCount(metrics.OutcomeSkippedUnhealthy) - beforeSkipped; got != 1 {
+		t.Errorf("expected skipped_unhealthy delta=1, got %d", got)
 	}
-	if got := p.messagesProcessed.Load(); got != 0 {
-		t.Errorf("expected messagesProcessed=0, got %d", got)
+	if got := subtreeCount(metrics.OutcomeProcessed) - beforeProcessed; got != 0 {
+		t.Errorf("expected processed delta=0, got %d", got)
 	}
 }
 
@@ -2132,6 +2153,8 @@ func TestHandleMessage_NotFoundGoesStraightToDLQ(t *testing.T) {
 		t.Fatalf("encode subtree msg: %v", encErr)
 	}
 
+	beforePermanent := subtreeCount(metrics.OutcomePermanentFailure)
+	beforeRetried := subtreeCount(metrics.OutcomeRetried)
 	if err := p.handleMessage(t.Context(), &sarama.ConsumerMessage{Value: value}); err != nil {
 		t.Fatalf("handleMessage: expected nil (permanent → DLQ returns nil), got: %v", err)
 	}
@@ -2155,11 +2178,11 @@ func TestHandleMessage_NotFoundGoesStraightToDLQ(t *testing.T) {
 		t.Errorf("permanent failure must NOT bump AttemptCount; expected 0, got %d",
 			decoded.AttemptCount)
 	}
-	if got := p.messagesDLQ.Load(); got != 1 {
-		t.Errorf("expected messagesDLQ=1, got %d", got)
+	if got := subtreeCount(metrics.OutcomePermanentFailure) - beforePermanent; got != 1 {
+		t.Errorf("expected permanent_failure delta=1, got %d", got)
 	}
-	if got := p.messagesRetried.Load(); got != 0 {
-		t.Errorf("expected messagesRetried=0, got %d", got)
+	if got := subtreeCount(metrics.OutcomeRetried) - beforeRetried; got != 0 {
+		t.Errorf("expected retried delta=0, got %d", got)
 	}
 }
 
@@ -2204,6 +2227,8 @@ func TestHandleMessage_TransientErrorStillRetries(t *testing.T) {
 		t.Fatalf("encode subtree msg: %v", encErr)
 	}
 
+	beforeRetried := subtreeCount(metrics.OutcomeRetried)
+	beforeDLQ := subtreeCount(metrics.OutcomeDLQ)
 	if err := p.handleMessage(t.Context(), &sarama.ConsumerMessage{Value: value}); err != nil {
 		t.Fatalf("handleMessage: expected nil (transient → retry returns nil), got: %v", err)
 	}
@@ -2227,10 +2252,10 @@ func TestHandleMessage_TransientErrorStillRetries(t *testing.T) {
 		t.Errorf("transient failure must bump AttemptCount; expected 1, got %d",
 			decoded.AttemptCount)
 	}
-	if got := p.messagesRetried.Load(); got != 1 {
-		t.Errorf("expected messagesRetried=1, got %d", got)
+	if got := subtreeCount(metrics.OutcomeRetried) - beforeRetried; got != 1 {
+		t.Errorf("expected retried delta=1, got %d", got)
 	}
-	if got := p.messagesDLQ.Load(); got != 0 {
-		t.Errorf("expected messagesDLQ=0, got %d", got)
+	if got := subtreeCount(metrics.OutcomeDLQ) - beforeDLQ; got != 0 {
+		t.Errorf("expected dlq delta=0, got %d", got)
 	}
 }

--- a/tools/debug-dashboard/handlers.go
+++ b/tools/debug-dashboard/handlers.go
@@ -228,7 +228,8 @@ func (h *Handlers) handleCallbackReceive(w http.ResponseWriter, r *http.Request)
 	}
 	h.callbackStore.Add(entry)
 
-	h.logger.Info("received callback",
+	h.logger.Info(
+		"received callback",
 		"status", parsed["status"],
 		"txid", parsed["txid"],
 	)

--- a/tools/debug-dashboard/main.go
+++ b/tools/debug-dashboard/main.go
@@ -92,7 +92,8 @@ func main() {
 	handler := loggingMiddleware(logger, mux)
 
 	addr := fmt.Sprintf(":%d", *port)
-	logger.Info("starting debug dashboard",
+	logger.Info(
+		"starting debug dashboard",
 		"addr", addr,
 		"merkleAPI", *merkleAPI,
 		"callbackURL", callbackURL,
@@ -116,7 +117,8 @@ func loggingMiddleware(logger *slog.Logger, next http.Handler) http.Handler {
 		start := time.Now()
 		sw := &statusWriter{ResponseWriter: w, status: 200}
 		next.ServeHTTP(sw, r)
-		logger.Debug("request",
+		logger.Debug(
+			"request",
 			"method", r.Method,
 			"path", r.URL.Path,
 			"status", sw.status,


### PR DESCRIPTION
This pull request introduces metrics instrumentation across all major services and components in the project. It adds Prometheus-based metrics collection, exposes metrics endpoints, and records key operational metrics such as database operations and STUMP build/encode timings. The changes are implemented in a way that allows metrics to be enabled or disabled via configuration, and the metrics server is properly started and stopped alongside each service.

**Metrics Instrumentation and Exposure**

* Added the `github.com/prometheus/client_golang` dependency and related indirect dependencies to `go.mod` to enable Prometheus metrics support. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R15) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R145) [[3]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L223)
* Integrated a `metrics.Server` in all main services (`api-server`, `block-processor`, `callback-delivery`, `merkle-service`, `p2p-client`, `subtree-fetcher`, `subtree-worker`) to conditionally start and stop a Prometheus metrics endpoint based on configuration. [[1]](diffhunk://#diff-9a806b47e2c7033d8cd996647dab85acf24df2026be1ffe009df197a35956002R12) [[2]](diffhunk://#diff-9a806b47e2c7033d8cd996647dab85acf24df2026be1ffe009df197a35956002R35-R51) [[3]](diffhunk://#diff-213ebda8c947a599411016e0494aeed174919565b51a80ba3e17edf09cab6dd2R9) [[4]](diffhunk://#diff-213ebda8c947a599411016e0494aeed174919565b51a80ba3e17edf09cab6dd2R36-R51) [[5]](diffhunk://#diff-0f393c549531d32ef44062702fb59a1f615f7ee6756ad2b2d8d63a02ee739071R9) [[6]](diffhunk://#diff-0f393c549531d32ef44062702fb59a1f615f7ee6756ad2b2d8d63a02ee739071R32-R47) [[7]](diffhunk://#diff-c368fe0d5f68ac46ac2912b459d6c0cc5f8b03c96ef640dc0e5f5915f2a1b717R14) [[8]](diffhunk://#diff-c368fe0d5f68ac46ac2912b459d6c0cc5f8b03c96ef640dc0e5f5915f2a1b717R51) [[9]](diffhunk://#diff-c368fe0d5f68ac46ac2912b459d6c0cc5f8b03c96ef640dc0e5f5915f2a1b717L82-R88) [[10]](diffhunk://#diff-e110ead43c5a9f396e696e1cb8f868fcafcf281663b37d5fbc5813887ac747aaR12) [[11]](diffhunk://#diff-e110ead43c5a9f396e696e1cb8f868fcafcf281663b37d5fbc5813887ac747aaR88-R103) [[12]](diffhunk://#diff-7ee2eca2942ee69eeaebddd4f079ab1e2416c51ff88a0740ed700cc896c88cc4R8) [[13]](diffhunk://#diff-7ee2eca2942ee69eeaebddd4f079ab1e2416c51ff88a0740ed700cc896c88cc4R32-R47) [[14]](diffhunk://#diff-539ea2e9a7937f550253634ab6548b8c0423e075232a4f33482854bb1ac26ae0R9) [[15]](diffhunk://#diff-539ea2e9a7937f550253634ab6548b8c0423e075232a4f33482854bb1ac26ae0R36-R51)

**API and Handler Metrics**

* Added middleware to the API server (`internal/api/server.go`) to expose HTTP metrics for all API endpoints.
* Enhanced the API handlers to record database operation metrics (timing and error status) for registration and lookup operations, tagging them by backend type. [[1]](diffhunk://#diff-6c6fe69fba99e4fd8a5b14a2751c6ef8363e4054217bbaab768340dedfb72735R16) [[2]](diffhunk://#diff-6c6fe69fba99e4fd8a5b14a2751c6ef8363e4054217bbaab768340dedfb72735L119-R123) [[3]](diffhunk://#diff-6c6fe69fba99e4fd8a5b14a2751c6ef8363e4054217bbaab768340dedfb72735L140-R148) [[4]](diffhunk://#diff-6c6fe69fba99e4fd8a5b14a2751c6ef8363e4054217bbaab768340dedfb72735R191-R193)
* Added logic to track and expose which backend is in use (SQL or Aerospike) for more granular metrics. [[1]](diffhunk://#diff-9dd4887dac4839dd701fb4778bd390ccc23ef2c858e9ad530ad790c2a834d093R44-R46) [[2]](diffhunk://#diff-9dd4887dac4839dd701fb4778bd390ccc23ef2c858e9ad530ad790c2a834d093R110-R128) [[3]](diffhunk://#diff-c368fe0d5f68ac46ac2912b459d6c0cc5f8b03c96ef640dc0e5f5915f2a1b717R51) [[4]](diffhunk://#diff-9a806b47e2c7033d8cd996647dab85acf24df2026be1ffe009df197a35956002R35-R51)

**Block Processing and STUMP Metrics**

* Instrumented the STUMP build and encode process to record timings and relevant counts, allowing for performance monitoring of these critical operations. [[1]](diffhunk://#diff-9a33e1a0c5519a202e584c3fb2bef26eee57032406cff5590ece74ab055c3f95R13) [[2]](diffhunk://#diff-9a33e1a0c5519a202e584c3fb2bef26eee57032406cff5590ece74ab055c3f95R202-R213)

**Callback and Subsystem Metrics**

* Integrated metrics collection in the callback delivery and subtree processing subsystems to monitor their operation and expose relevant metrics. [[1]](diffhunk://#diff-96db120e72580c8c6c82fe1ee8ba3a333ea157d1de9e419b413386239988d69fL17-R25) [[2]](diffhunk://#diff-0f393c549531d32ef44062702fb59a1f615f7ee6756ad2b2d8d63a02ee739071R9) [[3]](diffhunk://#diff-0f393c549531d32ef44062702fb59a1f615f7ee6756ad2b2d8d63a02ee739071R32-R47) [[4]](diffhunk://#diff-7ee2eca2942ee69eeaebddd4f079ab1e2416c51ff88a0740ed700cc896c88cc4R8) [[5]](diffhunk://#diff-7ee2eca2942ee69eeaebddd4f079ab1e2416c51ff88a0740ed700cc896c88cc4R32-R47) [[6]](diffhunk://#diff-539ea2e9a7937f550253634ab6548b8c0423e075232a4f33482854bb1ac26ae0R9) [[7]](diffhunk://#diff-539ea2e9a7937f550253634ab6548b8c0423e075232a4f33482854bb1ac26ae0R36-R51)

These changes significantly improve observability and operational insight into the system by providing detailed, backend-aware, and component-specific metrics for all critical paths.