### PR TITLE
chore(store): migrate Aerospike client v7 → v8 (match teranode)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bsv-blockchain/merkle-service
 go 1.26.2
 
 require (
-	github.com/aerospike/aerospike-client-go/v7 v7.10.2
+	github.com/aerospike/aerospike-client-go/v8 v8.7.0
 	github.com/bsv-blockchain/go-bt/v2 v2.6.7
 	github.com/bsv-blockchain/go-sdk v1.2.24
 	github.com/bsv-blockchain/go-subtree v1.4.4
@@ -32,7 +32,6 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
 	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/Microsoft/go-winio v0.6.3-0.20251027160822-ad3df93bed29 // indirect
-	github.com/aerospike/aerospike-client-go/v8 v8.7.0 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.42.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.13 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.32.25 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,6 @@ github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAw
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.3-0.20251027160822-ad3df93bed29 h1:0kQAzHq8vLs7Pptv+7TxjdETLf/nIqJpIB4oC6Ba4vY=
 github.com/Microsoft/go-winio v0.6.3-0.20251027160822-ad3df93bed29/go.mod h1:ZWa7ssZJT30CCDGJ7fk/2SBTq9BIQrrVjrcss0UW2s0=
-github.com/aerospike/aerospike-client-go/v7 v7.10.2 h1:6XK2FeehMg1dninih8BhSuqBN7VUsL/8ExdHR2C6C4c=
-github.com/aerospike/aerospike-client-go/v7 v7.10.2/go.mod h1:STlBtOkKT8nmp7iD+sEkr/JGEOu+4e2jGlNN0Jiu2a4=
 github.com/aerospike/aerospike-client-go/v8 v8.7.0 h1:ihcad2ekboqRsP5Rd6wvVRjBz4i+bOFXksAgMZarbAo=
 github.com/aerospike/aerospike-client-go/v8 v8.7.0/go.mod h1:H6RYZ7CMLH8Qt9Zj0Zsk5ynnEc/kfXm6z2J6tA81jH8=
 github.com/aws/aws-sdk-go-v2 v1.42.0 h1:XvXMJTkFQtpBKIWZnmr9ZEOc2InWM2yldjXEJ/bymhA=
@@ -201,7 +199,6 @@ github.com/go-openapi/testify/enable/yaml/v2 v2.5.1 h1:q9NtHwK4qHF7yZziBPvZyv7zW
 github.com/go-openapi/testify/enable/yaml/v2 v2.5.1/go.mod h1:JW0MXIotCYps/XsgJnG3a8Q7rE5xAiBwoOD5OfaIQBk=
 github.com/go-openapi/testify/v2 v2.5.1 h1:TMdhCaw8fUNraVSf3Omoob1dO/AzBfhtFAPW0an6sBo=
 github.com/go-openapi/testify/v2 v2.5.1/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
-github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=

--- a/internal/metrics/database.go
+++ b/internal/metrics/database.go
@@ -7,8 +7,8 @@ import (
 	"log/slog"
 	"time"
 
-	as "github.com/aerospike/aerospike-client-go/v7"
-	astypes "github.com/aerospike/aerospike-client-go/v7/types"
+	as "github.com/aerospike/aerospike-client-go/v8"
+	astypes "github.com/aerospike/aerospike-client-go/v8/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/internal/store/aerospike.go
+++ b/internal/store/aerospike.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"time"
 
-	as "github.com/aerospike/aerospike-client-go/v7"
+	as "github.com/aerospike/aerospike-client-go/v8"
 
 	"github.com/bsv-blockchain/merkle-service/internal/config"
 )

--- a/internal/store/callback_accumulator.go
+++ b/internal/store/callback_accumulator.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 
-	as "github.com/aerospike/aerospike-client-go/v7"
-	astypes "github.com/aerospike/aerospike-client-go/v7/types"
+	as "github.com/aerospike/aerospike-client-go/v8"
+	astypes "github.com/aerospike/aerospike-client-go/v8/types"
 )
 
 const accumEntriesBin = "entries"

--- a/internal/store/callback_dedup.go
+++ b/internal/store/callback_dedup.go
@@ -7,8 +7,8 @@ import (
 	"log/slog"
 	"time"
 
-	as "github.com/aerospike/aerospike-client-go/v7"
-	astypes "github.com/aerospike/aerospike-client-go/v7/types"
+	as "github.com/aerospike/aerospike-client-go/v8"
+	astypes "github.com/aerospike/aerospike-client-go/v8/types"
 )
 
 const (

--- a/internal/store/callback_url_registry.go
+++ b/internal/store/callback_url_registry.go
@@ -7,8 +7,8 @@ import (
 	"log/slog"
 	"time"
 
-	as "github.com/aerospike/aerospike-client-go/v7"
-	astypes "github.com/aerospike/aerospike-client-go/v7/types"
+	as "github.com/aerospike/aerospike-client-go/v8"
+	astypes "github.com/aerospike/aerospike-client-go/v8/types"
 )
 
 const (

--- a/internal/store/datahub_registry.go
+++ b/internal/store/datahub_registry.go
@@ -7,8 +7,8 @@ import (
 	"log/slog"
 	"time"
 
-	as "github.com/aerospike/aerospike-client-go/v7"
-	astypes "github.com/aerospike/aerospike-client-go/v7/types"
+	as "github.com/aerospike/aerospike-client-go/v8"
+	astypes "github.com/aerospike/aerospike-client-go/v8/types"
 )
 
 const (

--- a/internal/store/registration.go
+++ b/internal/store/registration.go
@@ -6,8 +6,8 @@ import (
 	"log/slog"
 	"time"
 
-	as "github.com/aerospike/aerospike-client-go/v7"
-	astypes "github.com/aerospike/aerospike-client-go/v7/types"
+	as "github.com/aerospike/aerospike-client-go/v8"
+	astypes "github.com/aerospike/aerospike-client-go/v8/types"
 )
 
 const (

--- a/internal/store/seen_counter.go
+++ b/internal/store/seen_counter.go
@@ -6,8 +6,8 @@ import (
 	"log/slog"
 	"time"
 
-	as "github.com/aerospike/aerospike-client-go/v7"
-	astypes "github.com/aerospike/aerospike-client-go/v7/types"
+	as "github.com/aerospike/aerospike-client-go/v8"
+	astypes "github.com/aerospike/aerospike-client-go/v8/types"
 )
 
 const (

--- a/internal/store/subtree_counter.go
+++ b/internal/store/subtree_counter.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"log/slog"
 
-	as "github.com/aerospike/aerospike-client-go/v7"
-	astypes "github.com/aerospike/aerospike-client-go/v7/types"
+	as "github.com/aerospike/aerospike-client-go/v8"
+	astypes "github.com/aerospike/aerospike-client-go/v8/types"
 )
 
 const (


### PR DESCRIPTION
## Problem

`internal/store/*` imported **`aerospike-client-go/v7`** (v7.10.2), but the binary **already linked v8 indirectly** via the teranode dependency (`teranode/model`, `teranode/util`). So two copies of the Aerospike client were compiled into every merkle-service binary, and merkle was a major version behind teranode (which is on v8).

## Change

Pure module-path migration — no logic changes:

- Every `aerospike-client-go/v7` import → `/v8` (9 `internal/store/*` files + `internal/metrics/database.go`).
- `go.mod`: drop the `v7` require; promote `v8` from indirect to a direct dependency.
- Resolves to **v8.7.0** — the version merkle was already pulling transitively (MVS floor from other deps; same major client as teranode main).

The API surface merkle uses (`NewKey`, `NewBatchWrite`, `ListAppendWithPolicyOp`, `BatchPolicy`, `NewClientWithPolicyAndHost`, CDT ops, etc.) is **identical** across v7 and v8 — the swap compiles and passes with zero source edits beyond the import line.

## Not in scope

This does **not** change `ConcurrentNodes` behaviour. Both v7 and v8 default `NewBatchPolicy().ConcurrentNodes` to `1` (serial per-node batch fan-out). That perf change is tracked separately in the throughput review.

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test -short ./internal/store/... ./internal/datahub/... ./internal/metrics/...` → 176 passed ✅
- `go list -m all | grep aerospike-client-go` → only `v8 v8.7.0` (v7 gone from the module graph) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)