### PR TITLE
fix(kafka): ensure consumer topics exist before group join (franz /reprocess fix)

### DIFF
--- a/internal/kafka/admin.go
+++ b/internal/kafka/admin.go
@@ -1,0 +1,79 @@
+package kafka
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// Topic creation defaults. Single partition + replication factor 1 matches the
+// broker defaults merkle-service has always relied on (and the integration
+// test's ensureTopicExists).
+const (
+	defaultTopicPartitions  int32 = 1
+	defaultTopicReplication int16 = 1
+)
+
+// EnsureTopics creates each non-empty topic that does not already exist, via the
+// franz admin API (kadm). It is idempotent: an already-existing topic is treated
+// as success (kerr.TopicAlreadyExists is checked on both the call error and the
+// per-topic response, per teranode #633 — not a string match).
+//
+// merkle-service calls this from NewConsumer so a consumer group's topics exist
+// BEFORE it joins, giving it a stable partition assignment immediately. Without
+// it, a consumer subscribed to a not-yet-created topic must wait for a metadata
+// refresh to discover the partition once a producer lazily auto-creates it — and
+// franz's default MetadataMaxAge is minutes, which left /reprocess block messages
+// unconsumed (the previous sarama client created topics eagerly on first
+// metadata request). Explicit creation also works on brokers with
+// auto.create.topics.enable=false.
+func EnsureTopics(ctx context.Context, brokers, topics []string, logger *slog.Logger) error {
+	uniq := dedupeNonEmpty(topics)
+	if len(uniq) == 0 {
+		return nil
+	}
+
+	client, err := kgo.NewClient(kgo.SeedBrokers(brokers...))
+	if err != nil {
+		return fmt.Errorf("ensure topics: admin client: %w", err)
+	}
+	defer client.Close()
+
+	admin := kadm.NewClient(client)
+	for _, topic := range uniq {
+		resp, cErr := admin.CreateTopic(ctx, defaultTopicPartitions, defaultTopicReplication, nil, topic)
+		if cErr != nil && !errors.Is(cErr, kerr.TopicAlreadyExists) {
+			return fmt.Errorf("ensure topic %s: %w", topic, cErr)
+		}
+		if resp.Err != nil && !errors.Is(resp.Err, kerr.TopicAlreadyExists) {
+			return fmt.Errorf("ensure topic %s: %w", topic, resp.Err)
+		}
+		if logger != nil {
+			logger.Debug("ensured kafka topic exists", "topic", topic)
+		}
+	}
+	return nil
+}
+
+// dedupeNonEmpty returns the input with empty strings dropped and duplicates
+// removed, preserving first-seen order.
+func dedupeNonEmpty(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/kafka/consumer.go
+++ b/internal/kafka/consumer.go
@@ -92,6 +92,19 @@ type Consumer struct {
 // correct: the handlers are idempotent and the backlog must be processed, never
 // dropped.
 func NewConsumer(brokers []string, groupID string, topics []string, handler MessageHandler, logger *slog.Logger) (*Consumer, error) {
+	// Ensure the subscribed topics exist before joining the group, so partition
+	// assignment is immediate rather than waiting for a metadata refresh to
+	// discover a lazily-auto-created topic (see EnsureTopics — this is what left
+	// /reprocess block messages unconsumed under franz). Best-effort: a transient
+	// failure is logged, not fatal — the consumer still works via metadata
+	// refresh + producer-side auto-creation, just less promptly.
+	ensureCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	if eErr := EnsureTopics(ensureCtx, brokers, topics, logger); eErr != nil && logger != nil {
+		logger.Warn("could not pre-create consumer topics; relying on auto-create",
+			"groupID", groupID, "topics", topics, "error", eErr)
+	}
+	cancel()
+
 	client, err := kgo.NewClient(consumerOpts(brokers, groupID, topics)...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create consumer group %s: %w", groupID, err)


### PR DESCRIPTION
## Problem
The sarama→franz migration (#141) also regressed the `/reprocess` recovery path. A franz consumer subscribed to a topic that doesn't exist yet only discovers the partition on a metadata refresh (franz default `MetadataMaxAge` is minutes) once a producer lazily auto-creates it. sarama created topics eagerly on its first metadata request, so the block-processor consumed reprocess block messages immediately; under franz they sat unconsumed and `/reprocess` never reached MINED (seen in arcade's e2e `TestSmoke_RealBlockMined_ViaReprocess`).

## Fix
Add `EnsureTopics` (kadm `CreateTopic`, idempotent on `kerr.TopicAlreadyExists` — both call error and per-topic resp, per #633) and call it from `NewConsumer` so a consumer group's topics exist **before** it joins → stable partition assignment immediately. Best-effort (logged, not fatal); producer-side `AllowAutoTopicCreation` (from #145) remains a fallback. Works on brokers with `auto.create.topics.enable=false` too.

Verified locally that `NewConsumer` now creates its subscribed topics up front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)