### PR TITLE
perf(store): concurrent batch-chunk dispatch (configurable)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -168,6 +168,21 @@ aerospike:
   # Env: AEROSPIKE_BATCH_CONCURRENT_NODES
   batchConcurrentNodes: 0
 
+  # How many of a single batch operation's 5000-key chunks are issued
+  # concurrently (registration BatchGet, seen-counter BatchIncrement). A
+  # teranode-default subtree (~1M txids) splits into ~210 chunks; serially that
+  # is ~210 sequential round-trips on one goroutine — the dominant SEEN/MINED
+  # read-path latency.
+  #   0 or 1 = serial, one chunk at a time (prior behaviour)
+  #   >1     = up to N chunks in flight at once
+  # Connection budget: this multiplies with batchConcurrentNodes and the
+  # caller's own concurrency (block.batchGetConcurrency, or active consumer
+  # partitions on the SEEN fetcher). Peak in-flight node connections ≈
+  # callerConcurrency × batchChunkConcurrency × nodes — keep under
+  # connectionQueueSize, or bound this on large clusters.
+  # Env: AEROSPIKE_BATCH_CHUNK_CONCURRENCY
+  batchChunkConcurrency: 8
+
 # ---------------------------------------------------------------------------
 # Kafka — async messaging between services
 # ---------------------------------------------------------------------------

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -198,6 +198,20 @@ type AerospikeConfig struct {
 	// (ConnectionQueueSize) under pressure, set a bound (e.g. 8) to trade some
 	// parallelism for steadier connection usage.
 	BatchConcurrentNodes int `yaml:"batchConcurrentNodes" mapstructure:"batchconcurrentnodes"`
+	// BatchChunkConcurrency caps how many of a single batch operation's 5000-key
+	// chunks are issued concurrently. A teranode-default subtree (~1M txids) is
+	// split into ~200 chunks; processed serially (the prior behaviour) that is
+	// ~200 sequential round-trips on one goroutine, the dominant SEEN/MINED
+	// read-path latency. Applies to registration BatchGet and seen-counter
+	// BatchIncrement. 0/1 = serial (one chunk at a time); >1 = up to N chunks
+	// in flight at once. Default 8.
+	//
+	// Connection-budget note: this multiplies with BatchConcurrentNodes and with
+	// the caller's own concurrency (block.batchGetConcurrency, or the number of
+	// active consumer partitions on the SEEN fetcher). Peak in-flight node
+	// connections ≈ callerConcurrency × BatchChunkConcurrency × nodes — keep that
+	// under ConnectionQueueSize, or bound this on large clusters.
+	BatchChunkConcurrency int `yaml:"batchChunkConcurrency" mapstructure:"batchchunkconcurrency"`
 }
 
 // SeedHosts returns the list of seed hosts to use when constructing the
@@ -415,6 +429,7 @@ func registerDefaults(v *viper.Viper) {
 	v.SetDefault("aerospike.maxerrorrate", 5)
 	v.SetDefault("aerospike.errorratewindow", 1)
 	v.SetDefault("aerospike.batchconcurrentnodes", 0)
+	v.SetDefault("aerospike.batchchunkconcurrency", 8)
 
 	// Kafka
 	v.SetDefault("kafka.brokers", []string{"localhost:9092"})

--- a/internal/store/aerospike.go
+++ b/internal/store/aerospike.go
@@ -28,6 +28,11 @@ type AerospikeClient struct {
 	// concurrently"; 1 restores the Aerospike library default of serial
 	// per-node sub-batches. See config.AerospikeConfig.BatchConcurrentNodes.
 	batchConcurrentNodes int
+	// batchChunkConcurrency caps how many of a batch operation's 5000-key chunks
+	// are issued concurrently (registration BatchGet, seen-counter
+	// BatchIncrement). <=1 runs chunks serially. See
+	// config.AerospikeConfig.BatchChunkConcurrency.
+	batchChunkConcurrency int
 }
 
 // defaults applied when the corresponding cfg.* field is 0.
@@ -44,6 +49,10 @@ const (
 	// node instead of stacking timeouts on it.
 	defaultMaxErrorRate    = 5
 	defaultErrorRateWindow = 1
+	// defaultBatchChunkConcurrency fans a multi-chunk batch out 8-wide. Matches
+	// the low end of the throughput-review recommendation (8-16); operators bound
+	// it on large clusters via aerospike.batchChunkConcurrency.
+	defaultBatchChunkConcurrency = 8
 )
 
 // NewAerospikeClient creates a new Aerospike client wrapper from a single seed.
@@ -64,10 +73,11 @@ func NewAerospikeClient(host string, port int, namespace string, maxRetries, ret
 		namespace:       namespace,
 		logger:          logger,
 		policy:          policy,
-		readTimeoutMs:   defaultReadTimeoutMs,
-		writeTimeoutMs:  defaultWriteTimeoutMs,
-		batchTimeoutMs:  defaultBatchTimeoutMs,
-		socketTimeoutMs: defaultSocketTimeoutMs,
+		readTimeoutMs:         defaultReadTimeoutMs,
+		writeTimeoutMs:        defaultWriteTimeoutMs,
+		batchTimeoutMs:        defaultBatchTimeoutMs,
+		socketTimeoutMs:       defaultSocketTimeoutMs,
+		batchChunkConcurrency: defaultBatchChunkConcurrency,
 	}, nil
 }
 
@@ -135,7 +145,8 @@ func NewAerospikeClientFromConfig(cfg config.AerospikeConfig, logger *slog.Logge
 		socketTimeoutMs: nz(cfg.SocketTimeoutMs, defaultSocketTimeoutMs),
 		// Not run through nz(): 0 is a meaningful value here (all nodes
 		// concurrent), and it is exactly the default we want.
-		batchConcurrentNodes: cfg.BatchConcurrentNodes,
+		batchConcurrentNodes:  cfg.BatchConcurrentNodes,
+		batchChunkConcurrency: nz(cfg.BatchChunkConcurrency, defaultBatchChunkConcurrency),
 	}
 
 	logger.Info(
@@ -151,6 +162,7 @@ func NewAerospikeClientFromConfig(cfg config.AerospikeConfig, logger *slog.Logge
 		"batchTimeoutMs", c.batchTimeoutMs,
 		"socketTimeoutMs", c.socketTimeoutMs,
 		"batchConcurrentNodes", c.batchConcurrentNodes,
+		"batchChunkConcurrency", c.batchChunkConcurrency,
 	)
 
 	return c, nil

--- a/internal/store/batch_chunk_test.go
+++ b/internal/store/batch_chunk_test.go
@@ -1,7 +1,10 @@
 package store
 
 import (
+	"errors"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -62,5 +65,112 @@ func TestChunkSlice(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func mkTxids(n int) []string {
+	s := make([]string, n)
+	for i := range s {
+		s[i] = fmt.Sprintf("txid-%d", i)
+	}
+	return s
+}
+
+// TestForEachChunkConcurrent_CoversEveryItemOnce checks the primitive that drives
+// concurrent BatchGet/BatchIncrement: regardless of concurrency, every item is
+// handled exactly once across the chunks. Run with -race, the shared-map merge
+// pattern the real callers use is also exercised for data races.
+func TestForEachChunkConcurrent_CoversEveryItemOnce(t *testing.T) {
+	for _, concurrency := range []int{0, 1, 4, 16} {
+		t.Run(fmt.Sprintf("concurrency=%d", concurrency), func(t *testing.T) {
+			const n = 23_456 // 5 chunks at size 5000, last partial
+			items := mkTxids(n)
+
+			var mu sync.Mutex
+			seen := make(map[string]int, n)
+			var chunkCount atomic.Int64
+
+			err := forEachChunkConcurrent(items, aerospikeBatchChunkSize, concurrency, func(chunk []string) error {
+				chunkCount.Add(1)
+				// Mirror the caller pattern: build a per-chunk local result, then
+				// merge under the mutex.
+				local := make([]string, len(chunk))
+				copy(local, chunk)
+				mu.Lock()
+				for _, id := range local {
+					seen[id]++
+				}
+				mu.Unlock()
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(seen) != n {
+				t.Fatalf("covered %d distinct items, want %d", len(seen), n)
+			}
+			for id, c := range seen {
+				if c != 1 {
+					t.Fatalf("item %s handled %d times, want exactly 1", id, c)
+				}
+			}
+			if got := chunkCount.Load(); got != 5 {
+				t.Fatalf("ran %d chunks, want 5", got)
+			}
+		})
+	}
+}
+
+// TestForEachChunkConcurrent_AttemptsAllAndReturnsError pins the best-effort
+// contract: a failing chunk does not abort the others, and an error is still
+// surfaced (so the caller redelivers).
+func TestForEachChunkConcurrent_AttemptsAllAndReturnsError(t *testing.T) {
+	for _, concurrency := range []int{1, 8} {
+		t.Run(fmt.Sprintf("concurrency=%d", concurrency), func(t *testing.T) {
+			items := mkTxids(20_000) // 4 chunks
+			var attempts atomic.Int64
+			sentinel := errors.New("boom")
+
+			err := forEachChunkConcurrent(items, aerospikeBatchChunkSize, concurrency, func(chunk []string) error {
+				attempts.Add(1)
+				if chunk[0] == "txid-5000" { // the 2nd chunk fails
+					return sentinel
+				}
+				return nil
+			})
+			if !errors.Is(err, sentinel) {
+				t.Fatalf("error = %v, want sentinel", err)
+			}
+			if got := attempts.Load(); got != 4 {
+				t.Fatalf("attempted %d chunks, want all 4 despite the failure", got)
+			}
+		})
+	}
+}
+
+// TestForEachChunkConcurrent_SingleChunkStaysSerial confirms the no-goroutine
+// fast path: a single chunk (or empty input) runs inline regardless of the
+// concurrency setting.
+func TestForEachChunkConcurrent_SingleChunkStaysSerial(t *testing.T) {
+	var calls atomic.Int64
+	if err := forEachChunkConcurrent(mkTxids(10), aerospikeBatchChunkSize, 16, func(_ []string) error {
+		calls.Add(1)
+		return nil
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("single chunk ran %d times, want 1", calls.Load())
+	}
+
+	calls.Store(0)
+	if err := forEachChunkConcurrent(nil, aerospikeBatchChunkSize, 16, func(_ []string) error {
+		calls.Add(1)
+		return nil
+	}); err != nil {
+		t.Fatalf("unexpected error on empty: %v", err)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("empty input ran fn %d times, want 0", calls.Load())
 	}
 }

--- a/internal/store/registration.go
+++ b/internal/store/registration.go
@@ -4,10 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	as "github.com/aerospike/aerospike-client-go/v8"
 	astypes "github.com/aerospike/aerospike-client-go/v8/types"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -261,15 +263,60 @@ func chunkSlice(items []string, size int) [][]string {
 	return chunks
 }
 
+// forEachChunkConcurrent splits items into <=chunkSize chunks and invokes fn on
+// each, running up to `concurrency` chunks at once. concurrency<=1 (or a single
+// chunk) runs them serially with no goroutine overhead. Every chunk is attempted
+// regardless of errors — matching the best-effort batch loops this replaces —
+// and the first error any fn reports is returned.
+//
+// fn MUST be safe for concurrent invocation: confine its writes to chunk-disjoint
+// state or synchronize them. Keys are disjoint across chunks, so callers merge
+// per-chunk results under a mutex.
+func forEachChunkConcurrent(items []string, chunkSize, concurrency int, fn func(chunk []string) error) error {
+	chunks := chunkSlice(items, chunkSize)
+	if concurrency <= 1 || len(chunks) <= 1 {
+		var firstErr error
+		for _, chunk := range chunks {
+			if err := fn(chunk); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		return firstErr
+	}
+
+	g := new(errgroup.Group)
+	g.SetLimit(concurrency)
+	for _, chunk := range chunks {
+		g.Go(func() error { return fn(chunk) })
+	}
+	return g.Wait()
+}
+
 // BatchGet returns (url, token) registrations for multiple txids, issuing one
-// Aerospike batch call per aerospikeBatchChunkSize keys. Same dual-shape
-// parsing as Get.
+// Aerospike batch call per aerospikeBatchChunkSize keys, up to
+// batchChunkConcurrency chunks concurrently. Same dual-shape parsing as Get.
+// Any chunk error fails the whole call (the caller redelivers; all ops are
+// idempotent reads).
 func (s *aerospikeRegistration) BatchGet(txids []string) (map[string][]CallbackEntry, error) {
 	result := make(map[string][]CallbackEntry)
-	for _, chunk := range chunkSlice(txids, aerospikeBatchChunkSize) {
-		if err := s.batchGetChunk(chunk, result); err != nil {
-			return nil, err
-		}
+	var mu sync.Mutex
+	err := forEachChunkConcurrent(txids, aerospikeBatchChunkSize, s.client.batchChunkConcurrency,
+		func(chunk []string) error {
+			// Per-chunk local map: chunk key sets are disjoint, so we merge into
+			// the shared result under a mutex rather than write the map concurrently.
+			local := make(map[string][]CallbackEntry, len(chunk))
+			if cErr := s.batchGetChunk(chunk, local); cErr != nil {
+				return cErr
+			}
+			mu.Lock()
+			for k, v := range local {
+				result[k] = v
+			}
+			mu.Unlock()
+			return nil
+		})
+	if err != nil {
+		return nil, err
 	}
 	return result, nil
 }

--- a/internal/store/seen_counter.go
+++ b/internal/store/seen_counter.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	as "github.com/aerospike/aerospike-client-go/v8"
@@ -160,22 +161,23 @@ func (s *aerospikeSeenCounter) Threshold() int {
 	return s.threshold
 }
 
-// BatchIncrement records that every txid in txids was seen in subtreeID using
-// two batched phases instead of 2 serial RTTs per txid (throughput review
-// F-4: the sequential Increment loop capped the SEEN path at ~500-1000
-// txids/s per instance):
+// BatchIncrement records that every txid in txids was seen in subtreeID,
+// replacing the sequential 2-RTT-per-txid Increment loop that capped the SEEN
+// path at ~500-1000 txids/s per instance (throughput review F-4).
 //
-//	Phase 1 (bulk, common case): one chunked BatchOperate appends subtreeID to
-//	every txid's unique-subtree list (idempotent: AddUnique|NoFail), then one
-//	chunked BatchGet reads back each record's list size and threshold-fired
-//	flag. Two batch round-trips per 5000 txids.
+// txids are split into <=aerospikeBatchChunkSize chunks, and up to
+// batchChunkConcurrency chunks are processed concurrently. Each chunk
+// (batchIncrementChunk) is a SINGLE batch round-trip that both appends
+// subtreeID to every txid's unique-subtree list AND reads back the count and
+// threshold-fired flag (the list-append op returns the new size, so no separate
+// read-back is needed). Any txid that has just reached the threshold without the
+// fired flag set then goes through the generation-CAS Increment, preserving the
+// F-045 exactly-once guarantee: when several workers race, exactly one observes
+// ThresholdReached=true. That fire path is empty in steady state.
 //
-//	Phase 2 (rare): only txids whose count has reached the threshold WITHOUT
-//	the fired flag set are candidates for the exactly-once 0->1 transition.
-//	Each candidate goes through the existing generation-CAS Increment, which
-//	preserves the F-045 guarantee: when several workers race, exactly one
-//	observes ThresholdReached=true. A txid crosses the threshold at most once
-//	in its lifetime, so phase 2 is empty in steady state.
+// Chunks cover disjoint txids, so each accumulates into its own local result map
+// (and its own CAS calls on distinct keys) merged under a mutex;
+// batchChunkConcurrency<=1 keeps the whole thing serial.
 //
 // Returns a result for every txid that succeeded plus the first error
 // encountered (F-058 partial-success contract: the caller emits callbacks for
@@ -187,19 +189,25 @@ func (s *aerospikeSeenCounter) BatchIncrement(txids []string, subtreeID string) 
 		return results, nil
 	}
 
-	var firstErr error
-	saveErr := func(err error) {
-		if firstErr == nil {
-			firstErr = err
-		}
-	}
-
-	for _, chunk := range chunkSlice(txids, aerospikeBatchChunkSize) {
-		if err := s.batchIncrementChunk(chunk, subtreeID, results); err != nil {
-			saveErr(err)
-		}
-	}
-	return results, firstErr
+	// Chunks carry disjoint txid sets, so each runs into its own local result map
+	// (and its own phase-2 generation-CAS calls on distinct keys) and is merged
+	// under a mutex. batchChunkConcurrency<=1 keeps this fully serial.
+	var mu sync.Mutex
+	err := forEachChunkConcurrent(txids, aerospikeBatchChunkSize, s.client.batchChunkConcurrency,
+		func(chunk []string) error {
+			local := make(map[string]*IncrementResult, len(chunk))
+			chunkErr := s.batchIncrementChunk(chunk, subtreeID, local)
+			// Merge partial results even on error: batchIncrementChunk follows the
+			// F-058 partial-success contract (populate what succeeded, surface the
+			// first error for redelivery).
+			mu.Lock()
+			for k, v := range local {
+				results[k] = v
+			}
+			mu.Unlock()
+			return chunkErr
+		})
+	return results, err
 }
 
 // batchIncrementChunk processes one <=aerospikeBatchChunkSize chunk in a SINGLE


### PR DESCRIPTION
> **Stacked on #151** (`perf/aerospike-concurrent-nodes`). Until #151 merges, the diff below includes its commit too — **review the top commit** (`perf(store): dispatch batch chunks concurrently`). GitHub will collapse the diff to just this change once #151 lands.

## Problem

A `BatchGet`/`BatchIncrement` over a large subtree is split into 5000-key chunks (Aerospike `batch-max-requests`). Those chunks were issued **serially on one goroutine**, so a teranode-default ~1M-txid subtree costs **~210 sequential batch round-trips** — the dominant SEEN/MINED read-path latency now that the prior P1 batching has landed. This was item 3.2 in the throughput review (~8x on the DB-bound arm; compounds with #151).

## Change

Fan the chunks out concurrently, bounded by a new knob (default on):

```
aerospike.batchChunkConcurrency   (env AEROSPIKE_BATCH_CHUNK_CONCURRENCY)
  0/1 = serial, one chunk at a time (prior behaviour)
  >1  = up to N chunks in flight at once
  default 8
```

- Applies to `registration.BatchGet` (SEEN fetcher **and** block path) and `seenCounter.BatchIncrement` (SEEN path), via a shared `forEachChunkConcurrent` helper.
- `<=1` or a single chunk → original serial path, **no goroutine overhead**.

## Correctness

- **Disjoint keys per chunk** → each chunk builds a local result map, merged under a mutex (no concurrent map writes).
- **Best-effort / F-058 partial-success preserved**: every chunk is attempted regardless of errors; the first error is still returned so the caller redelivers.
- **F-045 exactly-once threshold unchanged**: the seen-counter's phase-2 generation-CAS runs on distinct keys; parallelism across chunks doesn't introduce same-key races.

## Connection budget (important for large clusters)

This multiplies with `batchConcurrentNodes` (#151) and the caller's own concurrency (`block.batchGetConcurrency`, default 4; or active SEEN-fetcher partitions):

```
peak in-flight node connections ≈ callerConcurrency × batchChunkConcurrency × nodes
```

Documented in `config.yaml` and the config struct against `connectionQueueSize` (default 256). At defaults (4 × 8 × ~6 nodes ≈ 192) this is within budget; operators on larger clusters should bound `batchChunkConcurrency` or raise `connectionQueueSize`.

## Verification

- `go build ./...` ✅ · `go vet` ✅
- `go test -short` on store (+sql), config, subtree, block ✅
- `go test -race ./internal/store/` ✅
- New `TestForEachChunkConcurrent_*`: full item coverage at concurrency 0/1/4/16, attempt-all + first-error contract, single-chunk fast path, and a `-race`-checked shared-merge pattern.

## Validating the gain

Like #151, the win shows on a **multi-node cluster** with **production-shaped (~1M-leaf) subtrees** and a realistic registered-txid density — measure SEEN-path serial-RTTs-per-subtree / batch wall-clock before/after. Invisible on a 1-node dev cluster with tiny fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)