### PR TITLE
perf(datahub): cache SSRF URL validation + widen connection pool

### DIFF
--- a/internal/datahub/client.go
+++ b/internal/datahub/client.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"net"
 	"net/http"
+	"sync"
 	"syscall"
 	"time"
 
@@ -87,6 +88,21 @@ type Client struct {
 	// short-circuit on unhealthy peers — selection stays at the call
 	// site to preserve the "one URL in, one body out" contract.
 	peerHealth *PeerHealth
+
+	// lookupIP overrides the DNS resolver used by SSRF URL validation. nil
+	// selects net.LookupIP (the production path); tests set a stub to count or
+	// fake resolutions.
+	lookupIP func(host string) ([]net.IP, error)
+
+	// validatedURLs caches SUCCESSFUL SSRF validations of peer DataHub base URLs
+	// for dataHubURLValidationTTL, so a high subtree-fetch rate to the same peer
+	// does not re-run a synchronous DNS lookup (ssrfguard.ValidateURL ->
+	// net.LookupIP) on every fetch. Success only: rejections are never cached, so
+	// a transient resolver blip can't pin a peer as bad and a malicious URL keeps
+	// failing every time. DNS-rebind safety is unaffected — the transport's
+	// Dialer.Control hook re-validates the actually-resolved IP on every TCP
+	// dial, uncached. Keyed by the exact base URL string (stable per peer).
+	validatedURLs sync.Map // rawURL string -> expiry unix-nanos (int64)
 }
 
 // SetPeerHealth attaches a PeerHealth tracker. After this call, every
@@ -159,6 +175,12 @@ func newSSRFAwareHTTPClient(timeoutSec int, allowPrivateIPs bool) *http.Client {
 	transport := &http.Transport{
 		IdleConnTimeout:    90 * time.Second,
 		DisableCompression: false,
+		// Keep keep-alive connections warm for reuse under block-time fan-out.
+		// net/http's default MaxIdleConnsPerHost is 2, so concurrent subtree
+		// fetches to the SAME DataHub peer would otherwise re-dial (and re-TLS)
+		// on all but two of them — pure handshake overhead on the hot path.
+		MaxIdleConns:        128,
+		MaxIdleConnsPerHost: 64,
 		DialContext: (&net.Dialer{
 			Timeout:   10 * time.Second,
 			KeepAlive: 30 * time.Second,
@@ -324,13 +346,30 @@ func (c *Client) recordPeerOutcome(dataHubURL string, err error) {
 	c.peerHealth.RecordFailure(dataHubURL)
 }
 
+// dataHubURLValidationTTL bounds how long a successful SSRF validation of a
+// peer DataHub base URL is reused before the DNS lookup is repeated. Short
+// enough that a peer whose DNS legitimately changes is re-checked promptly;
+// the dial-time Control hook enforces SSRF on every connection regardless.
+const dataHubURLValidationTTL = 60 * time.Second
+
 // validateDataHubURL applies the shared SSRF predicate to a peer-supplied
 // DataHub base URL. It runs at request time (so the offending URL never
 // reaches Go's HTTP client) and is reinforced by the Dialer.Control hook
 // installed on the client transport. Errors are wrapped so callers can
 // distinguish SSRF rejection from transport failures.
+//
+// A successful validation is cached for dataHubURLValidationTTL so a burst of
+// fetches to the same peer does not repeat the synchronous DNS lookup. Only
+// successes are cached (see validatedURLs); rejections always re-run.
 func (c *Client) validateDataHubURL(rawURL string) error {
-	if err := ssrfguard.ValidateURL(rawURL, c.allowPrivateIPs, nil); err != nil {
+	if exp, ok := c.validatedURLs.Load(rawURL); ok {
+		if time.Now().UnixNano() < exp.(int64) {
+			return nil
+		}
+		c.validatedURLs.Delete(rawURL)
+	}
+
+	if err := ssrfguard.ValidateURL(rawURL, c.allowPrivateIPs, c.lookupIP); err != nil {
 		c.logger.Warn(
 			"rejecting DataHub URL by SSRF policy",
 			"url", rawURL,
@@ -346,6 +385,7 @@ func (c *Client) validateDataHubURL(rawURL string) error {
 			return fmt.Errorf("DataHub URL validation failed: %w", err)
 		}
 	}
+	c.validatedURLs.Store(rawURL, time.Now().Add(dataHubURLValidationTTL).UnixNano())
 	return nil
 }
 

--- a/internal/datahub/client_dns_cache_test.go
+++ b/internal/datahub/client_dns_cache_test.go
@@ -1,0 +1,100 @@
+package datahub
+
+import (
+	"log/slog"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// countingLookup returns a fixed IP and counts how many times it was invoked,
+// standing in for net.LookupIP so the validation cache can be observed without
+// real DNS.
+func countingLookup(ip string, calls *int) func(string) ([]net.IP, error) {
+	return func(string) ([]net.IP, error) {
+		*calls++
+		return []net.IP{net.ParseIP(ip)}, nil
+	}
+}
+
+func TestValidateDataHubURL_CachesSuccess(t *testing.T) {
+	var calls int
+	c := NewClientWithSSRFGuard(5, 1, 0, 0, false, slog.Default())
+	c.lookupIP = countingLookup("93.184.216.34", &calls) // public IP -> passes
+
+	const url = "http://datahub-peer.example:8080"
+	for i := 0; i < 3; i++ {
+		if err := c.validateDataHubURL(url); err != nil {
+			t.Fatalf("call %d: unexpected error: %v", i, err)
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("resolver called %d times for the same URL, want 1 (cached)", calls)
+	}
+
+	// A different peer URL must validate independently (separate cache entry).
+	if err := c.validateDataHubURL("http://other-peer.example:8080"); err != nil {
+		t.Fatalf("second URL: unexpected error: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("resolver called %d times across two distinct URLs, want 2", calls)
+	}
+}
+
+func TestValidateDataHubURL_DoesNotCacheFailure(t *testing.T) {
+	var calls int
+	// allowPrivateIPs=false so a private resolved IP is rejected.
+	c := NewClientWithSSRFGuard(5, 1, 0, 0, false, slog.Default())
+	c.lookupIP = countingLookup("10.0.0.1", &calls) // private IP -> rejected
+
+	const url = "http://evil-peer.example:8080"
+	for i := 0; i < 3; i++ {
+		if err := c.validateDataHubURL(url); err == nil {
+			t.Fatalf("call %d: expected SSRF rejection, got nil", i)
+		}
+	}
+	if calls != 3 {
+		t.Fatalf("resolver called %d times, want 3 (failures must never be cached)", calls)
+	}
+}
+
+func TestValidateDataHubURL_ExpiredEntryRevalidates(t *testing.T) {
+	var calls int
+	c := NewClientWithSSRFGuard(5, 1, 0, 0, false, slog.Default())
+	c.lookupIP = countingLookup("93.184.216.34", &calls)
+
+	const url = "http://datahub-peer.example:8080"
+	// Pre-seed an already-expired entry; validation must re-run, not trust it.
+	c.validatedURLs.Store(url, time.Now().Add(-time.Second).UnixNano())
+
+	if err := c.validateDataHubURL(url); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expired entry was not re-validated (resolver called %d times, want 1)", calls)
+	}
+	// And the refreshed entry is now cached.
+	if err := c.validateDataHubURL(url); err != nil {
+		t.Fatalf("unexpected error after refresh: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("refreshed entry not cached (resolver called %d times, want 1)", calls)
+	}
+}
+
+func TestNewSSRFAwareHTTPClient_PoolTuning(t *testing.T) {
+	client := newSSRFAwareHTTPClient(5, false)
+	tr, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport is %T, want *http.Transport", client.Transport)
+	}
+	// Guard against a regression back to net/http's default of 2 idle
+	// conns/host, which forces re-dials under same-peer fan-out.
+	if tr.MaxIdleConnsPerHost != 64 {
+		t.Errorf("MaxIdleConnsPerHost = %d, want 64", tr.MaxIdleConnsPerHost)
+	}
+	if tr.MaxIdleConns != 128 {
+		t.Errorf("MaxIdleConns = %d, want 128", tr.MaxIdleConns)
+	}
+}


### PR DESCRIPTION
## Problem

Two inefficiencies on the subtree/block fetch path, both amplified under block-time fan-out to a small set of DataHub peers:

1. **Per-fetch DNS.** Every `Fetch*` ran `ssrfguard.ValidateURL → net.LookupIP` — a synchronous DNS resolution on *every* fetch, even when hammering the same peer URL.
2. **Connection pool too small.** The transport left `MaxIdleConnsPerHost` at net/http's default of **2**, so concurrent fetches to the same peer re-dialed (and re-TLS'd) on all but two connections — pure handshake overhead on the hot path.

## Fixes

- **Cache successful URL validations for 60s**, keyed by the peer base URL. **Successes only** — a rejection always re-runs (a transient resolver blip must not pin a peer as bad, and a malicious URL must keep failing every time).
- **`MaxIdleConnsPerHost=64`, `MaxIdleConns=128`** so keep-alive connections are reused across fan-out.

## Security — DNS-rebind safety preserved

The cache only short-circuits the *request-time* SSRF check. The transport's `Dialer.Control` hook (`ssrfguard.CheckDialAddress`) still re-validates the **actually-resolved IP on every TCP dial, uncached** — that's the real enforcement layer, and it's untouched. So a peer that rebinds to a private IP within the TTL window is still blocked at connection time. A `net.LookupIP` seam (`Client.lookupIP`, `nil → net.LookupIP`) makes the cache deterministically testable.

## Verification

- `go build ./...`, `go vet` ✅
- `go test -race ./internal/datahub/` — including the existing SSRF suite ✅
- New tests: success-caching (resolver hit once over 3 calls), distinct-URL isolation, **failure-never-cached** (3 calls → 3 resolves), deterministic **expiry re-validation** (pre-seeded expired entry), and the pool settings.

> Independent of the other in-flight PRs (touches only `internal/datahub`). Latency/handshake reduction on the fetch path — a tail/efficiency win, secondary to the Aerospike read-path changes (#151–153).

🤖 Generated with [Claude Code](https://claude.com/claude-code)