### PR TITLE
Enhance block_processed message with extra data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/IBM/sarama v1.50.1
 	github.com/aerospike/aerospike-client-go/v7 v7.10.2
 	github.com/bsv-blockchain/go-bt/v2 v2.6.5
+	github.com/bsv-blockchain/go-sdk v1.2.24
 	github.com/bsv-blockchain/go-subtree v1.4.3
 	github.com/bsv-blockchain/go-teranode-p2p-client v0.2.6
 	github.com/bsv-blockchain/teranode v0.15.1
@@ -57,7 +58,6 @@ require (
 	github.com/bsv-blockchain/go-lockfree-queue v1.2.0 // indirect
 	github.com/bsv-blockchain/go-p2p-message-bus v0.1.19 // indirect
 	github.com/bsv-blockchain/go-safe-conversion v1.2.0 // indirect
-	github.com/bsv-blockchain/go-sdk v1.2.24 // indirect
 	github.com/bsv-blockchain/go-tx-map v1.3.8 // indirect
 	github.com/bsv-blockchain/go-wire v1.2.7 // indirect
 	github.com/bsv-blockchain/testcontainers-aerospike-go v0.3.7 // indirect

--- a/internal/block/coinbase_bump.go
+++ b/internal/block/coinbase_bump.go
@@ -1,0 +1,198 @@
+package block
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
+
+	"github.com/bsv-blockchain/merkle-service/internal/datahub"
+	"github.com/bsv-blockchain/merkle-service/internal/kafka"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
+	"github.com/bsv-blockchain/merkle-service/internal/store"
+	"github.com/bsv-blockchain/merkle-service/internal/stump"
+)
+
+// merkleRootFromHeader extracts the block header merkle root — bytes 36..68 of
+// the 80-byte block header — from a hex-encoded header. Those bytes are stored
+// in internal (little-endian) byte order; the returned chainhash.Hash.String()
+// yields the conventional display-order hex used on the wire.
+func merkleRootFromHeader(headerHex string) (*chainhash.Hash, error) {
+	raw, err := hex.DecodeString(headerHex)
+	if err != nil {
+		return nil, fmt.Errorf("decode header hex: %w", err)
+	}
+	if len(raw) < 80 {
+		return nil, fmt.Errorf("header too short: %d bytes (want >= 80)", len(raw))
+	}
+	return chainhash.NewHash(raw[36:68])
+}
+
+// coinbaseTxIDFromHex computes the coinbase transaction id (32-byte internal
+// order) as the double-SHA256 of the raw coinbase transaction bytes.
+func coinbaseTxIDFromHex(coinbaseHex string) ([]byte, error) {
+	raw, err := hex.DecodeString(coinbaseHex)
+	if err != nil {
+		return nil, fmt.Errorf("decode coinbase hex: %w", err)
+	}
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("empty coinbase transaction")
+	}
+	return chainhash.DoubleHashB(raw), nil
+}
+
+// buildCoinbaseSiblings returns the merkle-path sibling hashes proving the
+// coinbase transaction (subtree 0, leaf 0) up to the block merkle root:
+// subtree-0 internal siblings first (level 0 = leaf level), then the
+// across-subtree (top tree, leaves = subtree roots) siblings. It delegates the
+// actual hashing to go-subtree so the zero-pad-to-power-of-two and
+// duplicate-self-on-odd rules match the canonical block merkle root exactly.
+//
+// Because the coinbase sits at offset 0 it climbs the left spine, so every
+// returned sibling is the offset-1 node at its level. subtreeRoots are internal
+// byte order.
+func buildCoinbaseSiblings(subtree0Nodes []subtreepkg.Node, subtreeRoots []chainhash.Hash) ([][]byte, error) {
+	if len(subtree0Nodes) == 0 {
+		return nil, fmt.Errorf("subtree 0 has no nodes")
+	}
+
+	sub0 := &subtreepkg.Subtree{Nodes: subtree0Nodes}
+	sub0Proof, err := sub0.GetMerkleProof(0)
+	if err != nil {
+		return nil, fmt.Errorf("subtree-0 merkle proof: %w", err)
+	}
+
+	siblings := make([][]byte, 0, len(sub0Proof)+len(subtreeRoots))
+	for _, h := range sub0Proof {
+		siblings = append(siblings, append([]byte(nil), h[:]...))
+	}
+
+	// The across-subtree path only exists when the block has more than one
+	// subtree; a single-subtree block's root is the (corrected) subtree-0 root.
+	if len(subtreeRoots) > 1 {
+		topNodes := make([]subtreepkg.Node, len(subtreeRoots))
+		for i, r := range subtreeRoots {
+			topNodes[i] = subtreepkg.Node{Hash: r}
+		}
+		top := &subtreepkg.Subtree{Nodes: topNodes}
+		topProof, err := top.GetMerkleProof(0)
+		if err != nil {
+			return nil, fmt.Errorf("top-tree merkle proof: %w", err)
+		}
+		for _, h := range topProof {
+			siblings = append(siblings, append([]byte(nil), h[:]...))
+		}
+	}
+
+	return siblings, nil
+}
+
+// buildBlockProcessedData assembles the BlockProcessedData published on
+// BLOCK_PROCESSED. It is best-effort: any step that fails degrades gracefully
+// to the richest data gathered so far (a consumer that's missing a field falls
+// back to a datahub), and it never returns nil for a block with subtrees. The
+// merkle root and coinbase tx come from the P2P BlockMessage (no datahub); the
+// subtree list comes from the already-fetched metadata; only the coinbase
+// BUMP requires fetching subtree 0.
+func (p *Processor) buildBlockProcessedData(
+	ctx context.Context,
+	blockMsg *kafka.BlockMessage,
+	meta *datahub.BlockMetadata,
+	resolvedURL string,
+) *store.BlockProcessedData {
+	data := &store.BlockProcessedData{
+		SubtreeCount:  len(meta.Subtrees),
+		SubtreeHashes: meta.Subtrees,
+	}
+
+	merkleRoot, err := merkleRootFromHeader(blockMsg.Header)
+	if err != nil {
+		// Without the merkle root a consumer can't validate against the canonical
+		// chain, but the subtree list is still useful. Log and carry on.
+		p.Logger.Warn("BLOCK_PROCESSED: could not extract merkle root from header",
+			"blockHash", blockMsg.Hash, "error", err)
+		return data
+	}
+	data.MerkleRoot = merkleRoot.String()
+
+	// Everything below builds the coinbase BUMP. Any failure leaves the merkle
+	// root + subtree list in place and drops only the coinbase BUMP.
+	if len(meta.Subtrees) == 0 {
+		return data // coinbase-only block: no subtrees, no coinbase BUMP needed.
+	}
+
+	cbTxID, err := coinbaseTxIDFromHex(blockMsg.Coinbase)
+	if err != nil {
+		p.Logger.Warn("BLOCK_PROCESSED: could not compute coinbase txid; omitting coinbase BUMP",
+			"blockHash", blockMsg.Hash, "error", err)
+		return data
+	}
+
+	roots := make([]chainhash.Hash, len(meta.Subtrees))
+	for i, s := range meta.Subtrees {
+		h, hErr := chainhash.NewHashFromStr(s)
+		if hErr != nil {
+			p.Logger.Warn("BLOCK_PROCESSED: bad subtree hash; omitting coinbase BUMP",
+				"blockHash", blockMsg.Hash, "subtreeHash", s, "error", hErr)
+			return data
+		}
+		roots[i] = *h
+	}
+
+	// Fetch subtree 0's contents (the coinbase's subtree). Store it so the
+	// subtree worker doesn't re-fetch it later.
+	raw, err := p.dataHubClient.FetchSubtreeRaw(ctx, resolvedURL, meta.Subtrees[0])
+	if err != nil {
+		p.Logger.Warn("BLOCK_PROCESSED: could not fetch subtree 0; omitting coinbase BUMP",
+			"blockHash", blockMsg.Hash, "error", err)
+		return data
+	}
+	if p.subtreeStore != nil {
+		if sErr := p.subtreeStore.StoreSubtree(meta.Subtrees[0], raw, uint64(meta.Height)); sErr != nil {
+			p.Logger.Debug("BLOCK_PROCESSED: failed to cache subtree 0", "error", sErr)
+		}
+	}
+	nodes, err := datahub.ParseRawNodes(raw)
+	if err != nil {
+		p.Logger.Warn("BLOCK_PROCESSED: could not parse subtree 0; omitting coinbase BUMP",
+			"blockHash", blockMsg.Hash, "error", err)
+		return data
+	}
+
+	siblings, err := buildCoinbaseSiblings(nodes, roots)
+	if err != nil {
+		p.Logger.Warn("BLOCK_PROCESSED: could not build coinbase siblings; omitting coinbase BUMP",
+			"blockHash", blockMsg.Hash, "error", err)
+		return data
+	}
+
+	// Self-validate: folding the real coinbase up the siblings must reproduce
+	// the canonical header merkle root. Publishing a coinbase BUMP that fails
+	// its own root check would poison the consumer — refuse and let it fall
+	// back to a datahub.
+	computed := stump.CoinbaseRootFromSiblings(cbTxID, siblings)
+	if !bytes.Equal(computed, merkleRoot[:]) {
+		computedHash, _ := chainhash.NewHash(computed)
+		p.Logger.Warn("BLOCK_PROCESSED: coinbase BUMP self-validation failed; omitting coinbase BUMP",
+			"blockHash", blockMsg.Hash,
+			"computedRoot", hashString(computedHash),
+			"headerRoot", merkleRoot.String())
+		metrics.CoinbaseBumpValidationFailures.Inc()
+		return data
+	}
+
+	data.CoinbaseBUMP = hex.EncodeToString(stump.EncodeCoinbaseBUMP(uint64(meta.Height), cbTxID, siblings))
+	return data
+}
+
+// hashString renders a chainhash pointer that may be nil (NewHash only errors
+// on a wrong length, but guard anyway) for log output.
+func hashString(h *chainhash.Hash) string {
+	if h == nil {
+		return ""
+	}
+	return h.String()
+}

--- a/internal/block/coinbase_bump_test.go
+++ b/internal/block/coinbase_bump_test.go
@@ -32,6 +32,7 @@ func rootOf(t *testing.T, nodes []subtreepkg.Node) chainhash.Hash {
 	r := (&subtreepkg.Subtree{Nodes: nodes}).RootHash()
 	if r == nil {
 		t.Fatal("nil root hash")
+		return chainhash.Hash{} // unreachable after Fatal; guards the deref below
 	}
 	return *r
 }

--- a/internal/block/coinbase_bump_test.go
+++ b/internal/block/coinbase_bump_test.go
@@ -1,0 +1,172 @@
+package block
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	sdkchainhash "github.com/bsv-blockchain/go-sdk/chainhash"
+	sdktx "github.com/bsv-blockchain/go-sdk/transaction"
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
+
+	"github.com/bsv-blockchain/merkle-service/internal/stump"
+)
+
+// testHash returns a deterministic 32-byte hash for a seed, used to fabricate
+// subtree leaves and the coinbase txid.
+func testHash(seed uint64) chainhash.Hash {
+	var b [8]byte
+	binary.LittleEndian.PutUint64(b[:], seed)
+	sum := sha256.Sum256(b[:])
+	var h chainhash.Hash
+	copy(h[:], sum[:])
+	return h
+}
+
+func rootOf(t *testing.T, nodes []subtreepkg.Node) chainhash.Hash {
+	t.Helper()
+	r := (&subtreepkg.Subtree{Nodes: nodes}).RootHash()
+	if r == nil {
+		t.Fatal("nil root hash")
+	}
+	return *r
+}
+
+// TestBuildCoinbaseBUMP_FoldsToHeaderMerkleRoot is the core correctness check:
+// the coinbase BUMP merkle-service builds must fold the real coinbase txid up
+// to the canonical block merkle root, even though the stored subtree-0 root and
+// the published subtree hashes are computed against the coinbase placeholder.
+// It also confirms the encoded BUMP parses with go-sdk (arcade's parser) and
+// computes the same root.
+func TestBuildCoinbaseBUMP_FoldsToHeaderMerkleRoot(t *testing.T) {
+	const placeholderSeed = 0 // subtree-0 leaf 0 placeholder (zero-ish but deterministic)
+	cases := []struct {
+		numSubtrees int
+		leavesPer   int
+	}{
+		{1, 4},
+		{2, 4},
+		{4, 1},  // each subtree is a single leaf
+		{3, 8},  // non-power-of-two subtree count
+		{16, 8}, // mirrors the incident block (16 subtrees)
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("subtrees=%d_leaves=%d", tc.numSubtrees, tc.leavesPer), func(t *testing.T) {
+			realCoinbase := testHash(999_999)
+			placeholder := testHash(placeholderSeed)
+
+			// Build every subtree's leaves. Subtree 0, leaf 0 is the coinbase
+			// PLACEHOLDER (this is what the datahub/subtree store actually holds).
+			subtreeNodes := make([][]subtreepkg.Node, tc.numSubtrees)
+			for i := 0; i < tc.numSubtrees; i++ {
+				nodes := make([]subtreepkg.Node, tc.leavesPer)
+				for j := 0; j < tc.leavesPer; j++ {
+					nodes[j] = subtreepkg.Node{Hash: testHash(uint64(i*1000 + j + 1))}
+				}
+				if i == 0 {
+					nodes[0] = subtreepkg.Node{Hash: placeholder}
+				}
+				subtreeNodes[i] = nodes
+			}
+
+			// Placeholder-based subtree roots — what merkle-service publishes as
+			// SubtreeHashes.
+			placeholderRoots := make([]chainhash.Hash, tc.numSubtrees)
+			for i := range subtreeNodes {
+				placeholderRoots[i] = rootOf(t, subtreeNodes[i])
+			}
+
+			// Canonical (header) merkle root: recompute with the REAL coinbase at
+			// subtree-0 leaf 0.
+			realSub0 := append([]subtreepkg.Node(nil), subtreeNodes[0]...)
+			realSub0[0] = subtreepkg.Node{Hash: realCoinbase}
+			realSub0Root := rootOf(t, realSub0)
+			var headerRoot chainhash.Hash
+			if tc.numSubtrees == 1 {
+				headerRoot = realSub0Root
+			} else {
+				topNodes := make([]subtreepkg.Node, tc.numSubtrees)
+				topNodes[0] = subtreepkg.Node{Hash: realSub0Root}
+				for i := 1; i < tc.numSubtrees; i++ {
+					topNodes[i] = subtreepkg.Node{Hash: placeholderRoots[i]}
+				}
+				headerRoot = rootOf(t, topNodes)
+			}
+
+			// Build the coinbase siblings from the PLACEHOLDER-based inputs (what
+			// the producer actually has).
+			siblings, err := buildCoinbaseSiblings(subtreeNodes[0], placeholderRoots)
+			if err != nil {
+				t.Fatalf("buildCoinbaseSiblings: %v", err)
+			}
+
+			// Folding the real coinbase up the siblings must reproduce the header
+			// merkle root.
+			computed := stump.CoinbaseRootFromSiblings(realCoinbase[:], siblings)
+			if !bytes.Equal(computed, headerRoot[:]) {
+				gotHash, _ := chainhash.NewHash(computed)
+				t.Fatalf("folded root = %s, want header root %s", gotHash, headerRoot)
+			}
+
+			// The encoded BUMP must parse with go-sdk (arcade's parser) and
+			// ComputeRoot to the same value.
+			encoded := stump.EncodeCoinbaseBUMP(123, realCoinbase[:], siblings)
+			mp, err := sdktx.NewMerklePathFromBinary(encoded)
+			if err != nil {
+				t.Fatalf("go-sdk NewMerklePathFromBinary: %v", err)
+			}
+			sdkCoinbase, err := sdkchainhash.NewHash(realCoinbase[:])
+			if err != nil {
+				t.Fatalf("sdk coinbase hash: %v", err)
+			}
+			gotRoot, err := mp.ComputeRoot(sdkCoinbase)
+			if err != nil {
+				t.Fatalf("go-sdk ComputeRoot: %v", err)
+			}
+			if !bytes.Equal(gotRoot[:], headerRoot[:]) {
+				t.Fatalf("go-sdk computed root = %s, want %s", gotRoot, &headerRoot)
+			}
+		})
+	}
+}
+
+func TestMerkleRootFromHeader(t *testing.T) {
+	// 80-byte header: version(4) prev(32) merkleRoot(32) time(4) bits(4) nonce(4).
+	want := testHash(42)
+	header := make([]byte, 80)
+	copy(header[36:68], want[:])
+	got, err := merkleRootFromHeader(hex.EncodeToString(header))
+	if err != nil {
+		t.Fatalf("merkleRootFromHeader: %v", err)
+	}
+	if !got.IsEqual(&want) {
+		t.Fatalf("merkle root = %s, want %s", got, &want)
+	}
+
+	if _, err := merkleRootFromHeader("zz"); err == nil {
+		t.Fatal("expected error for non-hex header")
+	}
+	if _, err := merkleRootFromHeader("00"); err == nil {
+		t.Fatal("expected error for short header")
+	}
+}
+
+func TestCoinbaseTxIDFromHex(t *testing.T) {
+	raw := []byte{0x01, 0x02, 0x03, 0x04}
+	want := chainhash.DoubleHashB(raw)
+	got, err := coinbaseTxIDFromHex(hex.EncodeToString(raw))
+	if err != nil {
+		t.Fatalf("coinbaseTxIDFromHex: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("coinbase txid mismatch")
+	}
+	if _, err := coinbaseTxIDFromHex(""); err == nil {
+		t.Fatal("expected error for empty coinbase")
+	}
+}

--- a/internal/block/handle_message_test.go
+++ b/internal/block/handle_message_test.go
@@ -71,15 +71,16 @@ func (f *failingSyncProducer) AddMessageToTxn(*sarama.ConsumerMessage, string, *
 type fakeSubtreeCounter struct {
 	mu        sync.Mutex
 	values    map[string]int
+	data      map[string]*store.BlockProcessedData
 	initCalls int
 	failNext  bool
 }
 
 func newFakeSubtreeCounter() *fakeSubtreeCounter {
-	return &fakeSubtreeCounter{values: map[string]int{}}
+	return &fakeSubtreeCounter{values: map[string]int{}, data: map[string]*store.BlockProcessedData{}}
 }
 
-func (f *fakeSubtreeCounter) Init(blockHash string, count int) error {
+func (f *fakeSubtreeCounter) Init(blockHash string, count int, data *store.BlockProcessedData) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.initCalls++
@@ -88,14 +89,18 @@ func (f *fakeSubtreeCounter) Init(blockHash string, count int) error {
 		return errors.New("simulated counter init failure")
 	}
 	f.values[blockHash] = count
+	f.data[blockHash] = data
 	return nil
 }
 
-func (f *fakeSubtreeCounter) Decrement(blockHash string) (int, error) {
+func (f *fakeSubtreeCounter) Decrement(blockHash string) (int, *store.BlockProcessedData, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.values[blockHash]--
-	return f.values[blockHash], nil
+	if f.values[blockHash] <= 0 {
+		return f.values[blockHash], f.data[blockHash], nil
+	}
+	return f.values[blockHash], nil, nil
 }
 
 func (f *fakeSubtreeCounter) get(blockHash string) (int, bool) {

--- a/internal/block/processor.go
+++ b/internal/block/processor.go
@@ -243,6 +243,10 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 		//     so downstream consumers stay in step with the chain tip.
 		// A publish failure leaves the dedup cache untouched and returns
 		// an error so the consumer redelivers on the next session.
+		// Coinbase-only block: no subtrees, so the merkle root is the coinbase
+		// txid. Still surface the merkle root (and subtreeCount=0) so consumers
+		// can record it; there is no compound BUMP to build.
+		emptyBlockData := p.buildBlockProcessedData(ctx, blockMsg, meta, resolvedURL)
 		if err := emitBlockProcessedCallbacks(
 			p.Logger,
 			p.urlRegistry,
@@ -250,6 +254,7 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 			blockMsg.Hash,
 			blockMsg.OverrideCallbackURL,
 			blockMsg.OverrideCallbackToken,
+			emptyBlockData,
 		); err != nil {
 			return fmt.Errorf("emitting BLOCK_PROCESSED for empty block %s: %w", blockMsg.Hash, err)
 		}
@@ -303,9 +308,17 @@ func (p *Processor) handleMessage(ctx context.Context, msg *sarama.ConsumerMessa
 	// On reprocess we scope the counter key by override URL so a /reprocess
 	// for a hash already being processed live (or being reprocessed by a
 	// different arcade) gets its own counter — see SubtreeCounterKey.
+	// Build the BLOCK_PROCESSED enrichment (merkle root, subtree list, coinbase
+	// BUMP) now, while the block header, coinbase, and metadata are in hand, and
+	// stash it on the counter record so the worker that drains the counter to
+	// zero can surface it on BLOCK_PROCESSED without re-deriving anything. This
+	// is best-effort: buildBlockProcessedData degrades to partial data on any
+	// failure and the consumer falls back to a datahub.
+	blockData := p.buildBlockProcessedData(ctx, blockMsg, meta, resolvedURL)
+
 	counterKey := SubtreeCounterKey(blockMsg.Hash, blockMsg.OverrideCallbackURL)
 	if p.subtreeCounter != nil {
-		if err := p.subtreeCounter.Init(counterKey, len(encoded)); err != nil {
+		if err := p.subtreeCounter.Init(counterKey, len(encoded), blockData); err != nil {
 			p.Logger.Error(
 				"failed to init subtree counter",
 				"blockHash", blockMsg.Hash,

--- a/internal/block/reprocess_test.go
+++ b/internal/block/reprocess_test.go
@@ -108,6 +108,7 @@ func TestProcessBlockSubtree_FilterURL_ScopesToRequester(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatalf("expected non-nil result for filterURL match")
+		return // unreachable after Fatalf; guards the derefs below
 	}
 	if _, ok := result.CallbackGroups[urlA]; !ok {
 		t.Errorf("expected CallbackGroups to contain urlA, got %v", keys(result.CallbackGroups))

--- a/internal/block/reprocess_test.go
+++ b/internal/block/reprocess_test.go
@@ -194,7 +194,7 @@ func TestEmitBlockProcessed_OverrideSkipsRegistry(t *testing.T) {
 
 	const overrideURL = "https://arcade.example/cb"
 	const overrideToken = "tok-override"
-	if err := s.emitBlockProcessed("blk-override", overrideURL, overrideToken); err != nil {
+	if err := s.emitBlockProcessed("blk-override", overrideURL, overrideToken, nil); err != nil {
 		t.Fatalf("emitBlockProcessed: %v", err)
 	}
 	if err := mock.Close(); err != nil {
@@ -248,7 +248,7 @@ func TestEmitBlockProcessed_OverridePayload(t *testing.T) {
 
 	const overrideURL = "https://arcade.example/cb"
 	const overrideToken = "tok-override"
-	if err := s.emitBlockProcessed("blk-override", overrideURL, overrideToken); err != nil {
+	if err := s.emitBlockProcessed("blk-override", overrideURL, overrideToken, nil); err != nil {
 		t.Fatalf("emitBlockProcessed: %v", err)
 	}
 	if got := len(mock.captured); got != 1 {

--- a/internal/block/subtree_processor_test.go
+++ b/internal/block/subtree_processor_test.go
@@ -211,6 +211,7 @@ func TestMerkleTreeAndSTUMPBuild(t *testing.T) {
 	s := stump.Build(100, leaves, internalNodes, registeredIndices)
 	if s == nil {
 		t.Fatal("STUMP should not be nil")
+		return // unreachable after Fatal; guards the derefs below
 	}
 	if s.BlockHeight != 100 {
 		t.Errorf("expected block height 100, got %d", s.BlockHeight)

--- a/internal/block/subtree_worker.go
+++ b/internal/block/subtree_worker.go
@@ -636,7 +636,7 @@ func emitBlockProcessedCallbacks(
 		// consumer then falls back to a datahub.
 		if blockData != nil {
 			msg.MerkleRoot = blockData.MerkleRoot
-			msg.SubtreeCount = blockData.SubtreeCount
+			msg.SubtreeCount = &blockData.SubtreeCount
 			msg.SubtreeHashes = blockData.SubtreeHashes
 			msg.CoinbaseBUMP = blockData.CoinbaseBUMP
 		}

--- a/internal/block/subtree_worker.go
+++ b/internal/block/subtree_worker.go
@@ -425,7 +425,7 @@ func (s *SubtreeWorkerService) decrementCounterAndMaybeEmit(blockHash, overrideU
 		return nil
 	}
 	counterKey := SubtreeCounterKey(blockHash, overrideURL)
-	remaining, err := s.subtreeCounter.Decrement(counterKey)
+	remaining, blockData, err := s.subtreeCounter.Decrement(counterKey)
 	if err != nil {
 		if errors.Is(err, store.ErrCounterNotFound) {
 			// The per-block counter is gone (TTL expired before the block
@@ -458,7 +458,7 @@ func (s *SubtreeWorkerService) decrementCounterAndMaybeEmit(blockHash, overrideU
 	// drive the counter negative; we still need to emit so the notification is
 	// not silently lost. Receiver-side dedup handles the duplicate.
 	if remaining <= 0 {
-		if emitErr := s.emitBlockProcessed(blockHash, overrideURL, overrideToken); emitErr != nil {
+		if emitErr := s.emitBlockProcessed(blockHash, overrideURL, overrideToken, blockData); emitErr != nil {
 			s.Logger.Error(
 				"failed to emit BLOCK_PROCESSED; work item will be redelivered",
 				"blockHash", blockHash,
@@ -560,8 +560,8 @@ func (s *SubtreeWorkerService) publishSubtreeCallbacks(workMsg *kafka.SubtreeWor
 // On retry, the redelivered work item drives the counter past zero and
 // emit fires again; duplicate BLOCK_PROCESSED messages are deduplicated at
 // the callback delivery service (keyed by blockHash + callbackURL + type).
-func (s *SubtreeWorkerService) emitBlockProcessed(blockHash, overrideURL, overrideToken string) error {
-	return emitBlockProcessedCallbacks(s.Logger, s.urlRegistry, s.callbackProducer, blockHash, overrideURL, overrideToken)
+func (s *SubtreeWorkerService) emitBlockProcessed(blockHash, overrideURL, overrideToken string, blockData *store.BlockProcessedData) error {
+	return emitBlockProcessedCallbacks(s.Logger, s.urlRegistry, s.callbackProducer, blockHash, overrideURL, overrideToken, blockData)
 }
 
 // callbackPublisher is the narrow surface emitBlockProcessedCallbacks needs.
@@ -598,6 +598,7 @@ func emitBlockProcessedCallbacks(
 	urlRegistry store.CallbackURLRegistry,
 	producer callbackPublisher,
 	blockHash, overrideURL, overrideToken string,
+	blockData *store.BlockProcessedData,
 ) error {
 	if producer == nil {
 		return nil
@@ -628,6 +629,16 @@ func emitBlockProcessedCallbacks(
 			CallbackToken: entry.Token,
 			Type:          kafka.CallbackBlockProcessed,
 			BlockHash:     blockHash,
+		}
+		// Attach the block-level enrichment (merkle root, subtree list, coinbase
+		// BUMP) when the producer captured it. Absent for blocks processed
+		// before this shipped, or when the counter record lost the data — the
+		// consumer then falls back to a datahub.
+		if blockData != nil {
+			msg.MerkleRoot = blockData.MerkleRoot
+			msg.SubtreeCount = blockData.SubtreeCount
+			msg.SubtreeHashes = blockData.SubtreeHashes
+			msg.CoinbaseBUMP = blockData.CoinbaseBUMP
 		}
 		data, encErr := msg.Encode()
 		if encErr != nil {

--- a/internal/block/subtree_worker_handle_message_test.go
+++ b/internal/block/subtree_worker_handle_message_test.go
@@ -143,32 +143,37 @@ type countingSubtreeCounter struct {
 	decrementCalls int
 	initCalls      int
 	values         map[string]int
+	data           map[string]*store.BlockProcessedData
 	decrementErr   error
 }
 
 func newCountingSubtreeCounter() *countingSubtreeCounter {
-	return &countingSubtreeCounter{values: map[string]int{}}
+	return &countingSubtreeCounter{values: map[string]int{}, data: map[string]*store.BlockProcessedData{}}
 }
 
-func (c *countingSubtreeCounter) Init(blockHash string, count int) error {
+func (c *countingSubtreeCounter) Init(blockHash string, count int, data *store.BlockProcessedData) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.initCalls++
 	c.values[blockHash] = count
+	c.data[blockHash] = data
 	return nil
 }
 
-func (c *countingSubtreeCounter) Decrement(blockHash string) (int, error) {
+func (c *countingSubtreeCounter) Decrement(blockHash string) (int, *store.BlockProcessedData, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.decrementCalls++
 	if c.decrementErr != nil {
 		// Do NOT mutate the stored value on failure — emulates an Aerospike/SQL
 		// transient where the operation never committed.
-		return 0, c.decrementErr
+		return 0, nil, c.decrementErr
 	}
 	c.values[blockHash]--
-	return c.values[blockHash], nil
+	if c.values[blockHash] <= 0 {
+		return c.values[blockHash], c.data[blockHash], nil
+	}
+	return c.values[blockHash], nil, nil
 }
 
 func (c *countingSubtreeCounter) decrementCount() int {
@@ -431,7 +436,7 @@ func TestHandleMessage_CallbackPublishFailure_AtMaxAttempts_DLQAndDecrement(t *t
 	dlqMock := &callbackFailingProducer{}
 
 	counter := newCountingSubtreeCounter()
-	_ = counter.Init("block-dlq", 1)
+	_ = counter.Init("block-dlq", 1, nil)
 	// Reset init bookkeeping after pre-seed so test assertions only count
 	// what handleMessage drives.
 	counter.initCalls = 0
@@ -474,7 +479,7 @@ func TestHandleMessage_HappyPath_DecrementsExactlyOnce(t *testing.T) {
 	dlqMock := &callbackFailingProducer{}
 
 	counter := newCountingSubtreeCounter()
-	_ = counter.Init("block-happy", 1)
+	_ = counter.Init("block-happy", 1, nil)
 	counter.initCalls = 0
 
 	stumpStore := &stubStumpStore{}
@@ -588,7 +593,7 @@ func TestHandleMessage_DecrementFailureOnSuccessPath_RetriesAndPreservesCount(t 
 
 	const blockHash = "block-dec-fail"
 	counter := newCountingSubtreeCounter()
-	_ = counter.Init(blockHash, 3)
+	_ = counter.Init(blockHash, 3, nil)
 	counter.initCalls = 0
 	counter.decrementErr = errors.New("aerospike timeout")
 
@@ -646,7 +651,7 @@ func TestHandleMessage_DecrementFailureOnDLQPath_ReturnsError(t *testing.T) {
 
 	const blockHash = "block-dlq-dec-fail"
 	counter := newCountingSubtreeCounter()
-	_ = counter.Init(blockHash, 1)
+	_ = counter.Init(blockHash, 1, nil)
 	counter.initCalls = 0
 	counter.decrementErr = errors.New("aerospike cluster degraded")
 
@@ -697,7 +702,7 @@ func TestHandleMessage_HappyPath_DecrementToZeroEmitsBlockProcessed(t *testing.T
 	const blockHash = "block-zero-emit"
 	counter := newCountingSubtreeCounter()
 	// Pre-seed counter at 1 so the single subtree work item drives it to 0.
-	_ = counter.Init(blockHash, 1)
+	_ = counter.Init(blockHash, 1, nil)
 	counter.initCalls = 0
 
 	stumpStore := &stubStumpStore{}
@@ -766,7 +771,7 @@ func TestEmitBlockProcessed_PublishFailureReturnsError(t *testing.T) {
 	s.Logger = logger
 	s.callbackProducer = kafka.NewTestProducer(cbMock, "callback-test", logger)
 
-	err := s.emitBlockProcessed("blk-emit-fail", "", "")
+	err := s.emitBlockProcessed("blk-emit-fail", "", "", nil)
 	if err == nil {
 		t.Fatalf("expected error from emitBlockProcessed when callback publish fails")
 	}
@@ -793,7 +798,7 @@ func TestEmitBlockProcessed_PartialFailureContinuesAndReturnsFirstError(t *testi
 	s.Logger = logger
 	s.callbackProducer = kafka.NewTestProducer(cbMock, "callback-test", logger)
 
-	err := s.emitBlockProcessed("blk-partial", "", "")
+	err := s.emitBlockProcessed("blk-partial", "", "", nil)
 	if err == nil {
 		t.Fatalf("expected non-nil error when BLOCK_PROCESSED publishes fail")
 	}
@@ -821,11 +826,52 @@ func TestEmitBlockProcessed_HappyPath(t *testing.T) {
 	s.Logger = logger
 	s.callbackProducer = kafka.NewTestProducer(cbMock, "callback-test", logger)
 
-	if err := s.emitBlockProcessed("blk-happy", "", ""); err != nil {
+	if err := s.emitBlockProcessed("blk-happy", "", "", nil); err != nil {
 		t.Fatalf("expected nil error on happy path, got: %v", err)
 	}
 	if got := cbMock.sentCountOfType(kafka.CallbackBlockProcessed); got != 2 {
 		t.Errorf("expected 2 BLOCK_PROCESSED messages, got %d", got)
+	}
+}
+
+// TestEmitBlockProcessed_CarriesBlockData verifies the BLOCK_PROCESSED
+// enrichment (merkle root, subtree count, subtree hashes, coinbase BUMP) read
+// back from the counter is attached to every emitted CallbackTopicMessage.
+func TestEmitBlockProcessed_CarriesBlockData(t *testing.T) {
+	cbMock := &callbackFailingProducer{}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	s := &SubtreeWorkerService{
+		urlRegistry: &fakeURLRegistry{urls: []string{"http://cb.example.test/a"}},
+	}
+	s.InitBase("subtree-worker-test")
+	s.Logger = logger
+	s.callbackProducer = kafka.NewTestProducer(cbMock, "callback-test", logger)
+
+	blockData := &store.BlockProcessedData{
+		MerkleRoot:    "aabbcc",
+		SubtreeCount:  16,
+		SubtreeHashes: []string{"deadbeef", "feedface"},
+		CoinbaseBUMP:  "0102030405",
+	}
+	if err := s.emitBlockProcessed("blk-enriched", "", "", blockData); err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+
+	msgs := cbMock.messages
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	b, ok := msgs[0].Value.(sarama.ByteEncoder)
+	if !ok {
+		t.Fatal("message value is not ByteEncoder")
+	}
+	decoded, err := kafka.DecodeCallbackTopicMessage([]byte(b))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if decoded.MerkleRoot != "aabbcc" || decoded.SubtreeCount != 16 ||
+		decoded.CoinbaseBUMP != "0102030405" || len(decoded.SubtreeHashes) != 2 {
+		t.Errorf("block data not propagated to callback message: %+v", decoded)
 	}
 }
 
@@ -842,7 +888,7 @@ func TestEmitBlockProcessed_RegistryFailureReturnsError(t *testing.T) {
 	s.Logger = logger
 	s.callbackProducer = kafka.NewTestProducer(cbMock, "callback-test", logger)
 
-	if err := s.emitBlockProcessed("blk-registry-fail", "", ""); err == nil {
+	if err := s.emitBlockProcessed("blk-registry-fail", "", "", nil); err == nil {
 		t.Fatalf("expected error when URL registry GetAll fails")
 	}
 	if got := cbMock.sentCount(); got != 0 {
@@ -869,7 +915,7 @@ func TestHandleMessage_BlockProcessedEmitFailure_RetriesAndDoesNotAck(t *testing
 	const blockHash = "block-emit-fail"
 	counter := newCountingSubtreeCounter()
 	// Pre-seed at 1 so the single subtree drives the counter to 0 → emit fires.
-	_ = counter.Init(blockHash, 1)
+	_ = counter.Init(blockHash, 1, nil)
 	counter.initCalls = 0
 
 	stumpStore := &stubStumpStore{}
@@ -927,7 +973,7 @@ func TestHandleMessage_BlockProcessedEmitRetry_ReEmitsOnRedelivery(t *testing.T)
 	// decremented to 0 (and either succeeded-emit or failed-emit). The
 	// retry's decrement will drive the counter to -1, and remaining<=0 must
 	// still trigger emit so a previously-failed BLOCK_PROCESSED is retried.
-	_ = counter.Init(blockHash, 0)
+	_ = counter.Init(blockHash, 0, nil)
 	counter.initCalls = 0
 
 	stumpStore := &stubStumpStore{}
@@ -982,7 +1028,7 @@ func TestHandleMessage_BlockProcessedEmitFailure_AtMaxAttempts_DLQPathReturnsErr
 
 	const blockHash = "block-emit-dlq"
 	counter := newCountingSubtreeCounter()
-	_ = counter.Init(blockHash, 1)
+	_ = counter.Init(blockHash, 1, nil)
 	counter.initCalls = 0
 
 	stumpStore := &stubStumpStore{}

--- a/internal/block/subtree_worker_handle_message_test.go
+++ b/internal/block/subtree_worker_handle_message_test.go
@@ -869,7 +869,7 @@ func TestEmitBlockProcessed_CarriesBlockData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if decoded.MerkleRoot != "aabbcc" || decoded.SubtreeCount != 16 ||
+	if decoded.MerkleRoot != "aabbcc" || decoded.SubtreeCount == nil || *decoded.SubtreeCount != 16 ||
 		decoded.CoinbaseBUMP != "0102030405" || len(decoded.SubtreeHashes) != 2 {
 		t.Errorf("block data not propagated to callback message: %+v", decoded)
 	}

--- a/internal/block/subtree_worker_test.go
+++ b/internal/block/subtree_worker_test.go
@@ -49,7 +49,7 @@ func TestSubtreeWorkerService_EmitBlockProcessed_NilRegistry(t *testing.T) {
 	svc.callbackProducer = newTestKafkaProducer(mock, "callback-test", logger)
 
 	// Should not panic, and should return nil since there's no registry.
-	if err := svc.emitBlockProcessed("blockhash-123", "", ""); err != nil {
+	if err := svc.emitBlockProcessed("blockhash-123", "", "", nil); err != nil {
 		t.Errorf("expected nil error with nil registry, got: %v", err)
 	}
 

--- a/internal/callback/delivery.go
+++ b/internal/callback/delivery.go
@@ -73,7 +73,7 @@ type callbackPayload struct {
 	// BLOCK_PROCESSED enrichment — see CallbackTopicMessage. Additive and
 	// omitempty so consumers that don't read them are unaffected.
 	MerkleRoot    string   `json:"merkleRoot,omitempty"`
-	SubtreeCount  int      `json:"subtreeCount,omitempty"`
+	SubtreeCount  *int     `json:"subtreeCount,omitempty"`
 	SubtreeHashes []string `json:"subtreeHashes,omitempty"`
 	CoinbaseBUMP  string   `json:"coinbaseBump,omitempty"`
 }

--- a/internal/callback/delivery.go
+++ b/internal/callback/delivery.go
@@ -69,6 +69,13 @@ type callbackPayload struct {
 	BlockHash    string   `json:"blockHash,omitempty"`
 	SubtreeIndex int      `json:"subtreeIndex,omitempty"`
 	Stump        string   `json:"stump,omitempty"`
+
+	// BLOCK_PROCESSED enrichment — see CallbackTopicMessage. Additive and
+	// omitempty so consumers that don't read them are unaffected.
+	MerkleRoot    string   `json:"merkleRoot,omitempty"`
+	SubtreeCount  int      `json:"subtreeCount,omitempty"`
+	SubtreeHashes []string `json:"subtreeHashes,omitempty"`
+	CoinbaseBUMP  string   `json:"coinbaseBump,omitempty"`
 }
 
 // DeliveryService consumes callback messages from the callback Kafka topic
@@ -579,6 +586,13 @@ func (d *DeliveryService) deliverCallback(ctx context.Context, msg *kafka.Callba
 		TxIDs:        msg.TxIDs,
 		BlockHash:    msg.BlockHash,
 		SubtreeIndex: msg.SubtreeIndex,
+		// BLOCK_PROCESSED enrichment — pass through verbatim. Empty for other
+		// callback types (and for BLOCK_PROCESSED produced before the producer
+		// stamped them), where omitempty drops them from the JSON.
+		MerkleRoot:    msg.MerkleRoot,
+		SubtreeCount:  msg.SubtreeCount,
+		SubtreeHashes: msg.SubtreeHashes,
+		CoinbaseBUMP:  msg.CoinbaseBUMP,
 	}
 
 	// STUMP bytes are claim-checked: CallbackTopicMessage carries only a ref,

--- a/internal/callback/delivery_test.go
+++ b/internal/callback/delivery_test.go
@@ -427,12 +427,13 @@ func TestDeliverCallback_BlockProcessedEnrichmentInPayload(t *testing.T) {
 	cfg := defaultTestConfig()
 	ds, _, _ := newTestDeliveryService(t, cfg, server.Client())
 
+	subtreeCount := 16
 	msg := &kafka.CallbackTopicMessage{
 		CallbackURL:   server.URL + "/callback",
 		Type:          kafka.CallbackBlockProcessed,
 		BlockHash:     testBlockHash,
 		MerkleRoot:    "aabbccdd",
-		SubtreeCount:  16,
+		SubtreeCount:  &subtreeCount,
 		SubtreeHashes: []string{"deadbeef", "feedface"},
 		CoinbaseBUMP:  "0102030405",
 	}

--- a/internal/callback/delivery_test.go
+++ b/internal/callback/delivery_test.go
@@ -412,6 +412,60 @@ func TestDeliverCallback_RetryableStatusesNotPermanent(t *testing.T) {
 	}
 }
 
+// TestDeliverCallback_BlockProcessedEnrichmentInPayload verifies the new
+// BLOCK_PROCESSED enrichment fields (merkle root, subtree count, subtree
+// hashes, coinbase BUMP) are serialized into the outbound HTTP JSON body with
+// the exact keys arcade reads.
+func TestDeliverCallback_BlockProcessedEnrichmentInPayload(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := defaultTestConfig()
+	ds, _, _ := newTestDeliveryService(t, cfg, server.Client())
+
+	msg := &kafka.CallbackTopicMessage{
+		CallbackURL:   server.URL + "/callback",
+		Type:          kafka.CallbackBlockProcessed,
+		BlockHash:     testBlockHash,
+		MerkleRoot:    "aabbccdd",
+		SubtreeCount:  16,
+		SubtreeHashes: []string{"deadbeef", "feedface"},
+		CoinbaseBUMP:  "0102030405",
+	}
+
+	if err := ds.deliverCallback(context.Background(), msg); err != nil {
+		t.Fatalf("deliverCallback returned error: %v", err)
+	}
+
+	var payload struct {
+		Type          string   `json:"type"`
+		BlockHash     string   `json:"blockHash"`
+		MerkleRoot    string   `json:"merkleRoot"`
+		SubtreeCount  int      `json:"subtreeCount"`
+		SubtreeHashes []string `json:"subtreeHashes"`
+		CoinbaseBUMP  string   `json:"coinbaseBump"`
+	}
+	if err := json.Unmarshal(gotBody, &payload); err != nil {
+		t.Fatalf("decode body: %v\nraw: %s", err, gotBody)
+	}
+	if payload.MerkleRoot != "aabbccdd" {
+		t.Errorf("merkleRoot = %q, want aabbccdd", payload.MerkleRoot)
+	}
+	if payload.SubtreeCount != 16 {
+		t.Errorf("subtreeCount = %d, want 16", payload.SubtreeCount)
+	}
+	if len(payload.SubtreeHashes) != 2 || payload.SubtreeHashes[1] != "feedface" {
+		t.Errorf("subtreeHashes = %v", payload.SubtreeHashes)
+	}
+	if payload.CoinbaseBUMP != "0102030405" {
+		t.Errorf("coinbaseBump = %q", payload.CoinbaseBUMP)
+	}
+}
+
 // TestProcessDelivery_NonRetryable4xxRoutesStraightToDLQ verifies the
 // integration: a 401 response causes processDelivery to bypass the retry
 // budget and publish directly to DLQ, even though MaxRetries=5 is set.

--- a/internal/datahub/client_test.go
+++ b/internal/datahub/client_test.go
@@ -77,6 +77,7 @@ func TestFetchSubtree_Success(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatal("expected non-nil subtree")
+		return // unreachable after Fatal; guards the derefs below
 	}
 	if len(result.Nodes) != 2 {
 		t.Errorf("expected 2 nodes, got %d", len(result.Nodes))

--- a/internal/e2e/postgres_e2e_test.go
+++ b/internal/e2e/postgres_e2e_test.go
@@ -220,7 +220,7 @@ func TestPostgres_SubtreeCounterConcurrent(t *testing.T) {
 
 	const initial = 100
 	blockHash := "block-001"
-	if err := registry.SubtreeCounter.Init(blockHash, initial); err != nil {
+	if err := registry.SubtreeCounter.Init(blockHash, initial, nil); err != nil {
 		t.Fatalf("Init: %v", err)
 	}
 
@@ -231,7 +231,7 @@ func TestPostgres_SubtreeCounterConcurrent(t *testing.T) {
 	results := make(chan outcome, initial)
 	for i := 0; i < initial; i++ {
 		go func() {
-			v, err := registry.SubtreeCounter.Decrement(blockHash)
+			v, _, err := registry.SubtreeCounter.Decrement(blockHash)
 			results <- outcome{v, err}
 		}()
 	}

--- a/internal/kafka/consumer_test.go
+++ b/internal/kafka/consumer_test.go
@@ -208,6 +208,7 @@ func TestNewConsumerConfig_InitialOffsetOldest(t *testing.T) {
 	cfg := newConsumerConfig()
 	if cfg == nil {
 		t.Fatal("newConsumerConfig returned nil")
+		return // unreachable after Fatal; guards the derefs below
 	}
 	if got, want := cfg.Consumer.Offsets.Initial, sarama.OffsetOldest; got != want {
 		t.Errorf("Consumer.Offsets.Initial = %d, want %d (sarama.OffsetOldest); a new consumer group must replay the backlog, not jump to the topic head", got, want)

--- a/internal/kafka/messages.go
+++ b/internal/kafka/messages.go
@@ -83,6 +83,25 @@ type CallbackTopicMessage struct {
 	StumpRef     string    `json:"stumpRef,omitempty"`
 	RetryCount   int       `json:"retryCount,omitempty"`
 	NextRetryAt  time.Time `json:"nextRetryAt,omitempty"`
+
+	// BLOCK_PROCESSED enrichment (merkle-service issues #123/#124/#125 + the
+	// coinbase path). These let a consumer build and validate a compound BUMP
+	// without fetching the block from a teranode datahub. All additive and
+	// omitempty, so older consumers ignore them. Only populated for
+	// BLOCK_PROCESSED messages.
+	//
+	//   - MerkleRoot:   canonical block header merkle root (display-order hex).
+	//   - SubtreeCount: canonical number of subtrees in the block.
+	//   - SubtreeHashes: canonical (coinbase-placeholder-based) subtree roots,
+	//     display-order hex, in subtree-index order — exactly as teranode
+	//     stores them; the consumer corrects index 0 using CoinbaseBUMP.
+	//   - CoinbaseBUMP: hex-encoded BRC-74 merkle path of the coinbase tx up to
+	//     the block merkle root. Empty when the producer couldn't build it (the
+	//     consumer then falls back to a datahub).
+	MerkleRoot    string   `json:"merkleRoot,omitempty"`
+	SubtreeCount  int      `json:"subtreeCount,omitempty"`
+	SubtreeHashes []string `json:"subtreeHashes,omitempty"`
+	CoinbaseBUMP  string   `json:"coinbaseBump,omitempty"`
 }
 
 // PartitionKey returns the Kafka partition key for this callback message.

--- a/internal/kafka/messages.go
+++ b/internal/kafka/messages.go
@@ -91,7 +91,9 @@ type CallbackTopicMessage struct {
 	// BLOCK_PROCESSED messages.
 	//
 	//   - MerkleRoot:   canonical block header merkle root (display-order hex).
-	//   - SubtreeCount: canonical number of subtrees in the block.
+	//   - SubtreeCount: canonical number of subtrees in the block. A pointer so
+	//     a coinbase-only block's legitimate 0 is emitted (omitempty drops a nil
+	//     pointer, not a *0); only set for BLOCK_PROCESSED, nil for other types.
 	//   - SubtreeHashes: canonical (coinbase-placeholder-based) subtree roots,
 	//     display-order hex, in subtree-index order — exactly as teranode
 	//     stores them; the consumer corrects index 0 using CoinbaseBUMP.
@@ -99,7 +101,7 @@ type CallbackTopicMessage struct {
 	//     the block merkle root. Empty when the producer couldn't build it (the
 	//     consumer then falls back to a datahub).
 	MerkleRoot    string   `json:"merkleRoot,omitempty"`
-	SubtreeCount  int      `json:"subtreeCount,omitempty"`
+	SubtreeCount  *int     `json:"subtreeCount,omitempty"`
 	SubtreeHashes []string `json:"subtreeHashes,omitempty"`
 	CoinbaseBUMP  string   `json:"coinbaseBump,omitempty"`
 }

--- a/internal/kafka/messages_test.go
+++ b/internal/kafka/messages_test.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -267,6 +268,54 @@ func TestCallbackTopicMessage_BlockProcessed(t *testing.T) {
 	}
 	if decoded.StumpRef != "" {
 		t.Errorf("expected empty stumpRef, got %v", decoded.StumpRef)
+	}
+	// The enrichment fields are absent on this message, so they must be omitted
+	// from the JSON (backwards compatible) and decode to zero values.
+	if strings.Contains(string(data), "merkleRoot") || strings.Contains(string(data), "coinbaseBump") {
+		t.Errorf("enrichment fields should be omitted when unset: %s", data)
+	}
+	if decoded.SubtreeCount != 0 || decoded.MerkleRoot != "" || decoded.CoinbaseBUMP != "" || decoded.SubtreeHashes != nil {
+		t.Errorf("expected zero-value enrichment fields, got %+v", decoded)
+	}
+}
+
+func TestCallbackTopicMessage_BlockProcessed_Enriched(t *testing.T) {
+	msg := &CallbackTopicMessage{
+		CallbackURL:   "https://arcade.example.com/callback",
+		Type:          CallbackBlockProcessed,
+		BlockHash:     "000000000000000003a2d78e5f7c9012",
+		MerkleRoot:    "aabbcc",
+		SubtreeCount:  16,
+		SubtreeHashes: []string{"deadbeef", "feedface"},
+		CoinbaseBUMP:  "0102030405",
+	}
+
+	data, err := msg.Encode()
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+	decoded, err := DecodeCallbackTopicMessage(data)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+
+	if decoded.MerkleRoot != msg.MerkleRoot {
+		t.Errorf("merkleRoot mismatch: got %q", decoded.MerkleRoot)
+	}
+	if decoded.SubtreeCount != msg.SubtreeCount {
+		t.Errorf("subtreeCount mismatch: got %d", decoded.SubtreeCount)
+	}
+	if len(decoded.SubtreeHashes) != 2 || decoded.SubtreeHashes[0] != "deadbeef" {
+		t.Errorf("subtreeHashes mismatch: got %v", decoded.SubtreeHashes)
+	}
+	if decoded.CoinbaseBUMP != msg.CoinbaseBUMP {
+		t.Errorf("coinbaseBump mismatch: got %q", decoded.CoinbaseBUMP)
+	}
+	// JSON tag sanity — arcade reads these exact keys.
+	for _, key := range []string{`"merkleRoot"`, `"subtreeCount"`, `"subtreeHashes"`, `"coinbaseBump"`} {
+		if !strings.Contains(string(data), key) {
+			t.Errorf("expected JSON to contain %s: %s", key, data)
+		}
 	}
 }
 

--- a/internal/kafka/messages_test.go
+++ b/internal/kafka/messages_test.go
@@ -274,18 +274,24 @@ func TestCallbackTopicMessage_BlockProcessed(t *testing.T) {
 	if strings.Contains(string(data), "merkleRoot") || strings.Contains(string(data), "coinbaseBump") {
 		t.Errorf("enrichment fields should be omitted when unset: %s", data)
 	}
-	if decoded.SubtreeCount != 0 || decoded.MerkleRoot != "" || decoded.CoinbaseBUMP != "" || decoded.SubtreeHashes != nil {
+	if decoded.SubtreeCount != nil || decoded.MerkleRoot != "" || decoded.CoinbaseBUMP != "" || decoded.SubtreeHashes != nil {
 		t.Errorf("expected zero-value enrichment fields, got %+v", decoded)
+	}
+	// subtreeCount is a pointer, so an unset value must also be omitted from the
+	// JSON for non-BLOCK_PROCESSED messages.
+	if strings.Contains(string(data), "subtreeCount") {
+		t.Errorf("subtreeCount should be omitted when unset: %s", data)
 	}
 }
 
 func TestCallbackTopicMessage_BlockProcessed_Enriched(t *testing.T) {
+	subtreeCount := 16
 	msg := &CallbackTopicMessage{
 		CallbackURL:   "https://arcade.example.com/callback",
 		Type:          CallbackBlockProcessed,
 		BlockHash:     "000000000000000003a2d78e5f7c9012",
 		MerkleRoot:    "aabbcc",
-		SubtreeCount:  16,
+		SubtreeCount:  &subtreeCount,
 		SubtreeHashes: []string{"deadbeef", "feedface"},
 		CoinbaseBUMP:  "0102030405",
 	}
@@ -302,8 +308,8 @@ func TestCallbackTopicMessage_BlockProcessed_Enriched(t *testing.T) {
 	if decoded.MerkleRoot != msg.MerkleRoot {
 		t.Errorf("merkleRoot mismatch: got %q", decoded.MerkleRoot)
 	}
-	if decoded.SubtreeCount != msg.SubtreeCount {
-		t.Errorf("subtreeCount mismatch: got %d", decoded.SubtreeCount)
+	if decoded.SubtreeCount == nil || *decoded.SubtreeCount != *msg.SubtreeCount {
+		t.Errorf("subtreeCount mismatch: got %v", decoded.SubtreeCount)
 	}
 	if len(decoded.SubtreeHashes) != 2 || decoded.SubtreeHashes[0] != "deadbeef" {
 		t.Errorf("subtreeHashes mismatch: got %v", decoded.SubtreeHashes)
@@ -316,6 +322,36 @@ func TestCallbackTopicMessage_BlockProcessed_Enriched(t *testing.T) {
 		if !strings.Contains(string(data), key) {
 			t.Errorf("expected JSON to contain %s: %s", key, data)
 		}
+	}
+}
+
+// TestCallbackTopicMessage_BlockProcessed_ZeroSubtreeCount locks in the
+// coinbase-only-block contract (issue #124): subtreeCount is a *int so a
+// legitimate value of 0 is emitted on the wire rather than dropped by omitempty.
+func TestCallbackTopicMessage_BlockProcessed_ZeroSubtreeCount(t *testing.T) {
+	zero := 0
+	msg := &CallbackTopicMessage{
+		CallbackURL:  "https://arcade.example.com/callback",
+		Type:         CallbackBlockProcessed,
+		BlockHash:    "000000000000000003a2d78e5f7c9012",
+		MerkleRoot:   "aabbcc",
+		SubtreeCount: &zero,
+	}
+
+	data, err := msg.Encode()
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+	if !strings.Contains(string(data), `"subtreeCount":0`) {
+		t.Errorf("expected subtreeCount:0 to be present for coinbase-only block: %s", data)
+	}
+
+	decoded, err := DecodeCallbackTopicMessage(data)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if decoded.SubtreeCount == nil || *decoded.SubtreeCount != 0 {
+		t.Errorf("expected decoded subtreeCount 0, got %v", decoded.SubtreeCount)
 	}
 }
 

--- a/internal/metrics/bump.go
+++ b/internal/metrics/bump.go
@@ -55,6 +55,18 @@ var (
 			Buckets: CountBuckets,
 		},
 	)
+
+	// CoinbaseBumpValidationFailures counts blocks for which the producer built
+	// a coinbase BUMP whose folded root did not match the canonical header
+	// merkle root. A non-zero rate means coinbase BUMPs are being withheld from
+	// BLOCK_PROCESSED (consumers fall back to a datahub) and points at a bug in
+	// the coinbase-path construction or a malformed upstream subtree.
+	CoinbaseBumpValidationFailures = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "merkle_coinbase_bump_validation_failures_total",
+			Help: "Coinbase BUMPs withheld from BLOCK_PROCESSED because their folded root did not match the header merkle root.",
+		},
+	)
 )
 
 func init() {
@@ -65,6 +77,7 @@ func init() {
 		bumpTreeHeight,
 		bumpRegisteredIndices,
 		bumpLeavesCount,
+		CoinbaseBumpValidationFailures,
 	)
 }
 

--- a/internal/store/callback_accumulator_test.go
+++ b/internal/store/callback_accumulator_test.go
@@ -44,6 +44,7 @@ func TestCallbackAccumulatorStore_AppendSingle(t *testing.T) {
 	acc := result["http://example.com/cb"]
 	if acc == nil {
 		t.Fatal("expected entry for callback URL")
+		return // unreachable after Fatal; guards the derefs below
 	}
 	if len(acc.Entries) != 1 {
 		t.Fatalf("expected 1 entry (one subtree append), got %d", len(acc.Entries))
@@ -76,6 +77,7 @@ func TestCallbackAccumulatorStore_AppendMultipleSameURL(t *testing.T) {
 	acc := result["http://example.com/cb"]
 	if acc == nil {
 		t.Fatal("expected entry for callback URL")
+		return // unreachable after Fatal; guards the derefs below
 	}
 	if len(acc.Entries) != 2 {
 		t.Errorf("expected 2 entries (two subtree appends), got %d", len(acc.Entries))

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -91,12 +91,37 @@ type SeenCounterStore interface {
 	Threshold() int
 }
 
+// BlockProcessedData is the canonical block-level data the producer attaches
+// to a BLOCK_PROCESSED callback so downstream consumers can build and validate
+// a compound BUMP without fetching the block from a teranode datahub.
+//
+// It is stamped onto the per-block subtree-counter record at Init time (when
+// the block processor has the data in hand) and read back when the counter
+// drains to zero and BLOCK_PROCESSED fires. All hashes are display-order hex
+// (matching BlockHash / the chainhash.String() convention used elsewhere on
+// the wire); SubtreeHashes are the canonical (coinbase-placeholder-based)
+// subtree roots exactly as teranode stores them — consumers correct index 0
+// using CoinbaseBUMP. CoinbaseBUMP is the hex-encoded BRC-74 merkle path of the
+// coinbase transaction up to the block merkle root; it is empty when the
+// producer could not build it (the consumer then falls back to a datahub).
+type BlockProcessedData struct {
+	MerkleRoot    string   `json:"merkleRoot,omitempty"`
+	SubtreeCount  int      `json:"subtreeCount"`
+	SubtreeHashes []string `json:"subtreeHashes,omitempty"`
+	CoinbaseBUMP  string   `json:"coinbaseBump,omitempty"`
+}
+
 // SubtreeCounterStore coordinates BLOCK_PROCESSED emission: Init sets the
-// expected subtree count for a block, Decrement atomically counts one subtree
-// as done and returns the remaining count (caller fires BLOCK_PROCESSED at 0).
+// expected subtree count for a block (and stashes the BlockProcessedData to
+// surface on the callback), Decrement atomically counts one subtree as done
+// and returns the remaining count (caller fires BLOCK_PROCESSED at 0). When the
+// returned remaining count is <= 0, Decrement also returns the stashed
+// BlockProcessedData so the caller can populate the callback without an extra
+// round trip; it is nil otherwise (and may be nil even at zero if Init was
+// called without data or the record was rewritten).
 type SubtreeCounterStore interface {
-	Init(blockHash string, count int) error
-	Decrement(blockHash string) (remaining int, err error)
+	Init(blockHash string, count int, data *BlockProcessedData) error
+	Decrement(blockHash string) (remaining int, data *BlockProcessedData, err error)
 }
 
 // BackendHealth reports whether the underlying backend (Aerospike cluster, SQL

--- a/internal/store/sql/migrations/0006_subtree_counters_block_data.sql
+++ b/internal/store/sql/migrations/0006_subtree_counters_block_data.sql
@@ -1,0 +1,6 @@
+-- block_data: JSON-encoded BlockProcessedData (merkle root, subtree count,
+-- subtree hashes, coinbase BUMP) stamped at Init and read back when the counter
+-- drains to zero so BLOCK_PROCESSED can carry it. Nullable: pre-existing rows
+-- and callers that don't supply data leave it NULL, and the worker treats a
+-- missing value as "no data" (the consumer falls back to a datahub).
+ALTER TABLE subtree_counters ADD COLUMN block_data TEXT;

--- a/internal/store/sql/sql_test.go
+++ b/internal/store/sql/sql_test.go
@@ -620,11 +620,11 @@ func TestSubtreeCounter_InitAndDecrement(t *testing.T) {
 	db, d := newTestDB(t)
 	s := newSubtreeCounter(db, d, 600)
 
-	if err := s.Init("blk", 3); err != nil {
+	if err := s.Init("blk", 3, nil); err != nil {
 		t.Fatal(err)
 	}
 	for want := 2; want >= 0; want-- {
-		got, err := s.Decrement("blk")
+		got, _, err := s.Decrement("blk")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -648,7 +648,7 @@ func TestSubtreeCounter_DecrementMissingRow(t *testing.T) {
 	db, d := newTestDB(t)
 	s := newSubtreeCounter(db, d, 600)
 
-	got, err := s.Decrement("nonexistent-block")
+	got, _, err := s.Decrement("nonexistent-block")
 	if !errors.Is(err, storepkg.ErrCounterNotFound) {
 		t.Fatalf("Decrement on missing row = (%d, %v), want (0, ErrCounterNotFound)", got, err)
 	}
@@ -658,13 +658,13 @@ func TestSubtreeCounter_DecrementMissingRow(t *testing.T) {
 
 	// Sanity check: real ErrNoRows must not leak through even after an
 	// underlying failure has been observed once.
-	if initErr := s.Init("real-blk", 1); initErr != nil {
+	if initErr := s.Init("real-blk", 1, nil); initErr != nil {
 		t.Fatal(initErr)
 	}
-	if _, decErr := s.Decrement("real-blk"); decErr != nil {
+	if _, _, decErr := s.Decrement("real-blk"); decErr != nil {
 		t.Fatalf("Decrement on existing row: %v", decErr)
 	}
-	got, err = s.Decrement("still-nonexistent")
+	got, _, err = s.Decrement("still-nonexistent")
 	if !errors.Is(err, storepkg.ErrCounterNotFound) {
 		t.Fatalf("Decrement on missing row = (%d, %v), want (0, ErrCounterNotFound)", got, err)
 	}
@@ -686,7 +686,7 @@ func TestSubtreeCounter_DecrementRestampsTTL(t *testing.T) {
 	db, d := newTestDB(t)
 	s := newSubtreeCounter(db, d, 600)
 
-	if err := s.Init("blk", 3); err != nil {
+	if err := s.Init("blk", 3, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -700,7 +700,7 @@ func TestSubtreeCounter_DecrementRestampsTTL(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := s.Decrement("blk"); err != nil {
+	if _, _, err := s.Decrement("blk"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -723,7 +723,7 @@ func TestSubtreeCounter_ConcurrentDecrement(t *testing.T) {
 	s := newSubtreeCounter(db, d, 600)
 
 	const initial = 50
-	if err := s.Init("blk", initial); err != nil {
+	if err := s.Init("blk", initial, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -733,7 +733,7 @@ func TestSubtreeCounter_ConcurrentDecrement(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			v, err := s.Decrement("blk")
+			v, _, err := s.Decrement("blk")
 			if err != nil {
 				t.Errorf("Decrement: %v", err)
 				return
@@ -788,7 +788,7 @@ func TestSubtreeCounter_ConcurrentDecrementMultiConn(t *testing.T) {
 
 	s := newSubtreeCounter(db, d, 600)
 	const initial = 64
-	if err := s.Init("blk", initial); err != nil {
+	if err := s.Init("blk", initial, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -800,7 +800,7 @@ func TestSubtreeCounter_ConcurrentDecrementMultiConn(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			<-start
-			v, err := s.Decrement("blk")
+			v, _, err := s.Decrement("blk")
 			if err != nil {
 				t.Errorf("Decrement: %v", err)
 				return

--- a/internal/store/sql/sql_test.go
+++ b/internal/store/sql/sql_test.go
@@ -620,16 +620,37 @@ func TestSubtreeCounter_InitAndDecrement(t *testing.T) {
 	db, d := newTestDB(t)
 	s := newSubtreeCounter(db, d, 600)
 
-	if err := s.Init("blk", 3, nil); err != nil {
+	// Stash BlockProcessedData at Init: it must round-trip through block_data and
+	// surface only on the final (remaining == 0) decrement — never before.
+	wantData := &storepkg.BlockProcessedData{
+		MerkleRoot:    "aabbcc",
+		SubtreeCount:  3,
+		SubtreeHashes: []string{"deadbeef", "feedface"},
+		CoinbaseBUMP:  "0102030405",
+	}
+	if err := s.Init("blk", 3, wantData); err != nil {
 		t.Fatal(err)
 	}
 	for want := 2; want >= 0; want-- {
-		got, _, err := s.Decrement("blk")
+		got, data, err := s.Decrement("blk")
 		if err != nil {
 			t.Fatal(err)
 		}
 		if got != want {
 			t.Fatalf("Decrement = %d, want %d", got, want)
+		}
+		if want > 0 {
+			if data != nil {
+				t.Fatalf("expected nil block data on intermediate decrement (remaining %d), got %+v", got, data)
+			}
+			continue
+		}
+		// Final decrement: the stashed data must surface and match. The nil check
+		// short-circuits the field comparisons, so data is never dereferenced
+		// when nil.
+		if data == nil || data.MerkleRoot != wantData.MerkleRoot || data.SubtreeCount != wantData.SubtreeCount ||
+			data.CoinbaseBUMP != wantData.CoinbaseBUMP || len(data.SubtreeHashes) != len(wantData.SubtreeHashes) {
+			t.Fatalf("block data round-trip mismatch on final decrement: got %+v, want %+v", data, wantData)
 		}
 	}
 }

--- a/internal/store/sql/subtree_counter.go
+++ b/internal/store/sql/subtree_counter.go
@@ -48,10 +48,10 @@ func (s *subtreeCounter) Init(blockHash string, count int, data *storepkg.BlockP
 	return err
 }
 
-// decodeBlockData unmarshals the block_data column (NULL → nil) and logs but
-// never fails on a malformed value: a counter that drained but can't surface
-// its block data still emits BLOCK_PROCESSED, and the consumer falls back to a
-// datahub.
+// decodeBlockData unmarshals the block_data column (NULL → nil) and never fails
+// on a malformed value, returning nil instead: a counter that drained but can't
+// surface its block data still emits BLOCK_PROCESSED, and the consumer falls
+// back to a datahub.
 func decodeBlockData(raw sql.NullString) *storepkg.BlockProcessedData {
 	if !raw.Valid || raw.String == "" {
 		return nil
@@ -117,8 +117,12 @@ func (s *subtreeCounter) Decrement(blockHash string) (int, *storepkg.BlockProces
 		// would have its counter swept mid-flight, after which Decrement maps
 		// the missing row to ErrCounterNotFound and the worker acks the
 		// remaining items without ever emitting BLOCK_PROCESSED.
+		// Only return block_data on the final decrement (remaining <= 0). The
+		// CASE keeps the hot path from shipping the (potentially large) JSON
+		// blob across the wire on every subtree completion — in RETURNING,
+		// `remaining` already reflects the post-decrement value.
 		q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
-			"UPDATE subtree_counters SET remaining = remaining - 1, expires_at = %s WHERE block_hash = %s RETURNING remaining, block_data",
+			"UPDATE subtree_counters SET remaining = remaining - 1, expires_at = %s WHERE block_hash = %s RETURNING remaining, CASE WHEN remaining <= 0 THEN block_data END",
 			s.d.intervalSeconds(s.ttlSec), s.d.placeholder(1),
 		)
 		var remaining int

--- a/internal/store/sql/subtree_counter.go
+++ b/internal/store/sql/subtree_counter.go
@@ -3,6 +3,7 @@ package sql
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -23,16 +24,43 @@ func newSubtreeCounter(db *sql.DB, d *dialect, ttlSec int) *subtreeCounter {
 }
 
 // Init upserts the counter with the initial remaining count and a fresh TTL.
-func (s *subtreeCounter) Init(blockHash string, count int) error {
+// When data is non-nil it is JSON-encoded into the block_data column so the
+// final Decrement can surface it on BLOCK_PROCESSED without a second query.
+func (s *subtreeCounter) Init(blockHash string, count int, data *storepkg.BlockProcessedData) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+
+	var blockData any // nil → NULL column
+	if data != nil {
+		encoded, err := json.Marshal(data)
+		if err != nil {
+			return fmt.Errorf("encode block-processed data: %w", err)
+		}
+		blockData = string(encoded)
+	}
+
 	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
-		`INSERT INTO subtree_counters (block_hash, remaining, expires_at) VALUES (%s, %s, %s)
-        ON CONFLICT (block_hash) DO UPDATE SET remaining = EXCLUDED.remaining, expires_at = EXCLUDED.expires_at`,
-		s.d.placeholder(1), s.d.placeholder(2), s.d.intervalSeconds(s.ttlSec),
+		`INSERT INTO subtree_counters (block_hash, remaining, block_data, expires_at) VALUES (%s, %s, %s, %s)
+        ON CONFLICT (block_hash) DO UPDATE SET remaining = EXCLUDED.remaining, block_data = EXCLUDED.block_data, expires_at = EXCLUDED.expires_at`,
+		s.d.placeholder(1), s.d.placeholder(2), s.d.placeholder(3), s.d.intervalSeconds(s.ttlSec),
 	)
-	_, err := s.db.ExecContext(ctx, q, blockHash, count)
+	_, err := s.db.ExecContext(ctx, q, blockHash, count, blockData)
 	return err
+}
+
+// decodeBlockData unmarshals the block_data column (NULL → nil) and logs but
+// never fails on a malformed value: a counter that drained but can't surface
+// its block data still emits BLOCK_PROCESSED, and the consumer falls back to a
+// datahub.
+func decodeBlockData(raw sql.NullString) *storepkg.BlockProcessedData {
+	if !raw.Valid || raw.String == "" {
+		return nil
+	}
+	var d storepkg.BlockProcessedData
+	if err := json.Unmarshal([]byte(raw.String), &d); err != nil {
+		return nil
+	}
+	return &d
 }
 
 // Decrement atomically decrements the remaining count and returns the new
@@ -77,7 +105,7 @@ func (s *subtreeCounter) Init(blockHash string, count int) error {
 // suppressed the emit). The unbounded-redelivery-loop concern that justified
 // the old behavior was eliminated when the worker started ack'ing on
 // ErrCounterNotFound — see fix/subtree-counter-ttl-leak.
-func (s *subtreeCounter) Decrement(blockHash string) (int, error) {
+func (s *subtreeCounter) Decrement(blockHash string) (int, *storepkg.BlockProcessedData, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -90,17 +118,22 @@ func (s *subtreeCounter) Decrement(blockHash string) (int, error) {
 		// the missing row to ErrCounterNotFound and the worker acks the
 		// remaining items without ever emitting BLOCK_PROCESSED.
 		q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
-			"UPDATE subtree_counters SET remaining = remaining - 1, expires_at = %s WHERE block_hash = %s RETURNING remaining",
+			"UPDATE subtree_counters SET remaining = remaining - 1, expires_at = %s WHERE block_hash = %s RETURNING remaining, block_data",
 			s.d.intervalSeconds(s.ttlSec), s.d.placeholder(1),
 		)
 		var remaining int
-		if err := s.db.QueryRowContext(ctx, q, blockHash).Scan(&remaining); err != nil {
+		var blockData sql.NullString
+		if err := s.db.QueryRowContext(ctx, q, blockHash).Scan(&remaining, &blockData); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				return 0, storepkg.ErrCounterNotFound
+				return 0, nil, storepkg.ErrCounterNotFound
 			}
-			return 0, err
+			return 0, nil, err
 		}
-		return remaining, nil
+		// Only surface the stashed block data on the final decrement.
+		if remaining <= 0 {
+			return remaining, decodeBlockData(blockData), nil
+		}
+		return remaining, nil, nil
 	}
 
 	// SQLite path. Pin a connection, open the transaction with `BEGIN
@@ -109,12 +142,12 @@ func (s *subtreeCounter) Decrement(blockHash string) (int, error) {
 	// which is deferred and reintroduces the read-modify-write race.
 	conn, err := s.db.Conn(ctx)
 	if err != nil {
-		return 0, err
+		return 0, nil, err
 	}
 	defer func() { _ = conn.Close() }()
 
 	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
-		return 0, fmt.Errorf("begin immediate: %w", err)
+		return 0, nil, fmt.Errorf("begin immediate: %w", err)
 	}
 	committed := false
 	defer func() {
@@ -124,12 +157,13 @@ func (s *subtreeCounter) Decrement(blockHash string) (int, error) {
 	}()
 
 	var remaining int
-	qSel := fmt.Sprintf("SELECT remaining FROM subtree_counters WHERE block_hash = %s", s.d.placeholder(1)) //nolint:gosec // placeholder from internal function
-	if err := conn.QueryRowContext(ctx, qSel, blockHash).Scan(&remaining); err != nil {
+	var blockData sql.NullString
+	qSel := fmt.Sprintf("SELECT remaining, block_data FROM subtree_counters WHERE block_hash = %s", s.d.placeholder(1)) //nolint:gosec // placeholder from internal function
+	if err := conn.QueryRowContext(ctx, qSel, blockHash).Scan(&remaining, &blockData); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return 0, storepkg.ErrCounterNotFound
+			return 0, nil, storepkg.ErrCounterNotFound
 		}
-		return 0, err
+		return 0, nil, err
 	}
 	remaining--
 	// Re-stamp expires_at alongside remaining (see the Postgres branch above):
@@ -140,11 +174,15 @@ func (s *subtreeCounter) Decrement(blockHash string) (int, error) {
 		s.d.placeholder(1), s.d.intervalSeconds(s.ttlSec), s.d.placeholder(2),
 	)
 	if _, err := conn.ExecContext(ctx, qUp, remaining, blockHash); err != nil {
-		return 0, err
+		return 0, nil, err
 	}
 	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
-		return 0, fmt.Errorf("commit: %w", err)
+		return 0, nil, fmt.Errorf("commit: %w", err)
 	}
 	committed = true
-	return remaining, nil
+	// Only surface the stashed block data on the final decrement.
+	if remaining <= 0 {
+		return remaining, decodeBlockData(blockData), nil
+	}
+	return remaining, nil, nil
 }

--- a/internal/store/subtree_counter.go
+++ b/internal/store/subtree_counter.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -9,7 +10,14 @@ import (
 	astypes "github.com/aerospike/aerospike-client-go/v7/types"
 )
 
-const subtreeCounterBin = "remaining"
+const (
+	subtreeCounterBin = "remaining"
+	// blockDataBin holds the JSON-encoded BlockProcessedData stamped at Init
+	// and read back when the counter drains to zero so BLOCK_PROCESSED can
+	// carry the merkle root / subtree list / coinbase BUMP. Stored as a single
+	// string bin (an Aerospike CE core feature — no Enterprise dependency).
+	blockDataBin = "blockdata"
+)
 
 // ErrCounterNotFound is returned by Decrement when the per-block subtree
 // counter record is absent. The usual cause is TTL expiry: a large block whose
@@ -49,7 +57,9 @@ func NewSubtreeCounterStore(client *AerospikeClient, setName string, ttlSec, max
 }
 
 // Init creates a counter record for the given blockHash with the initial count.
-func (s *aerospikeSubtreeCounter) Init(blockHash string, count int) error {
+// When data is non-nil it is JSON-encoded and stamped onto the record so the
+// final Decrement can surface it on BLOCK_PROCESSED without a second fetch.
+func (s *aerospikeSubtreeCounter) Init(blockHash string, count int, data *BlockProcessedData) error {
 	key, err := as.NewKey(s.client.Namespace(), s.setName, blockHash)
 	if err != nil {
 		return fmt.Errorf("failed to create key: %w", err)
@@ -59,18 +69,35 @@ func (s *aerospikeSubtreeCounter) Init(blockHash string, count int) error {
 	wp.RecordExistsAction = as.UPDATE
 	wp.Expiration = uint32(s.ttlSec) //nolint:gosec // ttlSec is config-validated and fits uint32
 
-	err = s.client.Client().Put(wp, key, as.BinMap{subtreeCounterBin: count})
+	bins := as.BinMap{subtreeCounterBin: count}
+	if data != nil {
+		encoded, mErr := json.Marshal(data)
+		if mErr != nil {
+			// Non-fatal: a counter without block data still drives
+			// BLOCK_PROCESSED; the consumer just falls back to a datahub.
+			s.logger.Warn("failed to encode block-processed data for counter", "blockHash", blockHash, "error", mErr)
+		} else {
+			bins[blockDataBin] = string(encoded)
+		}
+	}
+
+	err = s.client.Client().Put(wp, key, bins)
 	if err != nil {
 		return fmt.Errorf("failed to init subtree counter: %w", err)
 	}
 	return nil
 }
 
-// Decrement atomically decrements the counter for the given blockHash and returns the new value.
-func (s *aerospikeSubtreeCounter) Decrement(blockHash string) (remaining int, err error) {
+// Decrement atomically decrements the counter for the given blockHash and
+// returns the new value. The Operate call already fetches every bin via GetOp,
+// so when the counter has drained (remaining <= 0) the stashed
+// BlockProcessedData is decoded from the same record and returned — no extra
+// round trip. data is nil while remaining > 0 (the common per-subtree path) to
+// avoid needless JSON work, and nil at zero if no data was stamped at Init.
+func (s *aerospikeSubtreeCounter) Decrement(blockHash string) (remaining int, data *BlockProcessedData, err error) {
 	key, err := as.NewKey(s.client.Namespace(), s.setName, blockHash)
 	if err != nil {
-		return 0, fmt.Errorf("failed to create key: %w", err)
+		return 0, nil, fmt.Errorf("failed to create key: %w", err)
 	}
 
 	wp := s.client.WritePolicy(s.maxRetries, s.retryBaseMs)
@@ -88,15 +115,28 @@ func (s *aerospikeSubtreeCounter) Decrement(blockHash string) (remaining int, er
 	if err != nil {
 		var asErr as.Error
 		if errors.As(err, &asErr) && asErr.Matches(astypes.KEY_NOT_FOUND_ERROR) {
-			return 0, ErrCounterNotFound
+			return 0, nil, ErrCounterNotFound
 		}
-		return 0, fmt.Errorf("failed to decrement subtree counter: %w", err)
+		return 0, nil, fmt.Errorf("failed to decrement subtree counter: %w", err)
 	}
 
 	val, ok := record.Bins[subtreeCounterBin].(int)
 	if !ok {
-		return 0, fmt.Errorf("unexpected type for counter bin: %T", record.Bins[subtreeCounterBin])
+		return 0, nil, fmt.Errorf("unexpected type for counter bin: %T", record.Bins[subtreeCounterBin])
 	}
 
-	return val, nil
+	// Only decode the stashed block data on the final decrement — the per-subtree
+	// hot path (remaining > 0) skips the JSON work entirely.
+	if val <= 0 {
+		if raw, ok := record.Bins[blockDataBin].(string); ok && raw != "" {
+			var d BlockProcessedData
+			if uErr := json.Unmarshal([]byte(raw), &d); uErr != nil {
+				s.logger.Warn("failed to decode block-processed data from counter", "blockHash", blockHash, "error", uErr)
+			} else {
+				data = &d
+			}
+		}
+	}
+
+	return val, data, nil
 }

--- a/internal/store/subtree_counter_test.go
+++ b/internal/store/subtree_counter_test.go
@@ -22,11 +22,11 @@ func TestSubtreeCounterStore_InitAndDecrement(t *testing.T) {
 	s := newSubtreeCounterStore(t)
 	blockHash := fmt.Sprintf("block-init-dec-%d", time.Now().UnixNano())
 
-	if err := s.Init(blockHash, 3); err != nil {
+	if err := s.Init(blockHash, 3, nil); err != nil {
 		t.Fatalf("Init failed: %v", err)
 	}
 
-	remaining, err := s.Decrement(blockHash)
+	remaining, _, err := s.Decrement(blockHash)
 	if err != nil {
 		t.Fatalf("Decrement failed: %v", err)
 	}
@@ -34,7 +34,7 @@ func TestSubtreeCounterStore_InitAndDecrement(t *testing.T) {
 		t.Errorf("expected 2, got %d", remaining)
 	}
 
-	remaining, err = s.Decrement(blockHash)
+	remaining, _, err = s.Decrement(blockHash)
 	if err != nil {
 		t.Fatalf("Decrement failed: %v", err)
 	}
@@ -42,7 +42,7 @@ func TestSubtreeCounterStore_InitAndDecrement(t *testing.T) {
 		t.Errorf("expected 1, got %d", remaining)
 	}
 
-	remaining, err = s.Decrement(blockHash)
+	remaining, _, err = s.Decrement(blockHash)
 	if err != nil {
 		t.Fatalf("Decrement failed: %v", err)
 	}
@@ -56,7 +56,7 @@ func TestSubtreeCounterStore_ConcurrentDecrements(t *testing.T) {
 	blockHash := fmt.Sprintf("block-concurrent-%d", time.Now().UnixNano())
 	count := 50
 
-	if err := s.Init(blockHash, count); err != nil {
+	if err := s.Init(blockHash, count, nil); err != nil {
 		t.Fatalf("Init failed: %v", err)
 	}
 
@@ -67,7 +67,7 @@ func TestSubtreeCounterStore_ConcurrentDecrements(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			remaining, err := s.Decrement(blockHash)
+			remaining, _, err := s.Decrement(blockHash)
 			if err != nil {
 				t.Errorf("Decrement failed: %v", err)
 				return

--- a/internal/store/subtree_counter_test.go
+++ b/internal/store/subtree_counter_test.go
@@ -22,32 +22,52 @@ func TestSubtreeCounterStore_InitAndDecrement(t *testing.T) {
 	s := newSubtreeCounterStore(t)
 	blockHash := fmt.Sprintf("block-init-dec-%d", time.Now().UnixNano())
 
-	if err := s.Init(blockHash, 3, nil); err != nil {
+	// Stash BlockProcessedData at Init: it must round-trip through the store and
+	// surface only on the final (remaining == 0) decrement.
+	want := &store.BlockProcessedData{
+		MerkleRoot:    "aabbcc",
+		SubtreeCount:  3,
+		SubtreeHashes: []string{"deadbeef", "feedface"},
+		CoinbaseBUMP:  "0102030405",
+	}
+	if err := s.Init(blockHash, 3, want); err != nil {
 		t.Fatalf("Init failed: %v", err)
 	}
 
-	remaining, _, err := s.Decrement(blockHash)
+	remaining, data, err := s.Decrement(blockHash)
 	if err != nil {
 		t.Fatalf("Decrement failed: %v", err)
 	}
 	if remaining != 2 {
 		t.Errorf("expected 2, got %d", remaining)
 	}
+	if data != nil {
+		t.Errorf("expected nil block data on intermediate decrement, got %+v", data)
+	}
 
-	remaining, _, err = s.Decrement(blockHash)
+	remaining, data, err = s.Decrement(blockHash)
 	if err != nil {
 		t.Fatalf("Decrement failed: %v", err)
 	}
 	if remaining != 1 {
 		t.Errorf("expected 1, got %d", remaining)
 	}
+	if data != nil {
+		t.Errorf("expected nil block data on intermediate decrement, got %+v", data)
+	}
 
-	remaining, _, err = s.Decrement(blockHash)
+	remaining, data, err = s.Decrement(blockHash)
 	if err != nil {
 		t.Fatalf("Decrement failed: %v", err)
 	}
 	if remaining != 0 {
 		t.Errorf("expected 0, got %d", remaining)
+	}
+	// The nil check short-circuits the field comparisons, so data is never
+	// dereferenced when nil.
+	if data == nil || data.MerkleRoot != want.MerkleRoot || data.SubtreeCount != want.SubtreeCount ||
+		data.CoinbaseBUMP != want.CoinbaseBUMP || len(data.SubtreeHashes) != len(want.SubtreeHashes) {
+		t.Fatalf("block data round-trip mismatch on final decrement: got %+v, want %+v", data, want)
 	}
 }
 

--- a/internal/stump/coinbase_bump.go
+++ b/internal/stump/coinbase_bump.go
@@ -1,0 +1,56 @@
+package stump
+
+import "github.com/bsv-blockchain/go-bt/v2/chainhash"
+
+// EncodeCoinbaseBUMP encodes a BRC-0074 BUMP proving the transaction at global
+// block offset 0 — the coinbase — up to the block merkle root.
+//
+// siblings are the merkle-path sibling hashes, level 0 (the leaf level) first,
+// one per level. Because the coinbase sits at offset 0 it always climbs the
+// left spine of the tree, so at every level the working node is at offset 0 and
+// its sibling is at offset 1. All hashes are 32-byte internal (little-endian)
+// byte order, matching the rest of the STUMP encoding and what go-sdk's
+// transaction.NewMerklePathFromBinary expects.
+//
+// The returned BUMP carries the real coinbase txid at level 0, offset 0 (flag
+// 0x02 / txid), so a consumer can both read the coinbase txid and fold it up to
+// the block merkle root. With no siblings (a single-transaction block) the
+// result is an empty-path BUMP — callers that need the coinbase txid in the
+// payload should guard against that degenerate case.
+func EncodeCoinbaseBUMP(blockHeight uint64, coinbaseTxID []byte, siblings [][]byte) []byte {
+	s := &STUMP{
+		BlockHeight: blockHeight,
+		TreeHeight:  uint8(len(siblings)), //nolint:gosec // tree height is log2(block tx count), far below 255
+		Paths:       make([]PathLevel, len(siblings)),
+	}
+	for i, sib := range siblings {
+		leaves := make([]Leaf, 0, 2)
+		if i == 0 {
+			cb := make([]byte, len(coinbaseTxID))
+			copy(cb, coinbaseTxID)
+			leaves = append(leaves, Leaf{Offset: 0, Hash: cb, TxID: true})
+		}
+		sibCopy := make([]byte, len(sib))
+		copy(sibCopy, sib)
+		leaves = append(leaves, Leaf{Offset: 1, Hash: sibCopy})
+		s.Paths[i] = PathLevel{Leaves: leaves}
+	}
+	return s.Encode()
+}
+
+// CoinbaseRootFromSiblings folds the coinbase txid up through the index-0
+// sibling hashes and returns the resulting block merkle root (32-byte internal
+// byte order). The coinbase is always the left child, so each step hashes
+// working||sibling. Used to self-validate a coinbase BUMP against the block
+// header merkle root before publishing it.
+func CoinbaseRootFromSiblings(coinbaseTxID []byte, siblings [][]byte) []byte {
+	working := make([]byte, len(coinbaseTxID))
+	copy(working, coinbaseTxID)
+	for _, sib := range siblings {
+		buf := make([]byte, 0, 64)
+		buf = append(buf, working...)
+		buf = append(buf, sib...)
+		working = chainhash.DoubleHashB(buf)
+	}
+	return working
+}


### PR DESCRIPTION
Fixes #123 , #124 , #125 .

Depends on https://github.com/bsv-blockchain/arcade/issues/195

This pull request implements a robust mechanism for surfacing block-level enrichment data (such as the block merkle root, subtree list, and coinbase BUMP) on the `BLOCK_PROCESSED` event without requiring re-derivation. The enrichment is now built once when the block is processed and stashed with the subtree counter, ensuring that the complete data is available when the counter is decremented to zero and the event is emitted. The changes also include comprehensive tests and refactorings to support this improved flow.

Key changes include:

**Block enrichment and emission flow:**

* The `buildBlockProcessedData` method in `coinbase_bump.go` assembles all relevant block-level enrichment data, including the block merkle root, subtree hashes, and coinbase BUMP, handling errors gracefully and ensuring partial data is surfaced when possible.
* The enrichment data is now stashed with the subtree counter at initialization and surfaced when the counter is decremented to zero, ensuring that the correct data is emitted on `BLOCK_PROCESSED` without recomputation. This is implemented in the processor and subtree worker logic. [[1]](diffhunk://#diff-dd0f8a254823197e765322cbc6d6afaae270a1d804dd783f2d40c7fd41aaed07R311-R321) [[2]](diffhunk://#diff-bb23bf9b6e0a037c63c54666b244ca792a492036a94d3f6d94002feb6b8360c0L428-R428) [[3]](diffhunk://#diff-bb23bf9b6e0a037c63c54666b244ca792a492036a94d3f6d94002feb6b8360c0L461-R461) [[4]](diffhunk://#diff-bb23bf9b6e0a037c63c54666b244ca792a492036a94d3f6d94002feb6b8360c0L563-R564) [[5]](diffhunk://#diff-bb23bf9b6e0a037c63c54666b244ca792a492036a94d3f6d94002feb6b8360c0R601) [[6]](diffhunk://#diff-bb23bf9b6e0a037c63c54666b244ca792a492036a94d3f6d94002feb6b8360c0R633-R642)

**Interface and signature changes:**

* The `SubtreeCounter` interface and its test doubles (`fakeSubtreeCounter`, `countingSubtreeCounter`) have been updated so that `Init` and `Decrement` now accept and return the enrichment data, respectively. [[1]](diffhunk://#diff-34417f41dc15a47c1865e9aca85a5cab5a9f97e715c3d1a12ddb482c8efb06ddR74-R83) [[2]](diffhunk://#diff-34417f41dc15a47c1865e9aca85a5cab5a9f97e715c3d1a12ddb482c8efb06ddR92-R103) [[3]](diffhunk://#diff-6cc7dfb64e58880213cd2dfbbc9c057b5604d51e44ef0152299522edd701ed47R146-R176)

**Testing and verification:**

* Comprehensive tests for coinbase BUMP correctness, merkle root extraction, and coinbase txid computation have been added in `coinbase_bump_test.go`, ensuring that the computed BUMP folds to the canonical header merkle root and is compatible with downstream SDKs.

**Callback and event emission:**

* The `emitBlockProcessed` and `emitBlockProcessedCallbacks` functions now accept the enrichment data and attach it to the emitted message, ensuring that all consumers receive the full enrichment payload if available. [[1]](diffhunk://#diff-67829257877344ab6b3e6628ff429f8faa778347f4d6b1bcb67f6c798a68caf6L197-R197) [[2]](diffhunk://#diff-67829257877344ab6b3e6628ff429f8faa778347f4d6b1bcb67f6c798a68caf6L251-R251) [[3]](diffhunk://#diff-bb23bf9b6e0a037c63c54666b244ca792a492036a94d3f6d94002feb6b8360c0L563-R564) [[4]](diffhunk://#diff-bb23bf9b6e0a037c63c54666b244ca792a492036a94d3f6d94002feb6b8360c0R601) [[5]](diffhunk://#diff-bb23bf9b6e0a037c63c54666b244ca792a492036a94d3f6d94002feb6b8360c0R633-R642)

These changes collectively ensure that block-level enrichment data is reliably and efficiently surfaced to consumers, improving correctness and reducing redundant computation.
