### PR TITLE
fix(kafka): restore EnsureTopics call dropped by #144 merge

### DIFF
--- a/internal/kafka/consumer.go
+++ b/internal/kafka/consumer.go
@@ -134,6 +134,19 @@ func NewConsumer(brokers []string, groupID string, topics []string, handler Mess
 		workers: make(map[topicPartition]*partitionWorker),
 	}
 
+	// Ensure the subscribed topics exist before joining the group, so partition
+	// assignment is immediate rather than waiting for a metadata refresh to
+	// discover a lazily-auto-created topic (see EnsureTopics — this is what left
+	// /reprocess block messages unconsumed under franz). Best-effort: a transient
+	// failure is logged, not fatal — the consumer still works via metadata
+	// refresh + producer-side auto-creation, just less promptly.
+	ensureCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	if eErr := EnsureTopics(ensureCtx, brokers, topics, logger); eErr != nil && logger != nil {
+		logger.Warn("could not pre-create consumer topics; relying on auto-create",
+			"groupID", groupID, "topics", topics, "error", eErr)
+	}
+	cancel()
+
 	opts := append(consumerOpts(brokers, groupID, topics),
 		// Rebalances are processed only inside PollFetches, so the
 		// assigned/revoked/lost callbacks below run on the poll goroutine and


### PR DESCRIPTION
## Problem

`EnsureTopics` is **orphaned on `main`** — defined in `internal/kafka/admin.go`, called from nowhere in non-test code.

It was introduced in **#147** ("ensure consumer topics exist before group join") and called from `NewConsumer`. **#144** (the SEEN-path batching PR) branched from before #147 and, when it merged *after* #147, its copy of `consumer.go` overwrote `NewConsumer` and silently dropped the `EnsureTopics` call.

## Impact

This reintroduces the exact regression #147 fixed:

- Under franz-go, a consumer subscribed to a not-yet-created topic only discovers the partition on a **metadata refresh** (default `MetadataMaxAge` is minutes) after some producer lazily auto-creates it.
- sarama created topics eagerly on its first metadata request, so this never surfaced pre-migration.
- Concretely: `/reprocess` block messages sit **unconsumed** and never reach `MINED`, because the block-processor consumer joins before its topic exists.

## Fix

Restore the best-effort `EnsureTopics` call ahead of client construction in `NewConsumer` (verbatim to #147's intent):

- Logged, not fatal — a transient broker hiccup at startup won't crash.
- Producer-side `AllowAutoTopicCreation` remains the fallback.
- Works on brokers with `auto.create.topics.enable=false`.

## Verification

- `go build ./internal/kafka/` ✅
- `go vet ./internal/kafka/` ✅
- `go test -short ./internal/kafka/` → 24 passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)