### PR TITLE
fix(kafka): key subtree-work retry/DLQ the same way as the fan-out

### DIFF
--- a/internal/block/subtree_worker.go
+++ b/internal/block/subtree_worker.go
@@ -366,7 +366,10 @@ func (s *SubtreeWorkerService) handleTransientFailure(workMsg *kafka.SubtreeWork
 			// next session.
 			return fmt.Errorf("encoding subtree work message for DLQ: %w", encErr)
 		}
-		if pubErr := s.dlqProducer.Publish(workMsg.SubtreeHash, data); pubErr != nil {
+		// PublishWithHashKey to keep the worker's subtree-hash keying uniform with
+		// the retry/fan-out paths (SHA256-derived). The DLQ is its own topic so
+		// this is cosmetic for co-location, but it avoids a confusing mixed scheme.
+		if pubErr := s.dlqProducer.PublishWithHashKey(workMsg.SubtreeHash, data); pubErr != nil {
 			return fmt.Errorf("publishing subtree work message to DLQ: %w", pubErr)
 		}
 		return nil
@@ -386,7 +389,13 @@ func (s *SubtreeWorkerService) handleTransientFailure(workMsg *kafka.SubtreeWork
 	if encErr != nil {
 		return fmt.Errorf("encoding subtree work message for retry: %w", encErr)
 	}
-	if pubErr := s.retryProducer.Publish(workMsg.SubtreeHash, data); pubErr != nil {
+	// PublishWithHashKey (not Publish) so the retried item keys IDENTICALLY to the
+	// block-processor's fan-out, which publishes subtree-work via HashBatchEntry
+	// (a SHA256-derived key). A raw key here would be hashed differently by the
+	// broker and land the retry on a DIFFERENT partition than its original —
+	// harmless for these independent units, but it breaks same-subtree partition
+	// stability. Keep the keying consistent across fan-out and retry.
+	if pubErr := s.retryProducer.PublishWithHashKey(workMsg.SubtreeHash, data); pubErr != nil {
 		return fmt.Errorf("re-publishing subtree work message for retry: %w", pubErr)
 	}
 	// Intentionally do NOT decrement on retry — only success or DLQ counts.

--- a/internal/kafka/keying_consistency_test.go
+++ b/internal/kafka/keying_consistency_test.go
@@ -1,0 +1,39 @@
+package kafka
+
+import "testing"
+
+// TestFanoutAndRetryKeyingAgree pins the fix for the subtree-work retry path:
+// the block-processor fans subtrees out with HashBatchEntry, and the
+// subtree-worker re-publishes a transient failure with PublishWithHashKey.
+// Both must derive the SAME partition key for a given subtree hash, or a retry
+// lands on a different partition than its original.
+//
+// HashBatchEntry sets Key = HashPartitionKey(k); PublishWithHashKey now also
+// keys via HashPartitionKey(k). This test fails if those ever diverge (e.g. a
+// future change makes one of them hash differently).
+func TestFanoutAndRetryKeyingAgree(t *testing.T) {
+	keys := []string{
+		"aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899",
+		"subtree-0",
+		"",
+	}
+	for _, k := range keys {
+		fanout := HashBatchEntry(k, []byte("v")).Key // block-processor fan-out
+		retry := HashPartitionKey(k)                 // PublishWithHashKey (subtree-worker retry/DLQ, callback emit/retry)
+		if fanout != retry {
+			t.Errorf("key mismatch for %q: fan-out=%q retry=%q (retry would land on a different partition)", k, fanout, retry)
+		}
+	}
+}
+
+// TestRawKeyDiffersFromHashedKey documents WHY the old retry was a bug: a raw
+// Publish(subtreeHash) keys differently from the HashBatchEntry(subtreeHash)
+// fan-out, so the broker would place them on different partitions.
+func TestRawKeyDiffersFromHashedKey(t *testing.T) {
+	const subtreeHash = "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+	raw := subtreeHash                     // old retry: Publish(subtreeHash) -> raw key
+	hashed := HashPartitionKey(subtreeHash) // fan-out / fixed retry
+	if raw == hashed {
+		t.Fatalf("expected raw and hashed keys to differ; both were %q", raw)
+	}
+}

--- a/internal/kafka/producer.go
+++ b/internal/kafka/producer.go
@@ -205,12 +205,13 @@ func (p *Producer) Publish(key string, value []byte) error {
 	return nil
 }
 
-// PublishWithHashKey sends a message using a SHA256 hash of the key for partitioning.
-// Useful for callback URL-based partitioning.
+// PublishWithHashKey sends a message keyed by the SHA256-derived partition key
+// of key — the single-record equivalent of HashBatchEntry. Both go through
+// HashPartitionKey, so a record published this way lands on the same partition
+// as one fanned out via HashBatchEntry for the same key (the property the
+// subtree-work retry path and the callback emit/retry paths rely on).
 func (p *Producer) PublishWithHashKey(key string, value []byte) error {
-	hash := sha256.Sum256([]byte(key))
-	hashKey := fmt.Sprintf("%x", hash[:8])
-	return p.Publish(hashKey, value)
+	return p.Publish(HashPartitionKey(key), value)
 }
 
 // PublishBatch sends every entry in one synchronous call when the underlying


### PR DESCRIPTION
## Problem

Messages on the `subtree-work` topic were keyed **inconsistently** depending on which code path produced them:

- **Fan-out** (block-processor): `PublishBatch(HashBatchEntry(subtreeHash))` → a **SHA256-derived** partition key.
- **Retry / DLQ** (subtree-worker, on transient failure): `Publish(workMsg.SubtreeHash)` → the **raw** hash.

The broker hashes "SHA256-of-hash" and "raw-hash" to different partitions, so **a retried subtree-work item landed on a different partition than its original fan-out**.

It's harmless today — `subtree-work` items are independent and idempotent with no per-key ordering requirement — but it means "the same subtree always maps to the same partition" wasn't actually true once retries were involved. That's a latent trap if anything ever comes to rely on that co-location.

## Fix

- Re-publish (and DLQ) via **`PublishWithHashKey`** so the retry keys **identically** to the fan-out.
- DRY up `PublishWithHashKey` to derive its key through `HashPartitionKey` — the *same function* `HashBatchEntry` uses — so the two paths can never silently drift apart again.

The `callback` topic already used `HashBatchEntry` (emit) and `PublishWithHashKey` (retry/DLQ) consistently, so its per-`(scope,URL)` co-location was already correct and is unaffected. The `subtree` and `block` topics use a raw key uniformly across fan-out and retry, so they're also consistent and untouched.

## Verification

- `go build ./...`, `go vet` ✅
- Full `kafka` + `block` suites pass ✅
- New tests: assert the fan-out (`HashBatchEntry`) and retry (`HashPartitionKey`/`PublishWithHashKey`) derive the **same** key for a given subtree hash, and document why the old raw key landed elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)