### PR TITLE
perf(store): concurrent Aerospike batch node fan-out (configurable)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -154,6 +154,20 @@ aerospike:
   # Env: AEROSPIKE_TOTAL_TIMEOUT_MS
   totalTimeoutMs: 15000
 
+  # How many cluster nodes a single BatchGet/BatchOperate fans out to
+  # concurrently. The Aerospike Go client defaults this to 1, issuing each
+  # owning node's sub-batch serially on the calling goroutine — so a batch
+  # whose keys span M nodes costs M sequential round-trips. On the SEEN/MINED
+  # read path that serialization is the dominant per-subtree database cost.
+  #   0  = all owning nodes concurrently (one parallel fan-out) — default
+  #   1  = serial, one node at a time (the Aerospike library default)
+  #   >1 = up to N nodes concurrently
+  # On a large cluster, bound this (e.g. 8) if wide fan-out from many partition
+  # workers at once pushes the per-node pool (connectionQueueSize) under
+  # pressure. Retries do NOT re-fan-out (batch MaxRetries is 0).
+  # Env: AEROSPIKE_BATCH_CONCURRENT_NODES
+  batchConcurrentNodes: 0
+
 # ---------------------------------------------------------------------------
 # Kafka — async messaging between services
 # ---------------------------------------------------------------------------

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -181,6 +181,23 @@ type AerospikeConfig struct {
 	// ErrorRateWindow is the number of cluster-tend iterations over which
 	// MaxErrorRate accumulates. Default 1 (~1 second of accumulation).
 	ErrorRateWindow int `yaml:"errorRateWindow" mapstructure:"errorratewindow"`
+	// BatchConcurrentNodes controls how many cluster nodes a single
+	// BatchGet/BatchOperate fans out to concurrently. The Aerospike Go client
+	// defaults this to 1 — each owning node's sub-batch is issued serially on
+	// the calling goroutine, so a batch whose keys span M nodes costs M
+	// sequential round-trips. On the SEEN/MINED read path (registration
+	// BatchGet, seen-counter BatchIncrement) that serialization is the dominant
+	// per-subtree database cost.
+	//
+	//	0  = all owning nodes concurrently — one parallel fan-out (default)
+	//	1  = serial, one node at a time (the Aerospike library default)
+	//	>1 = up to N nodes concurrently
+	//
+	// Default 0 (all concurrent). On a large cluster, where a wide fan-out from
+	// many partition workers at once could push the per-node pool
+	// (ConnectionQueueSize) under pressure, set a bound (e.g. 8) to trade some
+	// parallelism for steadier connection usage.
+	BatchConcurrentNodes int `yaml:"batchConcurrentNodes" mapstructure:"batchconcurrentnodes"`
 }
 
 // SeedHosts returns the list of seed hosts to use when constructing the
@@ -397,6 +414,7 @@ func registerDefaults(v *viper.Viper) {
 	v.SetDefault("aerospike.idletimeoutsec", 55)
 	v.SetDefault("aerospike.maxerrorrate", 5)
 	v.SetDefault("aerospike.errorratewindow", 1)
+	v.SetDefault("aerospike.batchconcurrentnodes", 0)
 
 	// Kafka
 	v.SetDefault("kafka.brokers", []string{"localhost:9092"})

--- a/internal/store/aerospike.go
+++ b/internal/store/aerospike.go
@@ -23,6 +23,11 @@ type AerospikeClient struct {
 	writeTimeoutMs  int
 	batchTimeoutMs  int
 	socketTimeoutMs int
+	// batchConcurrentNodes is applied to every BatchPolicy as ConcurrentNodes.
+	// 0 (the zero value, and our default) means "fan out to all owning nodes
+	// concurrently"; 1 restores the Aerospike library default of serial
+	// per-node sub-batches. See config.AerospikeConfig.BatchConcurrentNodes.
+	batchConcurrentNodes int
 }
 
 // defaults applied when the corresponding cfg.* field is 0.
@@ -128,6 +133,9 @@ func NewAerospikeClientFromConfig(cfg config.AerospikeConfig, logger *slog.Logge
 		writeTimeoutMs:  nz(cfg.WriteTimeoutMs, defaultWriteTimeoutMs),
 		batchTimeoutMs:  nz(cfg.BatchTimeoutMs, defaultBatchTimeoutMs),
 		socketTimeoutMs: nz(cfg.SocketTimeoutMs, defaultSocketTimeoutMs),
+		// Not run through nz(): 0 is a meaningful value here (all nodes
+		// concurrent), and it is exactly the default we want.
+		batchConcurrentNodes: cfg.BatchConcurrentNodes,
 	}
 
 	logger.Info(
@@ -142,6 +150,7 @@ func NewAerospikeClientFromConfig(cfg config.AerospikeConfig, logger *slog.Logge
 		"writeTimeoutMs", c.writeTimeoutMs,
 		"batchTimeoutMs", c.batchTimeoutMs,
 		"socketTimeoutMs", c.socketTimeoutMs,
+		"batchConcurrentNodes", c.batchConcurrentNodes,
 	)
 
 	return c, nil
@@ -197,5 +206,11 @@ func (c *AerospikeClient) BatchPolicy(maxRetries, retryBaseMs int) *as.BatchPoli
 	bp.SleepBetweenRetries = time.Duration(retryBaseMs) * time.Millisecond
 	bp.TotalTimeout = time.Duration(c.batchTimeoutMs) * time.Millisecond
 	bp.SocketTimeout = time.Duration(c.socketTimeoutMs) * time.Millisecond
+	// Fan a batch out to its owning nodes concurrently instead of serially.
+	// NewBatchPolicy() defaults ConcurrentNodes to 1, which issues each node's
+	// sub-batch one after another on this goroutine; a batch spanning M nodes
+	// then costs M sequential round-trips. 0 (our default) means all nodes at
+	// once. This does not re-fan-out on retry — MaxRetries stays 0.
+	bp.ConcurrentNodes = c.batchConcurrentNodes
 	return bp
 }

--- a/internal/store/aerospike_test.go
+++ b/internal/store/aerospike_test.go
@@ -1,0 +1,47 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+// TestBatchPolicyConcurrentNodes pins the ConcurrentNodes fix: the policy that
+// drives every BatchGet/BatchOperate must carry whatever the operator
+// configured, with the zero value meaning "all nodes concurrent" (0) rather
+// than the Aerospike library default of serial per-node fan-out (1).
+//
+// The returned *aerospike.BatchPolicy is referenced only by field access, so
+// this test deliberately does not import the aerospike client package and is
+// agnostic to its major version.
+func TestBatchPolicyConcurrentNodes(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  int
+		want int
+	}{
+		{"default is all-nodes-concurrent", 0, 0},
+		{"serial restores library default", 1, 1},
+		{"bounded fan-out", 8, 8},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &AerospikeClient{
+				batchTimeoutMs:       3000,
+				socketTimeoutMs:      1000,
+				batchConcurrentNodes: tc.cfg,
+			}
+			bp := c.BatchPolicy(0, 100)
+			if bp.ConcurrentNodes != tc.want {
+				t.Fatalf("ConcurrentNodes = %d, want %d", bp.ConcurrentNodes, tc.want)
+			}
+			// Guard against a refactor silently dropping the bounded timeouts /
+			// no-retry contract this policy depends on.
+			if bp.MaxRetries != 0 {
+				t.Errorf("MaxRetries = %d, want 0 (app retries via Kafka)", bp.MaxRetries)
+			}
+			if bp.TotalTimeout != 3000*time.Millisecond {
+				t.Errorf("TotalTimeout = %v, want 3s", bp.TotalTimeout)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`BatchPolicy()` (`internal/store/aerospike.go`) never set `ConcurrentNodes`, so it inherited the Aerospike Go client default of **1**. That means every `BatchGet`/`BatchOperate` issues each owning node's sub-batch **serially** on the calling goroutine — a batch whose keys span M nodes costs **M sequential round-trips**.

On the SEEN/MINED read path (registration `BatchGet`, seen-counter `BatchIncrement`) this node-serialization is the dominant per-subtree database cost, and it scales the *wrong* way with cluster size. It was the single highest-leverage finding in the throughput review (the path to ~2x).

> Note: the Aerospike client major version does not affect this — **both v7 and v8** default `NewBatchPolicy().ConcurrentNodes` to `1`. This fix is orthogonal to the v7→v8 migration (#150) and based on `main`; it rebases cleanly onto either.

## Change

New configurable knob, defaulting to the fix:

```
aerospike.batchConcurrentNodes   (env AEROSPIKE_BATCH_CONCURRENT_NODES)
  0  = all owning nodes concurrently — one parallel fan-out   (default)
  1  = serial, one node at a time (previous / library default)
  >1 = up to N nodes concurrently
```

- Default **0** makes concurrent fan-out the out-of-the-box behaviour; the Go zero value coincides with the library's own `<=0 ⇒ all nodes` sentinel.
- Operators on a **large** cluster can bound it (e.g. `8`) if a wide fan-out from many partition workers at once pressures the per-node pool (`connectionQueueSize`).
- Surfaced in the client-init log alongside the other policy values.

## Safety

Does **not** weaken the existing batch contract that the surrounding code is deliberate about:
- `MaxRetries` stays `0` → a failure does **not** re-fan-out across the cluster.
- Bounded `TotalTimeout`/`SocketTimeout` unchanged.
- Batch ops on these paths are idempotent and retried via Kafka, not in-client.

## Verification

- `go build ./...` ✅ · `go vet` ✅
- `go test -short ./internal/store/... ./internal/config/...` ✅ (incl. `internal/store/sql`)
- New `TestBatchPolicyConcurrentNodes` covers `0` / `1` / `8` and guards `MaxRetries=0` + bounded timeout. The test references the returned policy by field only (no aerospike import) so it's agnostic to the v7/v8 client version.

## Validating the gain

Per the review: the win is **≈ Aerospike node count M** on the per-subtree batch wall-clock — so it's **invisible on a 1-node dev cluster** and must be measured on a **multi-node (≥3)** cluster with production-shaped (~1M-leaf) subtrees. Watch Aerospike batch op wall-clock before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)