### PR TITLE
perf(store): collapse seen-counter read-back into the append op

### DIFF
--- a/internal/store/seen_counter.go
+++ b/internal/store/seen_counter.go
@@ -202,72 +202,66 @@ func (s *aerospikeSeenCounter) BatchIncrement(txids []string, subtreeID string) 
 	return results, firstErr
 }
 
-// batchIncrementChunk runs both phases for one <=aerospikeBatchChunkSize chunk.
+// batchIncrementChunk processes one <=aerospikeBatchChunkSize chunk in a SINGLE
+// batch round-trip. Per txid it issues a BatchOperate that both (a) idempotently
+// appends subtreeID to the unique-subtree list and (b) reads the threshold-fired
+// flag. The list-append operation itself returns the resulting list size
+// ("Server returns list size on bin name"), so the post-count is known without a
+// second read-back BatchGet — halving the per-chunk RTTs versus the prior
+// append-then-BatchGet pair.
+//
+// Phase 2 (the exactly-once 0->threshold transition) is unchanged: any txid that
+// has just reached the threshold without the fired flag set is delegated to the
+// generation-CAS Increment, preserving the F-045 guarantee that exactly one
+// concurrent observer reports ThresholdReached=true.
 func (s *aerospikeSeenCounter) batchIncrementChunk(txids []string, subtreeID string, results map[string]*IncrementResult) error {
-	keys := make([]*as.Key, len(txids))
+	listPolicy := as.NewListPolicy(as.ListOrderUnordered, as.ListWriteFlagsAddUnique|as.ListWriteFlagsNoFail)
+	batchRecs := make([]as.BatchRecordIfc, len(txids))
 	for i, txid := range txids {
 		key, err := as.NewKey(s.client.Namespace(), s.setName, txid)
 		if err != nil {
 			return fmt.Errorf("failed to create key for %s: %w", txid, err)
 		}
-		keys[i] = key
-	}
-
-	// Phase 1a: idempotent bulk append of subtreeID to every txid's list.
-	listPolicy := as.NewListPolicy(as.ListOrderUnordered, as.ListWriteFlagsAddUnique|as.ListWriteFlagsNoFail)
-	batchRecs := make([]as.BatchRecordIfc, len(keys))
-	for i, key := range keys {
+		// Two ops in one record transaction: the append returns the new
+		// unique-subtree count on seenSubtreesBin; GetBinOp reads only the fired
+		// flag (a different bin, so its result never collides with the append's).
 		batchRecs[i] = as.NewBatchWrite(nil, key,
 			as.ListAppendWithPolicyOp(listPolicy, seenSubtreesBin, subtreeID),
+			as.GetBinOp(seenThresholdFired),
 		)
 	}
+
 	bp := s.client.BatchPolicy(s.maxRetries, s.retryBaseMs)
 	if err := s.client.Client().BatchOperate(bp, batchRecs); err != nil {
-		return fmt.Errorf("batch append seen counters: %w", err)
+		return fmt.Errorf("batch append/read seen counters: %w", err)
 	}
 
-	// Per-key append failures: skip those txids (no result entry) and surface
-	// the first error; the caller's redelivery re-runs the whole idempotent batch.
-	appendOK := make([]bool, len(keys))
+	// Per-key failures: skip those txids (no result entry) and surface the first
+	// error; the caller's redelivery re-runs the whole idempotent batch.
 	var firstErr error
 	for i, br := range batchRecs {
-		if err := br.BatchRec().Err; err != nil {
+		rec := br.BatchRec()
+		if rec.Err != nil {
 			if firstErr == nil {
-				firstErr = fmt.Errorf("batch append seen counter for %s: %w", txids[i], err)
+				firstErr = fmt.Errorf("batch seen counter for %s: %w", txids[i], rec.Err)
 			}
 			continue
 		}
-		appendOK[i] = true
-	}
-
-	// Phase 1b: bulk read-back of list size + fired flag.
-	records, err := s.client.Client().BatchGet(bp, keys, seenSubtreesBin, seenThresholdFired)
-	if err != nil {
-		if firstErr == nil {
-			firstErr = fmt.Errorf("batch read seen counters: %w", err)
-		}
-		return firstErr
-	}
-
-	for i, record := range records {
-		if !appendOK[i] {
-			continue
-		}
-		if record == nil {
-			// Appended in 1a but missing in 1b (expired between phases, or a
-			// per-key read miss). Treat as a per-key failure for redelivery.
+		if rec.Record == nil {
 			if firstErr == nil {
-				firstErr = fmt.Errorf("seen counter for %s missing after batch append", txids[i])
+				firstErr = fmt.Errorf("seen counter for %s missing after batch operate", txids[i])
 			}
 			continue
 		}
 
+		// AddUnique|NoFail: a duplicate subtreeID leaves the count unchanged, so
+		// the returned size is the current unique-subtree count either way.
 		size := 0
-		if list, ok := record.Bins[seenSubtreesBin].([]interface{}); ok {
-			size = len(list)
+		if v, ok := rec.Record.Bins[seenSubtreesBin].(int); ok {
+			size = v
 		}
 		fired := false
-		if firedVal, ok := record.Bins[seenThresholdFired].(int); ok && firedVal == 1 {
+		if firedVal, ok := rec.Record.Bins[seenThresholdFired].(int); ok && firedVal == 1 {
 			fired = true
 		}
 

--- a/internal/store/throughput_bench_integration_test.go
+++ b/internal/store/throughput_bench_integration_test.go
@@ -264,3 +264,77 @@ func TestBatchIncrement_ConcurrentThresholdFiresOnce(t *testing.T) {
 		}
 	}
 }
+
+// TestBatchIncrement_CountIsListSizeAndIdempotent pins the read-back-collapse
+// change: BatchIncrement now derives NewCount from the list-append op's returned
+// size instead of a second BatchGet. This isolates that semantics — a distinct
+// subtree bumps the unique-subtree count by one, and a REPEAT of an
+// already-recorded subtree (AddUnique|NoFail) leaves it unchanged. Threshold is
+// set high so phase 2 never runs and only the phase-1 count path is exercised.
+func TestBatchIncrement_CountIsListSizeAndIdempotent(t *testing.T) {
+	host := os.Getenv("AEROSPIKE_HOST")
+	if host == "" {
+		host = "localhost"
+	}
+	port := 3000
+	if p := os.Getenv("AEROSPIKE_PORT"); p != "" {
+		if v, err := strconv.Atoi(p); err == nil {
+			port = v
+		}
+	}
+	ns := os.Getenv("AEROSPIKE_NAMESPACE")
+	if ns == "" {
+		ns = "merkle"
+	}
+	client, err := store.NewAerospikeClient(host, port, ns, 3, 100, slog.Default())
+	if err != nil {
+		t.Skipf("Aerospike not available: %v", err)
+	}
+	defer client.Close()
+
+	const threshold = 100 // high: keep phase 2 (threshold firing) out of the picture
+	setName := fmt.Sprintf("bench_count_%d", time.Now().UnixNano())
+	sc := store.NewSeenCounterStore(client, setName, threshold, 3, 100, slog.Default())
+	txids := benchTxids("count", 50)
+
+	assertCounts := func(stage string, results map[string]*store.IncrementResult, want int) {
+		t.Helper()
+		if len(results) != len(txids) {
+			t.Fatalf("%s: got %d results, want %d", stage, len(results), len(txids))
+		}
+		for _, txid := range txids {
+			res, ok := results[txid]
+			if !ok {
+				t.Fatalf("%s: missing result for %s", stage, txid)
+			}
+			if res.NewCount != want {
+				t.Errorf("%s: txid %s NewCount=%d, want %d", stage, txid, res.NewCount, want)
+			}
+			if res.ThresholdReached {
+				t.Errorf("%s: txid %s fired below threshold", stage, txid)
+			}
+		}
+	}
+
+	// First distinct subtree -> count 1.
+	r1, err := sc.BatchIncrement(txids, "subtree-A")
+	if err != nil {
+		t.Fatalf("BatchIncrement A: %v", err)
+	}
+	assertCounts("subtree-A", r1, 1)
+
+	// Second distinct subtree -> count 2.
+	r2, err := sc.BatchIncrement(txids, "subtree-B")
+	if err != nil {
+		t.Fatalf("BatchIncrement B: %v", err)
+	}
+	assertCounts("subtree-B", r2, 2)
+
+	// Repeat of subtree-A (AddUnique|NoFail) -> count stays 2, proving the size
+	// returned by the append reflects the deduplicated list, not a blind +1.
+	r3, err := sc.BatchIncrement(txids, "subtree-A")
+	if err != nil {
+		t.Fatalf("BatchIncrement A repeat: %v", err)
+	}
+	assertCounts("subtree-A repeat", r3, 2)
+}


### PR DESCRIPTION
## Problem

`BatchIncrement` processed each 5000-key chunk with **two** batch round-trips:

1. `BatchOperate` — append `subtreeID` to every txid's unique-subtree list.
2. A separate `BatchGet` — read back each list's size (`len(list)`) and the `tfired` flag.

But the Aerospike list-append operation **already returns the resulting list size** (`cdt_list.go`: *"Server returns list size on bin name"*), so the read-back was redundant — a wasted RTT per chunk on the hottest SEEN path.

## Change

Fold the read into the write. The per-record `BatchOperate` now carries two ops:

- `ListAppendWithPolicyOp(...)` — its result **is** the new unique-subtree count (on `subtrees`).
- `GetBinOp(tfired)` — the fired flag (a **different** bin, so the two op results never collide).

→ **one batch round-trip per chunk instead of two** (~2x on the SEEN-increment stage; compounds with the chunk-concurrency and `ConcurrentNodes` changes). As a bonus it removes the append-then-read race the old code had to guard against (a record expiring *between* the two phases) — there's no longer a gap.

## Correctness — F-045 preserved

Phase 2 (the exactly-once `0 -> threshold` transition) is **unchanged**: any txid that has just reached the threshold without `tfired` set is still delegated to the generation-CAS `Increment`. The count that decides "just reached the threshold" now comes from the append result instead of `len(list)` — same value, since `AddUnique|NoFail` means a duplicate subtree leaves the size unchanged.

## Validation — against real Aerospike 8.1.2 (`merkle` namespace)

- **`TestBatchIncrement_ConcurrentThresholdFiresOnce`** (F-045: 8 concurrent workers, 200 txids, threshold 3 → exactly one fire per txid) **passes**. Threshold firing depends on the count now read from the append result, so this directly exercises the change.
- **New `TestBatchIncrement_CountIsListSizeAndIdempotent`** pins the count semantics: distinct subtrees bump the count (1, 2), and a *repeat* subtree (`AddUnique|NoFail`) leaves it at 2 — proving the returned size reflects the deduplicated list, not a blind +1.
- `go build ./...`, `go vet -tags integration ./internal/store/`, and the full store suite pass.

> Independent of #151/#152 — touches only `batchIncrementChunk` (disjoint from #152's `BatchIncrement` loop), so it rebases cleanly in any merge order. Together with #151/#152 this completes the review's SEEN/MINED read-path 2x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)