### PR TITLE
fix(subtree-counter): stop infinite republish loop from expired/leaking counters

### DIFF
--- a/internal/block/subtree_worker.go
+++ b/internal/block/subtree_worker.go
@@ -323,14 +323,15 @@ func (s *SubtreeWorkerService) handleMessage(ctx context.Context, msg *sarama.Co
 // decrements the counter so BLOCK_PROCESSED can still fire (with a missing
 // STUMP that arcade will surface as a BUMP build error rather than silent loss).
 //
-// If the counter Decrement on the DLQ path fails, the error is returned to the
-// caller so the consumer redelivers the work item rather than silently acking
-// with a non-decremented counter (F-013). The work has already been published
-// to the DLQ, so on redelivery the next attempt will see AttemptCount past
-// max and DLQ-publish again — that is acceptable until the counter store
-// recovers and Decrement succeeds; BLOCK_PROCESSED is delayed but not
-// silently lost. Operators should treat repeated DLQ-publish-then-Decrement
-// failures as alert-worthy (the loud Error-level log below).
+// On the DLQ branch the counter is decremented BEFORE the DLQ publish. If the
+// decrement fails (counter-store transient hiccup), we return the error so the
+// consumer redelivers the work item — and crucially the DLQ publish has not
+// happened yet, so redelivery does NOT accumulate duplicate DLQ entries while
+// the counter store is degraded (F-013). If the DLQ publish fails after a
+// successful decrement, redelivery will re-decrement (going negative) and
+// re-attempt the DLQ publish; the negative-decrement re-emits BLOCK_PROCESSED
+// which is deduplicated by the receiver, while the DLQ publish either
+// eventually succeeds or surfaces as a sustained loud-error log.
 func (s *SubtreeWorkerService) handleTransientFailure(workMsg *kafka.SubtreeWorkMessage, cause error) error {
 	nextAttempt := workMsg.AttemptCount + 1
 	maxAttempts := s.maxAttempts()
@@ -345,6 +346,20 @@ func (s *SubtreeWorkerService) handleTransientFailure(workMsg *kafka.SubtreeWork
 			"maxAttempts", maxAttempts,
 			"error", cause,
 		)
+		// Decrement FIRST so a counter-store hiccup aborts before we publish to
+		// the DLQ — otherwise every redelivery while the counter store is
+		// degraded would publish another DLQ duplicate.
+		if decErr := s.decrementCounterAndMaybeEmit(workMsg.BlockHash, workMsg.OverrideCallbackURL, workMsg.OverrideCallbackToken); decErr != nil {
+			s.Logger.Error(
+				"ALERT: subtree counter decrement failed on DLQ path; deferring DLQ publish until counter store recovers",
+				"subtreeHash", workMsg.SubtreeHash,
+				"blockHash", workMsg.BlockHash,
+				"subtreeIndex", workMsg.SubtreeIndex,
+				"error", decErr,
+			)
+			return fmt.Errorf("decrementing subtree counter on DLQ path for block %s: %w",
+				workMsg.BlockHash, decErr)
+		}
 		workMsg.AttemptCount = nextAttempt
 		data, encErr := workMsg.Encode()
 		if encErr != nil {
@@ -355,24 +370,6 @@ func (s *SubtreeWorkerService) handleTransientFailure(workMsg *kafka.SubtreeWork
 		}
 		if pubErr := s.dlqProducer.Publish(workMsg.SubtreeHash, data); pubErr != nil {
 			return fmt.Errorf("publishing subtree work message to DLQ: %w", pubErr)
-		}
-		// Counter decrement is required here: the work item is terminally
-		// failed but we still need BLOCK_PROCESSED to fire so arcade isn't
-		// stuck waiting for a STUMP that will never arrive. If the decrement
-		// itself fails (counter-store transient hiccup), surface the error so
-		// the consumer redelivers and we re-attempt; the DLQ publish above
-		// will repeat, but that's preferable to silently acking with the
-		// counter still > 0 and BLOCK_PROCESSED never firing (F-013).
-		if decErr := s.decrementCounterAndMaybeEmit(workMsg.BlockHash, workMsg.OverrideCallbackURL, workMsg.OverrideCallbackToken); decErr != nil {
-			s.Logger.Error(
-				"ALERT: subtree counter decrement failed on DLQ path; BLOCK_PROCESSED delayed until counter store recovers",
-				"subtreeHash", workMsg.SubtreeHash,
-				"blockHash", workMsg.BlockHash,
-				"subtreeIndex", workMsg.SubtreeIndex,
-				"error", decErr,
-			)
-			return fmt.Errorf("decrementing subtree counter on DLQ path for block %s: %w",
-				workMsg.BlockHash, decErr)
 		}
 		return nil
 	}

--- a/internal/block/subtree_worker.go
+++ b/internal/block/subtree_worker.go
@@ -2,6 +2,7 @@ package block
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -429,6 +430,23 @@ func (s *SubtreeWorkerService) decrementCounterAndMaybeEmit(blockHash, overrideU
 	counterKey := SubtreeCounterKey(blockHash, overrideURL)
 	remaining, err := s.subtreeCounter.Decrement(counterKey)
 	if err != nil {
+		if errors.Is(err, store.ErrCounterNotFound) {
+			// The per-block counter is gone (TTL expired before the block
+			// finished). A worker cannot recreate it, so retrying this work
+			// item is futile — that futile retry, repeated across every
+			// remaining subtree, was the unbounded subtree-work republish
+			// loop. Ack the item (return nil) and emit a loud ALERT: the
+			// block must be reprocessed to rebuild its counter and re-emit
+			// BLOCK_PROCESSED. The subtree's STUMP/MINED callbacks have
+			// already been published by this point, so only the
+			// BLOCK_PROCESSED coordination is lost.
+			s.Logger.Error(
+				"ALERT: subtree counter missing (TTL expired); acking work item without retry — block must be reprocessed",
+				"blockHash", blockHash,
+				"counterKey", counterKey,
+			)
+			return nil
+		}
 		s.Logger.Error(
 			"failed to decrement subtree counter",
 			"blockHash", blockHash,

--- a/internal/block/subtree_worker_handle_message_test.go
+++ b/internal/block/subtree_worker_handle_message_test.go
@@ -504,6 +504,42 @@ func TestHandleMessage_HappyPath_DecrementsExactlyOnce(t *testing.T) {
 	}
 }
 
+// TestHandleMessage_CounterNotFound_AcksWithoutRetry verifies that when the
+// per-block subtree counter has expired (Decrement returns
+// store.ErrCounterNotFound), the work item is ack'd (handleMessage returns
+// nil) and is NOT re-published or routed to DLQ. Before the fix a vanished
+// counter was treated as a transient failure, so every remaining subtree work
+// item for a large block re-published itself forever — the unbounded
+// subtree-work republish loop.
+func TestHandleMessage_CounterNotFound_AcksWithoutRetry(t *testing.T) {
+	cbMock := &callbackFailingProducer{}
+	retryMock := &callbackFailingProducer{}
+	dlqMock := &callbackFailingProducer{}
+
+	counter := newCountingSubtreeCounter()
+	counter.decrementErr = store.ErrCounterNotFound
+
+	stumpStore := &stubStumpStore{}
+
+	subtreePayload := buildRawSubtreeBytes(t, 2)
+	server := rawSubtreeServer(subtreePayload)
+	defer server.Close()
+
+	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, 5)
+
+	value := makeWorkMessageBytes(t, "block-gone", "subtree-gone", server.URL, 0)
+	if err := svc.handleMessage(context.Background(), &sarama.ConsumerMessage{Value: value}); err != nil {
+		t.Fatalf("handleMessage with missing counter: expected nil error (ack), got: %v", err)
+	}
+
+	if got := retryMock.sentCount(); got != 0 {
+		t.Errorf("expected zero retry publishes when counter is gone, got %d", got)
+	}
+	if got := dlqMock.sentCount(); got != 0 {
+		t.Errorf("expected zero DLQ publishes when counter is gone, got %d", got)
+	}
+}
+
 // TestHandleMessage_StumpStoreFailure_RetriesAndDoesNotDecrement covers the
 // other half of F-012: a blob-store write failure (not Kafka) during callback
 // publishing must also re-drive via the retry pipeline.

--- a/internal/block/subtree_worker_handle_message_test.go
+++ b/internal/block/subtree_worker_handle_message_test.go
@@ -634,10 +634,10 @@ func TestHandleMessage_DecrementFailureOnSuccessPath_RetriesAndPreservesCount(t 
 
 // TestHandleMessage_DecrementFailureOnDLQPath_ReturnsError covers the harder
 // F-013 case: a callback-publish failure that has reached max attempts (so
-// the work item is DLQ'd) plus a Decrement failure. The DLQ publish itself
-// has already happened, but the Decrement error must surface to the caller
-// so the consumer redelivers — silently acking would leave the per-block
-// counter > 0 forever and BLOCK_PROCESSED would never fire.
+// the work item is DLQ'd) plus a Decrement failure. Decrement now runs
+// BEFORE the DLQ publish, so its failure short-circuits the DLQ publish
+// entirely — the error surfaces, the consumer redelivers, and no duplicate
+// DLQ entries pile up while the counter store is degraded.
 func TestHandleMessage_DecrementFailureOnDLQPath_ReturnsError(t *testing.T) {
 	// Force DLQ path: callback publish always fails, AttemptCount = max-1.
 	cbMock := &callbackFailingProducer{failAll: true, failErr: errors.New("kafka unavailable")}
@@ -665,10 +665,11 @@ func TestHandleMessage_DecrementFailureOnDLQPath_ReturnsError(t *testing.T) {
 		t.Fatalf("expected non-nil error when Decrement fails on DLQ path so consumer redelivers, got nil")
 	}
 
-	// DLQ was published BEFORE the decrement attempt — that ordering matches
-	// PR #77's terminal-failure semantics.
-	if got := dlqMock.sentCount(); got != 1 {
-		t.Errorf("expected exactly 1 DLQ publish, got %d", got)
+	// DLQ publish must NOT have happened — Decrement failed first, and
+	// publishing anyway would produce a duplicate DLQ entry on every
+	// redelivery while the counter store stays degraded.
+	if got := dlqMock.sentCount(); got != 0 {
+		t.Errorf("expected zero DLQ publishes when Decrement fails first, got %d", got)
 	}
 	if got := retryMock.sentCount(); got != 0 {
 		t.Errorf("expected zero retry publishes at max attempts, got %d", got)
@@ -964,12 +965,14 @@ func TestHandleMessage_BlockProcessedEmitRetry_ReEmitsOnRedelivery(t *testing.T)
 
 // TestHandleMessage_BlockProcessedEmitFailure_AtMaxAttempts_DLQPathReturnsError
 // covers the worst-case F-014 path: a STUMP-publish failure forces DLQ, and
-// the DLQ-path decrement-and-emit hits the F-014 emit failure too. The DLQ
-// publish has already happened, but the emit-failure is propagated so the
-// consumer redelivers — silently acking would leave the registered endpoint
-// without BLOCK_PROCESSED forever. This matches the F-013 DLQ-path
-// Decrement-failure semantics from PR #88: prefer a duplicate DLQ publish
-// over silently losing the BLOCK_PROCESSED notification.
+// the DLQ-path decrement-and-emit hits the F-014 emit failure too. Decrement
+// runs BEFORE the DLQ publish, so an emit-failure (which is surfaced from
+// decrementCounterAndMaybeEmit) short-circuits the DLQ publish entirely.
+// The error propagates so the consumer redelivers; on redelivery the counter
+// goes negative, emit is re-attempted, and receiver-side dedup absorbs any
+// duplicate. The DLQ is never written to during a sustained Kafka outage,
+// which is strictly better than the previous behavior of writing a duplicate
+// DLQ entry every redelivery.
 func TestHandleMessage_BlockProcessedEmitFailure_AtMaxAttempts_DLQPathReturnsError(t *testing.T) {
 	// Producer fails ALL callback publishes — STUMP fails (forcing DLQ) AND
 	// BLOCK_PROCESSED fails (forcing the F-014 path on the DLQ-decrement).
@@ -999,13 +1002,15 @@ func TestHandleMessage_BlockProcessedEmitFailure_AtMaxAttempts_DLQPathReturnsErr
 		t.Fatalf("expected non-nil error so consumer redelivers when emit fails on DLQ path, got nil")
 	}
 
-	if got := dlqMock.sentCount(); got != 1 {
-		t.Errorf("expected exactly 1 DLQ publish at max attempts, got %d", got)
+	// DLQ publish must NOT have happened — decrement-and-emit failed first.
+	if got := dlqMock.sentCount(); got != 0 {
+		t.Errorf("expected zero DLQ publishes when emit fails first, got %d", got)
 	}
 	if got := retryMock.sentCount(); got != 0 {
 		t.Errorf("expected zero retry publishes at max attempts, got %d", got)
 	}
-	// Counter Decrement was attempted exactly once on the DLQ path.
+	// Counter Decrement was attempted (and succeeded — emit is what failed)
+	// exactly once.
 	if got := counter.decrementCount(); got != 1 {
 		t.Errorf("expected counter Decrement called once on DLQ path, got %d", got)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -375,7 +375,12 @@ func registerDefaults(v *viper.Viper) {
 	v.SetDefault("aerospike.callbackurlregistry", "merkle_callback_urls")
 	v.SetDefault("aerospike.callbackurlregistryttlsec", 7*24*60*60)
 	v.SetDefault("aerospike.subtreecounterset", "merkle_subtree_counters")
-	v.SetDefault("aerospike.subtreecounterttlsec", 600)
+	// 1h. With Decrement re-stamping the TTL on every subtree, this is an
+	// inactivity window, not a hard block-processing deadline — it only fires
+	// if a block makes zero subtree progress for a full hour. The former 600s
+	// default expired mid-flight on large (tens-of-thousands-of-subtree)
+	// blocks even while they were actively progressing.
+	v.SetDefault("aerospike.subtreecounterttlsec", 3600)
 	v.SetDefault("aerospike.callbackaccumulatorset", "merkle_callback_accum")
 	v.SetDefault("aerospike.callbackaccumulatorttlsec", 600)
 	v.SetDefault("aerospike.datahubregistry", "merkle_datahub_urls")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -662,6 +662,15 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("invalid store.backend %q: must be %q or %q", cfg.Store.Backend, BackendAerospike, BackendSQL)
 	}
 
+	// SubtreeCounterTTLSec must be strictly positive. Zero or negative values
+	// silently produce dangerous Aerospike record TTLs: 0 means "use namespace
+	// default" (may be never-expire), and a negative int truncated to uint32
+	// becomes the Aerospike never-expire sentinel — either way the counter
+	// becomes a permanent record that the sweeper never reclaims.
+	if cfg.Aerospike.SubtreeCounterTTLSec <= 0 {
+		return nil, fmt.Errorf("invalid aerospike.subtreeCounterTTLSec %d: must be > 0", cfg.Aerospike.SubtreeCounterTTLSec)
+	}
+
 	return &cfg, nil
 }
 

--- a/internal/config/store_test.go
+++ b/internal/config/store_test.go
@@ -107,3 +107,20 @@ func TestStoreBackend_EnvOverride(t *testing.T) {
 		t.Fatalf("dsn = %q, want postgres://x", cfg.Store.SQL.DSN)
 	}
 }
+
+// Zero or negative subtreeCounterTTLSec silently produce dangerous Aerospike
+// record TTLs (namespace default / never-expire), turning the counter into a
+// permanent record. Load() must reject those at startup.
+func TestSubtreeCounterTTLSec_RejectsZero(t *testing.T) {
+	_, err := loadWith(t, map[string]string{"AEROSPIKE_SUBTREE_COUNTER_TTL_SEC": "0"}, "")
+	if err == nil {
+		t.Fatal("expected error for subtreeCounterTTLSec=0, got nil")
+	}
+}
+
+func TestSubtreeCounterTTLSec_RejectsNegative(t *testing.T) {
+	_, err := loadWith(t, map[string]string{"AEROSPIKE_SUBTREE_COUNTER_TTL_SEC": "-1"}, "")
+	if err == nil {
+		t.Fatal("expected error for subtreeCounterTTLSec=-1, got nil")
+	}
+}

--- a/internal/store/sql/sql_test.go
+++ b/internal/store/sql/sql_test.go
@@ -635,22 +635,22 @@ func TestSubtreeCounter_InitAndDecrement(t *testing.T) {
 }
 
 // TestSubtreeCounter_DecrementMissingRow verifies that Decrement returns
-// (0, nil) — not sql.ErrNoRows — when the counter row doesn't exist. This is
-// the production scenario where an Init never ran (or the sweeper purged the
-// row before all subtrees finished). Propagating ErrNoRows from this path
-// wedges the F-013 DLQ branch in subtree_worker.go: that branch republishes
-// the work item to the DLQ topic and then calls Decrement to drive
-// BLOCK_PROCESSED, but if Decrement keeps failing the message is never
-// ack'd and the partition gets stuck in an infinite redelivery loop.
-// Treating the missing row as "already drained" lets the DLQ branch ack and
-// the partition advance.
+// (0, storepkg.ErrCounterNotFound) — not sql.ErrNoRows, and not (0, nil) —
+// when the counter row doesn't exist. The row may legitimately be absent
+// because Init never ran (e.g. process crash between Init and message
+// publish), or the sweeper purged an expired counter. Returning a typed
+// "not found" error lets the worker ack the item without emitting a
+// premature BLOCK_PROCESSED while other subtrees of the same block may
+// still be in flight; the Aerospike backend behaves the same way, and the
+// unbounded-redelivery-loop concern that previously justified (0, nil) was
+// resolved when the worker started ack'ing on ErrCounterNotFound.
 func TestSubtreeCounter_DecrementMissingRow(t *testing.T) {
 	db, d := newTestDB(t)
 	s := newSubtreeCounter(db, d, 600)
 
 	got, err := s.Decrement("nonexistent-block")
-	if err != nil {
-		t.Fatalf("Decrement on missing row should not return error, got: %v", err)
+	if !errors.Is(err, storepkg.ErrCounterNotFound) {
+		t.Fatalf("Decrement on missing row = (%d, %v), want (0, ErrCounterNotFound)", got, err)
 	}
 	if got != 0 {
 		t.Fatalf("Decrement on missing row = %d, want 0", got)
@@ -665,8 +665,8 @@ func TestSubtreeCounter_DecrementMissingRow(t *testing.T) {
 		t.Fatalf("Decrement on existing row: %v", decErr)
 	}
 	got, err = s.Decrement("still-nonexistent")
-	if err != nil {
-		t.Fatalf("Decrement on missing row should not return error, got: %v", err)
+	if !errors.Is(err, storepkg.ErrCounterNotFound) {
+		t.Fatalf("Decrement on missing row = (%d, %v), want (0, ErrCounterNotFound)", got, err)
 	}
 	if got != 0 {
 		t.Fatalf("Decrement on missing row = %d, want 0", got)

--- a/internal/store/sql/sql_test.go
+++ b/internal/store/sql/sql_test.go
@@ -676,6 +676,48 @@ func TestSubtreeCounter_DecrementMissingRow(t *testing.T) {
 	}
 }
 
+// TestSubtreeCounter_DecrementRestampsTTL verifies that Decrement refreshes
+// expires_at on every call, matching the Aerospike backend's inactivity-window
+// semantics. Without this, the Init-time TTL is a hard deadline on the whole
+// block: a block that drains slower than ttlSec would have its counter swept
+// mid-flight, after which Decrement maps the missing row to ErrCounterNotFound
+// and the worker acks the remaining items with no BLOCK_PROCESSED.
+func TestSubtreeCounter_DecrementRestampsTTL(t *testing.T) {
+	db, d := newTestDB(t)
+	s := newSubtreeCounter(db, d, 600)
+
+	if err := s.Init("blk", 3); err != nil {
+		t.Fatal(err)
+	}
+
+	// Backdate the row's expiry firmly into the past — the state the sweeper
+	// would see for a block that has outlived its Init TTL.
+	if _, err := db.ExecContext(
+		context.Background(),
+		fmt.Sprintf("UPDATE subtree_counters SET expires_at = %s WHERE block_hash = %s", d.intervalSeconds(-3600), d.placeholder(1)),
+		"blk",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := s.Decrement("blk"); err != nil {
+		t.Fatal(err)
+	}
+
+	// After Decrement the expiry must be back in the future.
+	var future bool
+	if err := db.QueryRowContext(
+		context.Background(),
+		fmt.Sprintf("SELECT expires_at > %s FROM subtree_counters WHERE block_hash = %s", d.now, d.placeholder(1)),
+		"blk",
+	).Scan(&future); err != nil {
+		t.Fatal(err)
+	}
+	if !future {
+		t.Fatal("Decrement did not re-stamp expires_at into the future")
+	}
+}
+
 func TestSubtreeCounter_ConcurrentDecrement(t *testing.T) {
 	db, d := newTestDB(t)
 	s := newSubtreeCounter(db, d, 600)

--- a/internal/store/sql/subtree_counter.go
+++ b/internal/store/sql/subtree_counter.go
@@ -59,6 +59,10 @@ func (s *subtreeCounter) Init(blockHash string, count int) error {
 //     opened with the `_txlock=immediate` URL parameter, and the rest of
 //     the codebase opens connections without it.
 //
+// TTL: like the Aerospike backend, Decrement re-stamps expires_at on every
+// call so the counter survives ttlSec of *inactivity* rather than expiring
+// ttlSec after Init (which would be a hard deadline on the whole block).
+//
 // Missing rows: if the counter row does not exist (sql.ErrNoRows), Decrement
 // returns (0, storepkg.ErrCounterNotFound) — matching the Aerospike backend.
 // The row may legitimately be absent because the sweeper purged an expired
@@ -78,9 +82,16 @@ func (s *subtreeCounter) Decrement(blockHash string) (int, error) {
 	defer cancel()
 
 	if isPostgres(s.d) {
+		// Re-stamp expires_at on every decrement so the counter expires only
+		// after ttlSec of *inactivity*, mirroring the Aerospike backend. The
+		// value written by Init is otherwise a hard deadline on the whole
+		// block: a block that keeps making subtree progress longer than ttlSec
+		// would have its counter swept mid-flight, after which Decrement maps
+		// the missing row to ErrCounterNotFound and the worker acks the
+		// remaining items without ever emitting BLOCK_PROCESSED.
 		q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
-			"UPDATE subtree_counters SET remaining = remaining - 1 WHERE block_hash = %s RETURNING remaining",
-			s.d.placeholder(1),
+			"UPDATE subtree_counters SET remaining = remaining - 1, expires_at = %s WHERE block_hash = %s RETURNING remaining",
+			s.d.intervalSeconds(s.ttlSec), s.d.placeholder(1),
 		)
 		var remaining int
 		if err := s.db.QueryRowContext(ctx, q, blockHash).Scan(&remaining); err != nil {
@@ -121,9 +132,12 @@ func (s *subtreeCounter) Decrement(blockHash string) (int, error) {
 		return 0, err
 	}
 	remaining--
+	// Re-stamp expires_at alongside remaining (see the Postgres branch above):
+	// keeps the counter alive for ttlSec of inactivity rather than ttlSec
+	// after Init, so a slow-draining block isn't swept mid-flight.
 	qUp := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
-		"UPDATE subtree_counters SET remaining = %s WHERE block_hash = %s",
-		s.d.placeholder(1), s.d.placeholder(2),
+		"UPDATE subtree_counters SET remaining = %s, expires_at = %s WHERE block_hash = %s",
+		s.d.placeholder(1), s.d.intervalSeconds(s.ttlSec), s.d.placeholder(2),
 	)
 	if _, err := conn.ExecContext(ctx, qUp, remaining, blockHash); err != nil {
 		return 0, err

--- a/internal/store/sql/subtree_counter.go
+++ b/internal/store/sql/subtree_counter.go
@@ -60,16 +60,19 @@ func (s *subtreeCounter) Init(blockHash string, count int) error {
 //     the codebase opens connections without it.
 //
 // Missing rows: if the counter row does not exist (sql.ErrNoRows), Decrement
-// returns (0, nil) rather than propagating the error. The row may legitimately
-// be absent because the sweeper purged an expired counter, an Init never ran
-// (e.g. process crash between Init and message publish), or the row was
-// already consumed by an earlier successful Decrement that lost its return
-// value. Treating "missing" as "already drained" lets the F-013 DLQ path ack
-// its work item and lets BLOCK_PROCESSED fire; the alternative (propagate
-// ErrNoRows forever) wedges the partition on a redelivery loop because the
-// DLQ-path Decrement also fails, so the message is never ack'd. Receiver-side
-// dedup at the callback delivery service deduplicates any extra
-// BLOCK_PROCESSED that this might trigger, keyed by (blockHash, callbackURL).
+// returns (0, storepkg.ErrCounterNotFound) — matching the Aerospike backend.
+// The row may legitimately be absent because the sweeper purged an expired
+// counter, an Init never ran (e.g. process crash between Init and message
+// publish), or the row was already consumed by an earlier successful
+// Decrement. The worker handles ErrCounterNotFound by acking without emitting
+// BLOCK_PROCESSED and logging an ALERT for operator reprocess. Returning
+// (0, nil) here was the previous behavior — it triggered a premature
+// BLOCK_PROCESSED emission via the worker's `remaining <= 0` branch while
+// other subtrees of the same block were still in flight (and on the
+// Aerospike backend the same condition correctly logged an ALERT and
+// suppressed the emit). The unbounded-redelivery-loop concern that justified
+// the old behavior was eliminated when the worker started ack'ing on
+// ErrCounterNotFound — see fix/subtree-counter-ttl-leak.
 func (s *subtreeCounter) Decrement(blockHash string) (int, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -82,7 +85,7 @@ func (s *subtreeCounter) Decrement(blockHash string) (int, error) {
 		var remaining int
 		if err := s.db.QueryRowContext(ctx, q, blockHash).Scan(&remaining); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				return 0, nil
+				return 0, storepkg.ErrCounterNotFound
 			}
 			return 0, err
 		}
@@ -113,7 +116,7 @@ func (s *subtreeCounter) Decrement(blockHash string) (int, error) {
 	qSel := fmt.Sprintf("SELECT remaining FROM subtree_counters WHERE block_hash = %s", s.d.placeholder(1)) //nolint:gosec // placeholder from internal function
 	if err := conn.QueryRowContext(ctx, qSel, blockHash).Scan(&remaining); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return 0, nil
+			return 0, storepkg.ErrCounterNotFound
 		}
 		return 0, err
 	}

--- a/internal/store/subtree_counter.go
+++ b/internal/store/subtree_counter.go
@@ -1,13 +1,25 @@
 package store
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 
 	as "github.com/aerospike/aerospike-client-go/v7"
+	astypes "github.com/aerospike/aerospike-client-go/v7/types"
 )
 
 const subtreeCounterBin = "remaining"
+
+// ErrCounterNotFound is returned by Decrement when the per-block subtree
+// counter record is absent. The usual cause is TTL expiry: a large block whose
+// processing outlives the counter's TTL loses the record mid-flight. A subtree
+// worker cannot recreate the counter (Decrement is UPDATE_ONLY), so retrying a
+// vanished counter is futile — callers must treat this as terminal for the
+// work item and rely on a fresh block reprocess to rebuild the counter.
+// Retrying it forever was the cause of the unbounded subtree-work republish
+// loop.
+var ErrCounterNotFound = errors.New("subtree counter not found")
 
 // aerospikeSubtreeCounter is the Aerospike-backed SubtreeCounterStore
 // implementation. Used to coordinate BLOCK_PROCESSED emission: the block
@@ -63,9 +75,21 @@ func (s *aerospikeSubtreeCounter) Decrement(blockHash string) (remaining int, er
 
 	wp := s.client.WritePolicy(s.maxRetries, s.retryBaseMs)
 	wp.RecordExistsAction = as.UPDATE_ONLY
+	// Re-stamp the TTL on every decrement so the counter expires only after
+	// ttlSec of *inactivity*, not ttlSec after Init. Init's TTL would otherwise
+	// be a hard deadline on the whole block: a block with tens of thousands of
+	// subtrees can take far longer to drain than ttlSec, so the counter would
+	// expire mid-flight and every remaining worker would fail with
+	// KEY_NOT_FOUND. Re-stamping keeps the counter alive as long as subtrees
+	// keep being processed.
+	wp.Expiration = uint32(s.ttlSec) //nolint:gosec // ttlSec is config-validated and fits uint32
 
 	record, err := s.client.Client().Operate(wp, key, as.AddOp(as.NewBin(subtreeCounterBin, -1)), as.GetOp())
 	if err != nil {
+		var asErr as.Error
+		if errors.As(err, &asErr) && asErr.Matches(astypes.KEY_NOT_FOUND_ERROR) {
+			return 0, ErrCounterNotFound
+		}
 		return 0, fmt.Errorf("failed to decrement subtree counter: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

Fixes a class of failures around the per-block **subtree counter** that could leave the subtree-work topic growing without bound and `BLOCK_PROCESSED` never firing. Surfaced on a block with tens of thousands of subtrees.

The counter (Aerospike set `merkle_subtree_counters`) was written with a TTL only at `Init`. A large block takes far longer to drain than the 600s default, so the record expired mid-flight; every remaining subtree worker then failed `Decrement` with `KEY_NOT_FOUND`, which was classified as transient and **re-published the work item forever**.

## Changes

Four focused commits, each a distinct concern:

1. **`re-stamp TTL on decrement; stop infinite republish loop`** — `Decrement` now re-stamps the expiration on every call, making the TTL an *inactivity* window rather than a hard deadline on the whole block. A missing record is surfaced as a typed `store.ErrCounterNotFound` and treated as terminal (ack with a loud ALERT instead of re-publishing, since a worker can't recreate the counter — `Decrement` is `UPDATE_ONLY`). Raises the `aerospike.subtreecounterttlsec` default 600 → 3600.

2. **`align SQL backend to return ErrCounterNotFound on missing row`** — the SQL backend returned `(0, nil)` on a missing row while Aerospike returned `ErrCounterNotFound`. The `(0, nil)` path fed the `remaining <= 0` branch and fired `BLOCK_PROCESSED` prematurely. With the worker now ack'ing on `ErrCounterNotFound`, both backends behave identically.

3. **`reject zero or negative subtreeCounterTTLSec at startup`** — a zero or negative value maps to Aerospike's never-expire sentinel, making the counter a permanent leaking record the sweeper never reclaims. Fail loud at `Load()`.

4. **`decrement counter before DLQ publish on terminal failure`** — the DLQ branch published to the DLQ *before* decrementing; if the counter store was degraded, the redelivery loop produced a duplicate DLQ entry on every retry. Decrement now runs first and aborts before touching the DLQ on failure.

## Testing

- `go build ./...` clean
- `go test ./internal/block/... ./internal/config/... ./internal/store/... ./internal/store/sql/...` all pass
- Adds `TestHandleMessage_CounterNotFound_AcksWithoutRetry` and config-validation tests
