### PR TITLE
perf(kafka): configurable partition counts for subtree / subtree-work (widen by default)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -207,6 +207,20 @@ kafka:
   # Env: KAFKA_CONSUMER_GROUP
   consumerGroup: merkle-service
 
+  # Partition counts for the two topics that carry independent, per-subtree work
+  # units with no ordering requirement. More partitions = more subtrees a stage
+  # can fetch/build in parallel (a consumer group runs one in-order worker per
+  # partition). Created at this width on first start, and grown to it on later
+  # starts if the topic already exists narrower (partition counts only ever
+  # increase). The 'block' and 'callback' topics are intentionally fixed at 1
+  # partition and are not configurable here — 'block' is low-rate, and 'callback'
+  # depends on single-partition ordering to keep BLOCK_PROCESSED behind its
+  # STUMPs (see docs/callback-topic-partition-design.md).
+  # Env: KAFKA_SUBTREE_PARTITIONS
+  subtreePartitions: 12
+  # Env: KAFKA_SUBTREE_WORK_PARTITIONS
+  subtreeWorkPartitions: 24
+
 # ---------------------------------------------------------------------------
 # P2P — Teranode network connectivity via go-teranode-p2p-client
 # ---------------------------------------------------------------------------

--- a/internal/block/processor.go
+++ b/internal/block/processor.go
@@ -121,6 +121,7 @@ func (p *Processor) Init(cfg interface{}) error {
 		p.kafkaCfg.ConsumerGroup+"-block",
 		[]string{p.kafkaCfg.BlockTopic},
 		p.handleMessage,
+		nil, // 'block' is low-rate and deliberately stays at 1 partition
 		p.Logger,
 	)
 	if err != nil {

--- a/internal/block/subtree_worker.go
+++ b/internal/block/subtree_worker.go
@@ -149,6 +149,7 @@ func (s *SubtreeWorkerService) Init(_ interface{}) error {
 		s.kafkaCfg.ConsumerGroup+"-subtree-worker",
 		[]string{s.kafkaCfg.SubtreeWorkTopic},
 		s.handleMessage,
+		s.kafkaCfg.TopicPartitions(),
 		s.Logger,
 	)
 	if err != nil {

--- a/internal/callback/delivery.go
+++ b/internal/callback/delivery.go
@@ -218,6 +218,7 @@ func (d *DeliveryService) Init(_ interface{}) error {
 		d.cfg.Kafka.ConsumerGroup+"-callback",
 		[]string{d.cfg.Kafka.CallbackTopic},
 		d.handleMessage,
+		nil, // 'callback' must stay at 1 partition until a cross-partition BLOCK_PROCESSED barrier exists
 		d.Logger,
 	)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -213,6 +213,14 @@ func (a AerospikeConfig) SeedHosts() []string {
 }
 
 // KafkaConfig holds Kafka connection configuration.
+// Default partition counts for the two safe-to-widen topics. subtree-work gets
+// the most because a block fans out into hundreds–thousands of independent
+// subtree build units; subtree (the SEEN path) gets a smaller spread.
+const (
+	defaultSubtreePartitions     = 12
+	defaultSubtreeWorkPartitions = 24
+)
+
 type KafkaConfig struct {
 	Brokers             []string `yaml:"brokers"             mapstructure:"brokers"`
 	SubtreeTopic        string   `yaml:"subtreeTopic"        mapstructure:"subtreetopic"`
@@ -223,6 +231,44 @@ type KafkaConfig struct {
 	SubtreeWorkTopic    string   `yaml:"subtreeWorkTopic"    mapstructure:"subtreeworktopic"`
 	SubtreeWorkDLQTopic string   `yaml:"subtreeWorkDlqTopic" mapstructure:"subtreeworkdlqtopic"`
 	ConsumerGroup       string   `yaml:"consumerGroup"       mapstructure:"consumergroup"`
+
+	// SubtreePartitions / SubtreeWorkPartitions set how many partitions the
+	// 'subtree' and 'subtree-work' topics are created with (and grown to on
+	// startup). These two topics carry independent, idempotent, per-subtree work
+	// units with NO ordering requirement between them, so partitioning them is
+	// purely a parallelism lever: a consumer group can run at most one in-order
+	// worker goroutine per partition, so partitions cap how many subtrees a stage
+	// can fetch/build concurrently. Defaults: subtree-work 24, subtree 12.
+	//
+	// The 'block' and 'callback' topics are deliberately NOT configurable here and
+	// stay at 1 partition: 'block' is low-rate, and 'callback' relies on
+	// single-partition ordering to keep BLOCK_PROCESSED behind its STUMPs until a
+	// cross-partition delivery barrier exists (see docs/callback-topic-partition-design.md).
+	SubtreePartitions     int `yaml:"subtreePartitions"     mapstructure:"subtreepartitions"`
+	SubtreeWorkPartitions int `yaml:"subtreeWorkPartitions" mapstructure:"subtreeworkpartitions"`
+}
+
+// TopicPartitions maps each topic name to the partition count it should be
+// created with (and grown to). Only the two safe-to-widen topics carry a count
+// above 1; every other topic is absent, which callers/EnsureTopics treat as the
+// default of 1. Counts <= 0 fall back to the built-in default.
+func (k KafkaConfig) TopicPartitions() map[string]int32 {
+	subtree := k.SubtreePartitions
+	if subtree <= 0 {
+		subtree = defaultSubtreePartitions
+	}
+	work := k.SubtreeWorkPartitions
+	if work <= 0 {
+		work = defaultSubtreeWorkPartitions
+	}
+	m := make(map[string]int32, 2)
+	if k.SubtreeTopic != "" {
+		m[k.SubtreeTopic] = int32(subtree) //nolint:gosec // partition counts are small, config-validated
+	}
+	if k.SubtreeWorkTopic != "" {
+		m[k.SubtreeWorkTopic] = int32(work) //nolint:gosec // partition counts are small, config-validated
+	}
+	return m
 }
 
 // P2PMsgBusConfig holds configuration for the underlying libp2p message bus.
@@ -426,6 +472,8 @@ func registerDefaults(v *viper.Viper) {
 	v.SetDefault("kafka.subtreeworktopic", "subtree-work")
 	v.SetDefault("kafka.subtreeworkdlqtopic", "subtree-work-dlq")
 	v.SetDefault("kafka.consumergroup", "merkle-service")
+	v.SetDefault("kafka.subtreepartitions", defaultSubtreePartitions)
+	v.SetDefault("kafka.subtreeworkpartitions", defaultSubtreeWorkPartitions)
 
 	// P2P
 	v.SetDefault("p2p.network", "main")

--- a/internal/config/topic_partitions_test.go
+++ b/internal/config/topic_partitions_test.go
@@ -1,0 +1,39 @@
+package config
+
+import "testing"
+
+func TestKafkaConfig_TopicPartitions(t *testing.T) {
+	t.Run("defaults map only the two safe topics", func(t *testing.T) {
+		k := KafkaConfig{SubtreeTopic: "subtree", SubtreeWorkTopic: "subtree-work", BlockTopic: "block", CallbackTopic: "callback"}
+		m := k.TopicPartitions()
+		if got := m["subtree"]; got != defaultSubtreePartitions {
+			t.Errorf("subtree = %d, want %d", got, defaultSubtreePartitions)
+		}
+		if got := m["subtree-work"]; got != defaultSubtreeWorkPartitions {
+			t.Errorf("subtree-work = %d, want %d", got, defaultSubtreeWorkPartitions)
+		}
+		// block and callback must be ABSENT so EnsureTopics defaults them to 1.
+		if _, ok := m["block"]; ok {
+			t.Error("block must not appear in the partition map (it stays at 1)")
+		}
+		if _, ok := m["callback"]; ok {
+			t.Error("callback must not appear in the partition map (it stays at 1)")
+		}
+	})
+
+	t.Run("explicit values win", func(t *testing.T) {
+		k := KafkaConfig{SubtreeTopic: "subtree", SubtreeWorkTopic: "subtree-work", SubtreePartitions: 4, SubtreeWorkPartitions: 32}
+		m := k.TopicPartitions()
+		if m["subtree"] != 4 || m["subtree-work"] != 32 {
+			t.Errorf("explicit counts not honoured: %+v", m)
+		}
+	})
+
+	t.Run("non-positive falls back to default", func(t *testing.T) {
+		k := KafkaConfig{SubtreeTopic: "subtree", SubtreeWorkTopic: "subtree-work", SubtreePartitions: 0, SubtreeWorkPartitions: -5}
+		m := k.TopicPartitions()
+		if m["subtree"] != defaultSubtreePartitions || m["subtree-work"] != defaultSubtreeWorkPartitions {
+			t.Errorf("non-positive should fall back to defaults: %+v", m)
+		}
+	})
+}

--- a/internal/kafka/admin.go
+++ b/internal/kafka/admin.go
@@ -13,16 +13,30 @@ import (
 
 // Topic creation defaults. Single partition + replication factor 1 matches the
 // broker defaults merkle-service has always relied on (and the integration
-// test's ensureTopicExists).
+// test's ensureTopicExists). A topic with no entry in the partitions map is
+// created at defaultTopicPartitions.
 const (
 	defaultTopicPartitions  int32 = 1
 	defaultTopicReplication int16 = 1
 )
 
-// EnsureTopics creates each non-empty topic that does not already exist, via the
-// franz admin API (kadm). It is idempotent: an already-existing topic is treated
-// as success (kerr.TopicAlreadyExists is checked on both the call error and the
-// per-topic response, per teranode #633 — not a string match).
+// EnsureTopics creates each non-empty topic that does not already exist, and
+// grows any existing topic that is narrower than its desired partition count, via
+// the franz admin API (kadm).
+//
+// partitions maps a topic name to the number of partitions it should have; a
+// topic absent from the map (or with a count < 1) is created with
+// defaultTopicPartitions (1). Growing is one-way — Kafka only allows increasing a
+// topic's partition count, never decreasing — so a topic already at or above its
+// desired count is left untouched (the broker's "not an increase" rejection is
+// treated as success). This makes the call safe to run on every startup, and
+// safe even if a producer lazily auto-created the topic at 1 partition first: the
+// next consumer start grows it to the configured width.
+//
+// It is idempotent: an already-existing topic is success (kerr.TopicAlreadyExists
+// checked on both the call error and the per-topic response, per teranode #633 —
+// not a string match), and an already-wide-enough topic is success
+// (kerr.InvalidPartitions from the grow request).
 //
 // merkle-service calls this from NewConsumer so a consumer group's topics exist
 // BEFORE it joins, giving it a stable partition assignment immediately. Without
@@ -32,7 +46,7 @@ const (
 // unconsumed (the previous sarama client created topics eagerly on first
 // metadata request). Explicit creation also works on brokers with
 // auto.create.topics.enable=false.
-func EnsureTopics(ctx context.Context, brokers, topics []string, logger *slog.Logger) error {
+func EnsureTopics(ctx context.Context, brokers, topics []string, partitions map[string]int32, logger *slog.Logger) error {
 	uniq := dedupeNonEmpty(topics)
 	if len(uniq) == 0 {
 		return nil
@@ -46,15 +60,45 @@ func EnsureTopics(ctx context.Context, brokers, topics []string, logger *slog.Lo
 
 	admin := kadm.NewClient(client)
 	for _, topic := range uniq {
-		resp, cErr := admin.CreateTopic(ctx, defaultTopicPartitions, defaultTopicReplication, nil, topic)
-		if cErr != nil && !errors.Is(cErr, kerr.TopicAlreadyExists) {
+		want := defaultTopicPartitions
+		if p, ok := partitions[topic]; ok && p > 0 {
+			want = p
+		}
+
+		resp, cErr := admin.CreateTopic(ctx, want, defaultTopicReplication, nil, topic)
+		existed := errors.Is(cErr, kerr.TopicAlreadyExists) || errors.Is(resp.Err, kerr.TopicAlreadyExists)
+		if cErr != nil && !existed {
 			return fmt.Errorf("ensure topic %s: %w", topic, cErr)
 		}
-		if resp.Err != nil && !errors.Is(resp.Err, kerr.TopicAlreadyExists) {
+		if resp.Err != nil && !existed {
 			return fmt.Errorf("ensure topic %s: %w", topic, resp.Err)
 		}
+		if !existed {
+			if logger != nil {
+				logger.Debug("created kafka topic", "topic", topic, "partitions", want)
+			}
+			continue
+		}
+
+		// Topic already existed. Grow it to `want` when wider than the default.
+		// We don't read the current count first: UpdatePartitions sets the final
+		// count, and the broker rejects anything that isn't a strict increase with
+		// InvalidPartitions, which we treat as "already wide enough".
+		if want <= defaultTopicPartitions {
+			if logger != nil {
+				logger.Debug("ensured kafka topic exists", "topic", topic, "partitions", want)
+			}
+			continue
+		}
+		gResp, gErr := admin.UpdatePartitions(ctx, int(want), topic)
+		if gErr != nil {
+			return fmt.Errorf("grow topic %s to %d partitions: %w", topic, want, gErr)
+		}
+		if tErr := gResp[topic].Err; tErr != nil && !errors.Is(tErr, kerr.InvalidPartitions) {
+			return fmt.Errorf("grow topic %s to %d partitions: %w", topic, want, tErr)
+		}
 		if logger != nil {
-			logger.Debug("ensured kafka topic exists", "topic", topic)
+			logger.Info("ensured kafka topic partition count", "topic", topic, "partitions", want)
 		}
 	}
 	return nil

--- a/internal/kafka/admin_test.go
+++ b/internal/kafka/admin_test.go
@@ -1,0 +1,93 @@
+package kafka
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// partitionCount returns how many partitions the topic currently has on the
+// cluster, via a metadata/admin lookup.
+func partitionCount(t *testing.T, brokers []string, topic string) int {
+	t.Helper()
+	cl, err := kgo.NewClient(kgo.SeedBrokers(brokers...))
+	if err != nil {
+		t.Fatalf("admin client: %v", err)
+	}
+	defer cl.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	td, err := kadm.NewClient(cl).ListTopics(ctx, topic)
+	if err != nil {
+		t.Fatalf("list topics: %v", err)
+	}
+	return len(td[topic].Partitions)
+}
+
+// TestEnsureTopics_CreatesAtConfiguredWidth checks a fresh topic is created with
+// the partition count from the map, and that a topic absent from the map falls
+// back to the single-partition default.
+func TestEnsureTopics_CreatesAtConfiguredWidth(t *testing.T) {
+	cluster, err := kfake.NewCluster(kfake.NumBrokers(1))
+	if err != nil {
+		t.Fatalf("kfake: %v", err)
+	}
+	defer cluster.Close()
+	brokers := cluster.ListenAddrs()
+
+	ctx := context.Background()
+	wide, narrow := "subtree-work", "block"
+	if err := EnsureTopics(ctx, brokers, []string{wide, narrow}, map[string]int32{wide: 8}, nil); err != nil {
+		t.Fatalf("EnsureTopics: %v", err)
+	}
+
+	if got := partitionCount(t, brokers, wide); got != 8 {
+		t.Errorf("%s created with %d partitions, want 8", wide, got)
+	}
+	if got := partitionCount(t, brokers, narrow); got != 1 {
+		t.Errorf("%s (absent from map) created with %d partitions, want default 1", narrow, got)
+	}
+}
+
+// TestEnsureTopics_GrowsExistingTopic checks the one-way grow: an existing
+// narrow topic is widened to the configured count, the call is idempotent when
+// already at target, and a target below the current count never shrinks it.
+func TestEnsureTopics_GrowsExistingTopic(t *testing.T) {
+	const topic = "subtree-work"
+	cluster, err := kfake.NewCluster(kfake.NumBrokers(1), kfake.SeedTopics(2, topic))
+	if err != nil {
+		t.Fatalf("kfake: %v", err)
+	}
+	defer cluster.Close()
+	brokers := cluster.ListenAddrs()
+	ctx := context.Background()
+
+	// Grow 2 -> 6.
+	if err := EnsureTopics(ctx, brokers, []string{topic}, map[string]int32{topic: 6}, nil); err != nil {
+		t.Fatalf("grow: %v", err)
+	}
+	if got := partitionCount(t, brokers, topic); got != 6 {
+		t.Fatalf("after grow: %d partitions, want 6", got)
+	}
+
+	// Idempotent: same target again is a no-op, not an error.
+	if err := EnsureTopics(ctx, brokers, []string{topic}, map[string]int32{topic: 6}, nil); err != nil {
+		t.Fatalf("re-ensure at same width: %v", err)
+	}
+	if got := partitionCount(t, brokers, topic); got != 6 {
+		t.Fatalf("after re-ensure: %d partitions, want 6", got)
+	}
+
+	// Never shrink: a smaller target is ignored (InvalidPartitions treated as
+	// "already wide enough"), and must not error.
+	if err := EnsureTopics(ctx, brokers, []string{topic}, map[string]int32{topic: 3}, nil); err != nil {
+		t.Fatalf("smaller target should be a benign no-op, got: %v", err)
+	}
+	if got := partitionCount(t, brokers, topic); got != 6 {
+		t.Fatalf("after smaller target: %d partitions, want still 6 (never shrink)", got)
+	}
+}

--- a/internal/kafka/consumer.go
+++ b/internal/kafka/consumer.go
@@ -124,7 +124,11 @@ type Consumer struct {
 // this service consumes, replaying from the earliest available offset is always
 // correct: the handlers are idempotent and the backlog must be processed, never
 // dropped.
-func NewConsumer(brokers []string, groupID string, topics []string, handler MessageHandler, logger *slog.Logger) (*Consumer, error) {
+// partitions optionally maps a subscribed topic name to the partition count it
+// should be created with (and grown to) by the startup EnsureTopics call; topics
+// absent from the map default to 1. Pass nil to create/keep every subscribed
+// topic at 1 partition.
+func NewConsumer(brokers []string, groupID string, topics []string, handler MessageHandler, partitions map[string]int32, logger *slog.Logger) (*Consumer, error) {
 	c := &Consumer{
 		groupID: groupID,
 		topics:  topics,
@@ -134,14 +138,15 @@ func NewConsumer(brokers []string, groupID string, topics []string, handler Mess
 		workers: make(map[topicPartition]*partitionWorker),
 	}
 
-	// Ensure the subscribed topics exist before joining the group, so partition
-	// assignment is immediate rather than waiting for a metadata refresh to
-	// discover a lazily-auto-created topic (see EnsureTopics — this is what left
-	// /reprocess block messages unconsumed under franz). Best-effort: a transient
-	// failure is logged, not fatal — the consumer still works via metadata
-	// refresh + producer-side auto-creation, just less promptly.
+	// Ensure the subscribed topics exist (at their configured partition count)
+	// before joining the group, so partition assignment is immediate rather than
+	// waiting for a metadata refresh to discover a lazily-auto-created topic (see
+	// EnsureTopics — this is what left /reprocess block messages unconsumed under
+	// franz). Best-effort: a transient failure is logged, not fatal — the consumer
+	// still works via metadata refresh + producer-side auto-creation, just less
+	// promptly (and at the default partition count until a later start grows it).
 	ensureCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	if eErr := EnsureTopics(ensureCtx, brokers, topics, logger); eErr != nil && logger != nil {
+	if eErr := EnsureTopics(ensureCtx, brokers, topics, partitions, logger); eErr != nil && logger != nil {
 		logger.Warn("could not pre-create consumer topics; relying on auto-create",
 			"groupID", groupID, "topics", topics, "error", eErr)
 	}

--- a/internal/kafka/kafka_integration_test.go
+++ b/internal/kafka/kafka_integration_test.go
@@ -79,7 +79,7 @@ func TestKafka_ProduceConsumeRoundTrip(t *testing.T) {
 		return nil
 	}
 
-	consumer, err := kafka.NewConsumer(brokers, groupID, []string{topic}, handler, slog.Default())
+	consumer, err := kafka.NewConsumer(brokers, groupID, []string{topic}, handler, nil, slog.Default())
 	if err != nil {
 		t.Skipf("Kafka not available: %v", err)
 	}
@@ -139,7 +139,7 @@ func TestKafka_ProduceMultipleConsumeInOrder(t *testing.T) {
 		return nil
 	}
 
-	consumer, err := kafka.NewConsumer(brokers, groupID, []string{topic}, handler, slog.Default())
+	consumer, err := kafka.NewConsumer(brokers, groupID, []string{topic}, handler, nil, slog.Default())
 	if err != nil {
 		t.Skipf("Kafka not available: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestKafka_ConsumerGroupOffsetManagement(t *testing.T) {
 		return nil
 	}
 
-	consumer1, err := kafka.NewConsumer(brokers, groupID, []string{topic}, handler1, slog.Default())
+	consumer1, err := kafka.NewConsumer(brokers, groupID, []string{topic}, handler1, nil, slog.Default())
 	if err != nil {
 		t.Fatalf("failed to create consumer1: %v", err)
 	}
@@ -264,7 +264,7 @@ func TestKafka_ConsumerGroupOffsetManagement(t *testing.T) {
 		return nil
 	}
 
-	consumer2, err := kafka.NewConsumer(brokers, groupID, []string{topic}, handler2, slog.Default())
+	consumer2, err := kafka.NewConsumer(brokers, groupID, []string{topic}, handler2, nil, slog.Default())
 	if err != nil {
 		t.Fatalf("failed to create consumer2: %v", err)
 	}

--- a/internal/kafka/partition_concurrency_test.go
+++ b/internal/kafka/partition_concurrency_test.go
@@ -95,7 +95,7 @@ func TestConsumer_PartitionsProcessConcurrently(t *testing.T) {
 		return nil
 	}
 
-	consumer, err := NewConsumer(brokers, "partition-concurrency-group", []string{topic}, handler, discardLogger())
+	consumer, err := NewConsumer(brokers, "partition-concurrency-group", []string{topic}, handler, nil, discardLogger())
 	if err != nil {
 		t.Fatalf("creating consumer: %v", err)
 	}

--- a/internal/kafka/redelivery_test.go
+++ b/internal/kafka/redelivery_test.go
@@ -80,7 +80,7 @@ func TestConsumer_RedeliversFailedRecordAndTail(t *testing.T) {
 		return nil
 	}
 
-	consumer, err := NewConsumer(brokers, "redeliver-group", []string{topic}, handler, discardLogger())
+	consumer, err := NewConsumer(brokers, "redeliver-group", []string{topic}, handler, nil, discardLogger())
 	if err != nil {
 		t.Fatalf("creating consumer: %v", err)
 	}

--- a/internal/subtree/processor.go
+++ b/internal/subtree/processor.go
@@ -157,6 +157,7 @@ func (p *Processor) Init(_ interface{}) error {
 		p.cfg.Kafka.ConsumerGroup+"-subtree",
 		[]string{p.cfg.Kafka.SubtreeTopic},
 		p.handleMessage,
+		p.cfg.Kafka.TopicPartitions(),
 		p.Logger,
 	)
 	if err != nil {


### PR DESCRIPTION
## Problem

Every topic is created at **1 partition** (the hardcoded `defaultTopicPartitions`), and a consumer group runs at most **one in-order worker goroutine per partition**. So the subtree-fetcher and subtree-worker stages could only process **one subtree at a time per pod**, no matter how many replicas you ran — this is the real ceiling on the build/storage throughput the recent read-path work unlocked.

These two topics carry **independent, idempotent, per-subtree work units with no ordering requirement** between them, so partitioning them is purely a parallelism lever and is correctness-neutral.

## What this does

- **New config knobs:** `kafka.subtreePartitions` (default **12**) and `kafka.subtreeWorkPartitions` (default **24**). `KafkaConfig.TopicPartitions()` returns a map containing **only these two topics** — every other topic is absent and therefore defaults to 1.
- **`EnsureTopics` is now partition-aware:** it creates a missing topic at the configured width, **and grows an existing narrower topic up to it** (`UpdatePartitions`). Kafka only ever *increases* partition counts, so a topic already at/above target is left untouched — the broker's "not an increase" rejection (`InvalidPartitions`) is treated as success. This makes the call safe to run on every startup and self-correcting if a producer lazily auto-created the topic at 1 partition first.
- **`NewConsumer` takes the map and passes it through.** The subtree and subtree-worker stages pass their config map; **`block` and `callback` pass `nil` and deliberately stay at 1 partition**:
  - `block` is low-rate (~1 message per block).
  - `callback` depends on single-partition ordering to keep `BLOCK_PROCESSED` delivered behind its block's STUMPs. Widening it without a cross-partition delivery barrier causes silent missed-MINED transactions — see [`docs/callback-topic-partition-design.md`](docs/callback-topic-partition-design.md). That's a separate, larger piece of work.

## Why growing existing topics is safe here

Increasing a topic's partition count reshuffles which partition *future* messages key to. That's harmless for `subtree`/`subtree-work` precisely because their messages have no ordering requirement (each subtree is processed independently and idempotently) — which is exactly the property `callback` lacks, and why it's excluded.

## Verification

- `go build ./...`, `go vet ./...` ✅
- Full unit suite — **640 tests, 25 packages** ✅
- New tests against an in-memory `kfake` broker: `EnsureTopics` creates at the configured width, grows an existing narrow topic, is idempotent at target, and **never shrinks** (smaller target is a benign no-op). Plus `TopicPartitions()` mapping incl. defaults/overrides/non-positive fallback.

## Operational note

On upgrade, existing `subtree`/`subtree-work` topics at 1 partition will be **grown automatically** to 12/24 when the consuming stage starts (logged at info). This is intended and safe; tune via the new config if you want different widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)