### PR TITLE
perf(block): drop the double hash-copy in STUMP build

### DIFF
--- a/internal/block/subtree_processor.go
+++ b/internal/block/subtree_processor.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	subtreepkg "github.com/bsv-blockchain/go-subtree"
 
 	"github.com/bsv-blockchain/merkle-service/internal/datahub"
@@ -175,20 +174,22 @@ func ProcessBlockSubtree(
 		return nil, fmt.Errorf("building merkle tree for subtree %s: %w", subtreeHash, err)
 	}
 
-	// Convert leaf hashes to [][]byte.
+	// Expose leaf and internal-node hashes to stump.Build as [][]byte WITHOUT
+	// copying. stump.Build only reads these, and the resulting STUMP is fully
+	// serialized by s.Encode() below (which copies into the wire buffer) before
+	// this function returns — so a []byte view into each [32]byte hash is safe
+	// and avoids ~2*nLeaves small allocations per subtree (~64MB of churn at a
+	// teranode-default 1M-leaf subtree, on the block-time fan-out hot path).
+	// Index the backing slices directly: h[:] on a range *copy* would alias the
+	// loop variable.
 	leaves := make([][]byte, len(nodes))
-	for i, node := range nodes {
-		hashCopy := make([]byte, chainhash.HashSize)
-		copy(hashCopy, node.Hash[:])
-		leaves[i] = hashCopy
+	for i := range nodes {
+		leaves[i] = nodes[i].Hash[:]
 	}
-
-	// Convert internal nodes (from BuildMerkleTreeStoreFromBytes) to [][]byte.
 	internalNodes := make([][]byte, len(*merkleTreeStore))
-	for i, h := range *merkleTreeStore {
-		hashCopy := make([]byte, chainhash.HashSize)
-		copy(hashCopy, h[:])
-		internalNodes[i] = hashCopy
+	mts := *merkleTreeStore
+	for i := range mts {
+		internalNodes[i] = mts[i][:]
 	}
 
 	// 6.6: Map registered txids to their leaf indices in the subtree.


### PR DESCRIPTION
## Problem

`buildSTUMPForSubtree` converted leaf and internal-node hashes to `[][]byte` by allocating a fresh `make([]byte, 32)` + `copy` for **every** node — twice per subtree (leaves *and* internal nodes), `~2×nLeaves` small allocations **regardless of how many txids are registered**.

At a teranode-default ~1M-leaf subtree that's ~4M allocations / ~64MB of churn **per subtree**, on the block-time fan-out hot path — feeding avoidable GC pressure during exactly the bursts that matter most.

## Change

`stump.Build` only **reads** these slices, and the STUMP it returns is fully serialized by `s.Encode()` (which copies into the wire buffer) before this function returns. So a `[]byte` *view* into each `[32]byte` hash is safe:

```go
leaves := make([][]byte, len(nodes))
for i := range nodes {
	leaves[i] = nodes[i].Hash[:]
}
internalNodes := make([][]byte, len(*merkleTreeStore))
mts := *merkleTreeStore
for i := range mts {
	internalNodes[i] = mts[i][:]
}
```

Both copy loops are gone; the hashes are referenced in place, leaving only the two outer `[][]byte` headers. Indices into the backing slices are used (not a range copy's `h[:]`, which would alias the loop variable). `stump.Build`'s signature is unchanged.

This removes **allocation churn only** — the dominant `~nLeaves` double-SHA256 tree build (`BuildMerkleTreeStoreFromBytes`) is untouched. GC-pressure relief, not a CPU multiplier.

## Verification

- `go build ./...`, `go vet` ✅
- `go test -race ./internal/block/` (62) ✅ — the concurrent fan-out path; each invocation's views are local, no cross-goroutine sharing
- `go test ./internal/stump/` ✅ and the integration-tagged `block` + `e2e` suites ✅ — STUMP output unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)