### PR TITLE
fix(kafka): restore topic auto-creation lost in sarama->franz migration

### DIFF
--- a/internal/kafka/consumer.go
+++ b/internal/kafka/consumer.go
@@ -52,6 +52,12 @@ func consumerOpts(brokers []string, groupID string, topics []string) []kgo.Opt {
 		kgo.HeartbeatInterval(3 * time.Second),
 		kgo.RebalanceTimeout(60 * time.Second),
 		kgo.FetchMaxWait(100 * time.Millisecond),
+		// Restore implicit broker-side topic auto-creation (sarama defaulted
+		// Metadata.AllowAutoTopicCreation=true). merkle-service does not create
+		// its topics in production code and relies on broker auto-create; without
+		// this a consumer group on a fresh broker never triggers creation of a
+		// topic that no producer has touched yet. Matches the producer option.
+		kgo.AllowAutoTopicCreation(),
 	}
 }
 

--- a/internal/kafka/kafka_integration_test.go
+++ b/internal/kafka/kafka_integration_test.go
@@ -310,3 +310,25 @@ func TestKafka_ConsumerGroupOffsetManagement(t *testing.T) {
 		}
 	}
 }
+
+// TestProducer_AutoCreatesTopic verifies the producer publishes successfully to
+// a topic that does NOT pre-exist, relying on broker-side auto-creation. This
+// is the behavior sarama provided by default (Metadata.AllowAutoTopicCreation=
+// true) and that franz only provides when kgo.AllowAutoTopicCreation() is set.
+// Regression guard for the sarama->franz migration that silently dropped topic
+// auto-creation, causing produce to fail with UNKNOWN_TOPIC_OR_PARTITION
+// ("failed to enqueue") against a fresh broker. Deliberately does NOT call
+// ensureTopicExists.
+func TestProducer_AutoCreatesTopic(t *testing.T) {
+	topic := uniqueTopic(t, "autocreate")
+
+	p, err := kafka.NewProducer(brokers, topic, slog.Default())
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	if err := p.Publish("key", []byte("value")); err != nil {
+		t.Fatalf("Publish to not-pre-created topic %q failed (auto-create regression): %v", topic, err)
+	}
+}

--- a/internal/kafka/producer.go
+++ b/internal/kafka/producer.go
@@ -136,6 +136,17 @@ func NewProducer(brokers []string, topic string, logger *slog.Logger) (*Producer
 		kgo.ProducerBatchMaxBytes(clampBatchMaxBytes(10 * 1024 * 1024)),
 		// Default partitioner hashes a non-nil key and round-robins a nil key —
 		// equivalent to sarama.NewHashPartitioner for our always-keyed produces.
+		//
+		// Restore implicit broker-side topic auto-creation. sarama defaulted
+		// Metadata.AllowAutoTopicCreation=true, so a produce to a not-yet-created
+		// topic triggered the broker (with auto.create.topics.enable=true) to
+		// create it; merkle-service relies on that — it never creates its topics
+		// in production code (only the integration test uses an admin client).
+		// franz defaults this OFF, so without it the first produce to a fresh
+		// broker fails with UNKNOWN_TOPIC_OR_PARTITION ("failed to enqueue") and
+		// consumers find no topic — exactly the round-trip regression introduced
+		// by the sarama->franz migration.
+		kgo.AllowAutoTopicCreation(),
 	}
 
 	client, err := kgo.NewClient(opts...)


### PR DESCRIPTION
## Problem
The sarama→franz-go migration (#141) silently dropped implicit broker-side topic auto-creation.

- sarama defaulted `Metadata.AllowAutoTopicCreation=true`, so producing/metadata against a broker with `auto.create.topics.enable=true` created the topic on demand.
- merkle-service relies on this — it **never creates its topics in production code** (only the integration test uses an admin client; `docker-compose.yml` sets `KAFKA_AUTO_CREATE_TOPICS_ENABLE=true`).
- franz defaults `AllowAutoTopicCreation` **OFF**. So against a fresh broker the first produce fails with `UNKNOWN_TOPIC_OR_PARTITION` ("failed to enqueue") and consumers find no topic.

This is the block round-trip regression observed in arcade's e2e against v0.2.4: dropped BLOCK_PROCESSED callbacks (txs never MINED) and `/reprocess` → 500 "failed to enqueue reprocess".

## Fix
Add `kgo.AllowAutoTopicCreation()` to both the producer and consumer franz client options, restoring the prior sarama default.

## Verification
Added an integration regression guard (`TestProducer_AutoCreatesTopic`) that produces to a not-pre-created topic. Against a local redpanda with auto-create enabled:
- **with** the option → PASS
- **without** it → `UNKNOWN_TOPIC_OR_PARTITION: This server does not host this topic-partition` (the exact prod symptom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)