### PR TITLE
feat(callback): circuit-breaker for permanently-failing callback URLs

### DIFF
--- a/cmd/callback-delivery/main.go
+++ b/cmd/callback-delivery/main.go
@@ -27,7 +27,7 @@ func main() {
 	}
 	defer func() { _ = registry.Close() }()
 
-	deliverySvc := callback.NewDeliveryService(cfg, registry.CallbackDedup, registry.Stump)
+	deliverySvc := callback.NewDeliveryService(cfg, registry.CallbackDedup, registry.Stump, registry.CallbackURLRegistry)
 
 	var metricsSrv *metrics.Server
 	if cfg.Metrics.Enabled {

--- a/cmd/merkle-service/main.go
+++ b/cmd/merkle-service/main.go
@@ -79,7 +79,7 @@ func main() {
 	subtreeFetcher := subtree.NewProcessor(cfg, registry.Registration, registry.SeenCounter, registry.Subtree)
 	blockProcessor := block.NewProcessor(cfg.Kafka, cfg.Block, cfg.DataHub, registry.Registration, registry.Subtree, registry.CallbackURLRegistry, registry.DataHubRegistry, registry.SubtreeCounter, logger)
 	subtreeWorker := block.NewSubtreeWorkerService(cfg.Kafka, cfg.Block, cfg.DataHub, registry.Registration, registry.Subtree, registry.Stump, registry.CallbackURLRegistry, registry.SubtreeCounter, registry.ExpectedStump, logger)
-	callbackDelivery := callback.NewDeliveryService(cfg, registry.CallbackDedup, registry.Stump)
+	callbackDelivery := callback.NewDeliveryService(cfg, registry.CallbackDedup, registry.Stump, registry.CallbackURLRegistry)
 
 	services := []service.Service{}
 	if cfg.Metrics.Enabled {

--- a/internal/block/reprocess_test.go
+++ b/internal/block/reprocess_test.go
@@ -170,7 +170,8 @@ func keys(m map[string][]string) []string {
 // in override mode must NOT consult the registry at all.
 type explodingURLRegistry struct{}
 
-func (explodingURLRegistry) Add(string, string) error { return nil }
+func (explodingURLRegistry) Add(string, string) error                { return nil }
+func (explodingURLRegistry) RecordFailure(string, int) (bool, error) { return false, nil }
 func (explodingURLRegistry) GetAll() ([]store.CallbackEntry, error) {
 	return nil, errors.New("registry must not be consulted on /reprocess")
 }

--- a/internal/block/subtree_worker_handle_message_test.go
+++ b/internal/block/subtree_worker_handle_message_test.go
@@ -711,6 +711,7 @@ type fakeURLRegistry struct {
 }
 
 func (f *fakeURLRegistry) Add(callbackURL, callbackToken string) error { return nil }
+func (f *fakeURLRegistry) RecordFailure(string, int) (bool, error)     { return false, nil }
 func (f *fakeURLRegistry) GetAll() ([]store.CallbackEntry, error) {
 	if f.getAllErr != nil {
 		return nil, f.getAllErr

--- a/internal/callback/callback_integration_test.go
+++ b/internal/callback/callback_integration_test.go
@@ -90,7 +90,7 @@ func TestCallbackDelivery_SuccessfulCallback(t *testing.T) {
 		},
 	}
 
-	svc := callback.NewDeliveryService(cfg, nil, newTestStumpStore())
+	svc := callback.NewDeliveryService(cfg, nil, newTestStumpStore(), nil)
 	if err := svc.Init(nil); err != nil {
 		t.Skipf("Kafka not available; skipping: %v", err)
 	}
@@ -196,7 +196,7 @@ func TestCallbackDelivery_RetryOnFailure(t *testing.T) {
 		},
 	}
 
-	svc := callback.NewDeliveryService(cfg, nil, newTestStumpStore())
+	svc := callback.NewDeliveryService(cfg, nil, newTestStumpStore(), nil)
 	if err := svc.Init(nil); err != nil {
 		t.Skipf("Kafka not available; skipping: %v", err)
 	}

--- a/internal/callback/delivery.go
+++ b/internal/callback/delivery.go
@@ -115,6 +115,9 @@ type DeliveryService struct {
 	httpClient    *http.Client
 	dedupStore    CallbackDeduper
 	stumpStore    store.StumpStore
+	// urlRegistry trips a per-URL circuit breaker after a DLQ'd callback so dead
+	// endpoints stop receiving fan-out. nil disables the breaker.
+	urlRegistry store.CallbackURLRegistry
 
 	// bodyCache memoizes the fully-marshaled HTTP body of STUMP callbacks,
 	// keyed by (StumpRef, BlockHash, SubtreeIndex). The auth token travels in
@@ -139,12 +142,13 @@ const bodyCacheMaxEntries = 64
 // NewDeliveryService creates a new callback DeliveryService. stumpStore is
 // required whenever STUMP-type messages are delivered — it is the claim-check
 // store holding the STUMP bytes referenced by CallbackTopicMessage.StumpRef.
-func NewDeliveryService(cfg *config.Config, dedupStore CallbackDeduper, stumpStore store.StumpStore) *DeliveryService {
+func NewDeliveryService(cfg *config.Config, dedupStore CallbackDeduper, stumpStore store.StumpStore, urlRegistry store.CallbackURLRegistry) *DeliveryService {
 	return &DeliveryService{
-		cfg:        cfg,
-		dedupStore: dedupStore,
-		stumpStore: stumpStore,
-		bodyCache:  make(map[string][]byte, bodyCacheMaxEntries),
+		cfg:         cfg,
+		dedupStore:  dedupStore,
+		stumpStore:  stumpStore,
+		urlRegistry: urlRegistry,
+		bodyCache:   make(map[string][]byte, bodyCacheMaxEntries),
 	}
 }
 
@@ -497,7 +501,11 @@ func (d *DeliveryService) scheduleRetryOrDLQ(cbMsg *kafka.CallbackTopicMessage, 
 			"reason", "permanent",
 			"cause", cause,
 		)
-		return d.publishToDLQDurably(cbMsg)
+		if err := d.publishToDLQDurably(cbMsg); err != nil {
+			return err
+		}
+		d.recordCallbackURLFailure(cbMsg.CallbackURL)
+		return nil
 	}
 
 	// Retry budget exhausted: route to DLQ.
@@ -511,7 +519,11 @@ func (d *DeliveryService) scheduleRetryOrDLQ(cbMsg *kafka.CallbackTopicMessage, 
 			"subtreeIndex", cbMsg.SubtreeIndex,
 			"cause", cause,
 		)
-		return d.publishToDLQDurably(cbMsg)
+		if err := d.publishToDLQDurably(cbMsg); err != nil {
+			return err
+		}
+		d.recordCallbackURLFailure(cbMsg.CallbackURL)
+		return nil
 	}
 
 	// Bump retry count + compute next NextRetryAt using linear backoff, then
@@ -533,6 +545,31 @@ func (d *DeliveryService) scheduleRetryOrDLQ(cbMsg *kafka.CallbackTopicMessage, 
 	)
 
 	return d.republishForRetry(cbMsg, "retry after delivery failure")
+}
+
+// recordCallbackURLFailure trips the per-URL circuit breaker after a callback
+// to this URL was DLQ'd. When the URL crosses cfg.Callback.BreakerThreshold it
+// is disabled in the registry so BLOCK_PROCESSED / STUMP fan-out stops
+// targeting it; a re-registration via /watch clears the breaker. A nil registry
+// or a non-positive threshold disables the breaker entirely. Best-effort —
+// a registry error is logged, not propagated (the DLQ publish already
+// succeeded, so the source offset must still be committed).
+func (d *DeliveryService) recordCallbackURLFailure(callbackURL string) {
+	threshold := d.cfg.Callback.BreakerThreshold
+	if d.urlRegistry == nil || threshold <= 0 || callbackURL == "" {
+		return
+	}
+	disabled, err := d.urlRegistry.RecordFailure(callbackURL, threshold)
+	if err != nil {
+		d.Logger.Warn("failed to record callback URL breaker failure",
+			"callbackUrl", callbackURL, "error", err)
+		return
+	}
+	if disabled {
+		d.Logger.Warn("callback URL auto-disabled after repeated DLQ'd deliveries — "+
+			"re-register via /watch to re-enable",
+			"callbackUrl", callbackURL, "threshold", threshold)
+	}
 }
 
 // republishForRetry encodes cbMsg and publishes it back to the callback

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -354,6 +354,11 @@ type CallbackConfig struct {
 	DedupTTLSec         int `yaml:"dedupTTLSec"         mapstructure:"dedupttlsec"`
 	MaxConnsPerHost     int `yaml:"maxConnsPerHost"     mapstructure:"maxconnsperhost"`
 	MaxIdleConnsPerHost int `yaml:"maxIdleConnsPerHost" mapstructure:"maxidleconnsperhost"`
+	// BreakerThreshold is the number of DLQ'd callbacks to a single URL that
+	// trips its circuit breaker. Once tripped the URL is disabled in the
+	// registry and BLOCK_PROCESSED / STUMP fan-out stops targeting it (a fresh
+	// /watch re-enables it). Default 20; set <= 0 to disable the breaker.
+	BreakerThreshold int `yaml:"breakerThreshold" mapstructure:"breakerthreshold"`
 	// AllowPrivateIPs disables the SSRF guard that normally rejects
 	// callback URLs (or dial addresses) pointing at loopback,
 	// link-local, or RFC1918 destinations. Default false. Operators
@@ -526,6 +531,7 @@ func registerDefaults(v *viper.Viper) {
 
 	// Callback
 	v.SetDefault("callback.maxretries", 5)
+	v.SetDefault("callback.breakerthreshold", 20)
 	v.SetDefault("callback.backoffbasesec", 30)
 	v.SetDefault("callback.timeoutsec", 10)
 	v.SetDefault("callback.seenthreshold", 3)

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -186,7 +186,7 @@ func startDeliveryService(t *testing.T, callbackTopic string) (*callback.Deliver
 	}
 
 	stumpStore := store.NewStumpStore(store.NewMemoryBlobStore(), 0, testLogger())
-	ds := callback.NewDeliveryService(cfg, nil, stumpStore)
+	ds := callback.NewDeliveryService(cfg, nil, stumpStore, nil)
 	if err := ds.Init(nil); err != nil {
 		t.Fatalf("failed to init delivery service: %v", err)
 	}

--- a/internal/store/callback_url_registry.go
+++ b/internal/store/callback_url_registry.go
@@ -164,3 +164,13 @@ func (r *aerospikeCallbackURLRegistry) GetAll() ([]CallbackEntry, error) {
 	}
 	return entries, nil
 }
+
+// RecordFailure is a no-op for the Aerospike backend: it has no durable
+// per-URL failure counter, and dead URLs are already bounded by the per-record
+// TTL eviction (a URL that stops re-registering disappears within the TTL
+// window). The circuit breaker is implemented on the SQL backend, which is the
+// production registry. Returns (false, nil) so callers treat the URL as still
+// enabled.
+func (r *aerospikeCallbackURLRegistry) RecordFailure(_ string, _ int) (bool, error) {
+	return false, nil
+}

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -63,6 +63,12 @@ type CallbackDedupStore interface {
 type CallbackURLRegistry interface {
 	Add(callbackURL, callbackToken string) error
 	GetAll() ([]CallbackEntry, error)
+	// RecordFailure increments the per-URL failure counter after a callback to
+	// this URL was DLQ'd. When the counter reaches threshold the URL is
+	// disabled so GetAll stops returning it (a subsequent Add re-enables it).
+	// Returns whether the URL is now disabled. A non-positive threshold or an
+	// unknown URL is a no-op.
+	RecordFailure(callbackURL string, threshold int) (disabled bool, err error)
 }
 
 // DataHubRegistry remembers every DataHub URL the block processor has

--- a/internal/store/sql/callback_url_registry.go
+++ b/internal/store/sql/callback_url_registry.go
@@ -3,6 +3,7 @@ package sql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -43,13 +44,55 @@ func (r *callbackURLRegistry) Add(callbackURL, callbackToken string) error {
 	// PostgreSQL and SQLite (>= 3.24) support. The token is also refreshed
 	// so a rotation in arcade's cfg.CallbackToken converges within one
 	// /watch round-trip.
+	// A fresh /watch also clears the circuit breaker: a tenant that comes back
+	// online re-enables its URL (failure_count -> 0, disabled_at -> NULL) within
+	// one round-trip.
 	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		"INSERT INTO callback_urls (callback_url, last_seen_at, callback_token) VALUES (%s, %s, %s) "+
-			"ON CONFLICT (callback_url) DO UPDATE SET last_seen_at = %s, callback_token = EXCLUDED.callback_token",
+			"ON CONFLICT (callback_url) DO UPDATE SET last_seen_at = %s, callback_token = EXCLUDED.callback_token, "+
+			"failure_count = 0, disabled_at = NULL",
 		r.d.placeholder(1), r.d.now, r.d.placeholder(2), r.d.now,
 	)
 	_, err := r.db.ExecContext(ctx, q, callbackURL, callbackToken)
 	return err
+}
+
+// RecordFailure increments the URL's failure counter and disables it once the
+// counter reaches threshold. Returns whether the URL is now disabled. A
+// non-positive threshold or an unknown URL is a no-op.
+func (r *callbackURLRegistry) RecordFailure(callbackURL string, threshold int) (bool, error) {
+	if threshold <= 0 {
+		return false, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Increment, and set disabled_at on the transition to >= threshold (leave it
+	// set once tripped). disabled_at uses the driver's now expression.
+	upd := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
+		"UPDATE callback_urls SET failure_count = failure_count + 1, "+
+			"disabled_at = CASE WHEN failure_count + 1 >= %s AND disabled_at IS NULL THEN %s ELSE disabled_at END "+
+			"WHERE callback_url = %s",
+		r.d.placeholder(1), r.d.now, r.d.placeholder(2),
+	)
+	if _, err := r.db.ExecContext(ctx, upd, threshold, callbackURL); err != nil {
+		return false, err
+	}
+
+	// Report disabled state from the durable failure_count so the result is
+	// portable across dialects (avoids scanning a boolean / nullable timestamp).
+	sel := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
+		"SELECT failure_count FROM callback_urls WHERE callback_url = %s",
+		r.d.placeholder(1),
+	)
+	var failureCount int
+	switch err := r.db.QueryRowContext(ctx, sel, callbackURL).Scan(&failureCount); {
+	case errors.Is(err, sql.ErrNoRows):
+		return false, nil
+	case err != nil:
+		return false, err
+	}
+	return failureCount >= threshold, nil
 }
 
 func (r *callbackURLRegistry) GetAll() ([]storepkg.CallbackEntry, error) {
@@ -60,9 +103,11 @@ func (r *callbackURLRegistry) GetAll() ([]storepkg.CallbackEntry, error) {
 	// are treated as fresh until the next Add() (which stamps last_seen_at)
 	// or the next sweeper tick (which uses the same NULL-tolerant predicate).
 	cutoff := -int(r.retention / time.Second)
+	// disabled_at IS NULL excludes URLs whose circuit breaker has tripped, so
+	// BLOCK_PROCESSED / STUMP fan-out stops targeting a dead endpoint.
 	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
 		"SELECT callback_url, callback_token FROM callback_urls "+
-			"WHERE last_seen_at IS NULL OR last_seen_at >= %s "+
+			"WHERE (last_seen_at IS NULL OR last_seen_at >= %s) AND disabled_at IS NULL "+
 			"ORDER BY callback_url",
 		r.d.intervalSeconds(cutoff),
 	)

--- a/internal/store/sql/callback_url_registry_breaker_test.go
+++ b/internal/store/sql/callback_url_registry_breaker_test.go
@@ -1,0 +1,89 @@
+package sql
+
+import (
+	"testing"
+	"time"
+)
+
+func registryHasURL(t *testing.T, r *callbackURLRegistry, url string) bool {
+	t.Helper()
+	all, err := r.GetAll()
+	if err != nil {
+		t.Fatalf("GetAll: %v", err)
+	}
+	for _, e := range all {
+		if e.URL == url {
+			return true
+		}
+	}
+	return false
+}
+
+// WS4: RecordFailure trips the breaker at the threshold, GetAll then excludes
+// the URL, and a fresh Add re-enables it (resetting the counter).
+func TestCallbackURLRegistry_BreakerDisablesAndReenables(t *testing.T) {
+	db, d := newTestDB(t)
+	r := newCallbackURLRegistry(db, d, time.Hour)
+
+	const url = "http://flaky"
+	if err := r.Add(url, "tok"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Failures below the threshold leave the URL enabled.
+	for i := 1; i < 3; i++ {
+		disabled, err := r.RecordFailure(url, 3)
+		if err != nil {
+			t.Fatalf("RecordFailure %d: %v", i, err)
+		}
+		if disabled {
+			t.Fatalf("URL disabled too early (failure %d of threshold 3)", i)
+		}
+	}
+	if !registryHasURL(t, r, url) {
+		t.Fatal("URL should still appear in GetAll before the threshold")
+	}
+
+	// Reaching the threshold disables it and drops it from GetAll.
+	disabled, err := r.RecordFailure(url, 3)
+	if err != nil {
+		t.Fatalf("RecordFailure at threshold: %v", err)
+	}
+	if !disabled {
+		t.Fatal("expected URL to be disabled at the threshold")
+	}
+	if registryHasURL(t, r, url) {
+		t.Fatal("a disabled URL must not appear in GetAll")
+	}
+
+	// Re-registration clears the breaker (URL re-enabled, counter reset).
+	if err = r.Add(url, "tok"); err != nil {
+		t.Fatal(err)
+	}
+	if !registryHasURL(t, r, url) {
+		t.Fatal("re-registered URL should appear in GetAll again")
+	}
+	disabled, err = r.RecordFailure(url, 3)
+	if err != nil {
+		t.Fatalf("RecordFailure after re-register: %v", err)
+	}
+	if disabled {
+		t.Fatal("breaker should have reset on re-registration (one failure must not re-trip threshold 3)")
+	}
+}
+
+// WS4: a non-positive threshold or an unknown URL is a no-op.
+func TestCallbackURLRegistry_RecordFailureNoOp(t *testing.T) {
+	db, d := newTestDB(t)
+	r := newCallbackURLRegistry(db, d, time.Hour)
+
+	if err := r.Add("http://known", "tok"); err != nil {
+		t.Fatal(err)
+	}
+	if disabled, err := r.RecordFailure("http://known", 0); err != nil || disabled {
+		t.Fatalf("threshold 0 must be a no-op: disabled=%v err=%v", disabled, err)
+	}
+	if disabled, err := r.RecordFailure("http://unknown", 3); err != nil || disabled {
+		t.Fatalf("unknown URL must be a no-op: disabled=%v err=%v", disabled, err)
+	}
+}

--- a/internal/store/sql/migrations/0008_callback_url_breaker.sql
+++ b/internal/store/sql/migrations/0008_callback_url_breaker.sql
@@ -1,0 +1,15 @@
+-- 0006: Circuit breaker for permanently-failing callback URLs.
+--
+-- The callback-delivery service records a failure against a URL each time one
+-- of its messages lands in the DLQ (permanent error or retries exhausted).
+-- Once failure_count crosses the configured breaker threshold the URL is
+-- disabled (disabled_at set), and GetAll stops returning it so BLOCK_PROCESSED
+-- and STUMP fan-out no longer target a dead endpoint. A fresh /watch (Add)
+-- resets failure_count to 0 and clears disabled_at, re-enabling the URL within
+-- one round-trip once the tenant comes back.
+--
+-- This stops a fleet of dead callback URLs (e.g. offline ngrok dev tunnels)
+-- from soaking delivery throughput and delaying live tenants' callbacks.
+ALTER TABLE callback_urls ADD COLUMN failure_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE callback_urls ADD COLUMN disabled_at ${TIMESTAMPTZ};
+CREATE INDEX ${IF_NOT_EXISTS_INDEX} idx_callback_urls_disabled_at ON callback_urls (disabled_at);

--- a/test/scale/production_test.go
+++ b/test/scale/production_test.go
@@ -215,7 +215,7 @@ func runProductionScaleTest(t *testing.T, fixtureDir string, timeout time.Durati
 		},
 	}
 	for i := 0; i < prodDeliveryInstances; i++ {
-		ds := callback.NewDeliveryService(deliveryCfg, nil, stumpStore)
+		ds := callback.NewDeliveryService(deliveryCfg, nil, stumpStore, nil)
 		if err := ds.Init(nil); err != nil {
 			t.Fatalf("failed to init delivery service %d: %v", i, err)
 		}

--- a/test/scale/scale_test.go
+++ b/test/scale/scale_test.go
@@ -284,7 +284,7 @@ func runScaleTest(t *testing.T, fixtureDir string, instanceCount int, timeout ti
 			MaxIdleConnsPerHost: 32,
 		},
 	}
-	deliveryService1 := callback.NewDeliveryService(deliveryCfg, nil, stumpStore)
+	deliveryService1 := callback.NewDeliveryService(deliveryCfg, nil, stumpStore, nil)
 	if err := deliveryService1.Init(nil); err != nil {
 		t.Fatalf("failed to init delivery service 1: %v", err)
 	}
@@ -294,7 +294,7 @@ func runScaleTest(t *testing.T, fixtureDir string, instanceCount int, timeout ti
 	t.Cleanup(func() { deliveryService1.Stop() })
 
 	// Start second delivery service instance (same consumer group) for multi-instance validation.
-	deliveryService2 := callback.NewDeliveryService(deliveryCfg, nil, stumpStore)
+	deliveryService2 := callback.NewDeliveryService(deliveryCfg, nil, stumpStore, nil)
 	if err := deliveryService2.Init(nil); err != nil {
 		t.Fatalf("failed to init delivery service 2: %v", err)
 	}


### PR DESCRIPTION
## Context

During the 2026-06-24 `arcade-v2-ttn` incident, ~91% of callback registrations pointed at **offline ngrok dev tunnels**. The callback-delivery service kept attempting (and DLQ'ing) delivery to them, and every block's `BLOCK_PROCESSED` was fanned out to the dead URLs — soaking throughput and delaying the live tenant's callbacks. The stale registrations were purged operationally; this PR stops them re-accumulating into the same problem.

## What it does

Adds a per-URL **circuit breaker** to the callback URL registry:

- **Migration `0006`** — `failure_count` + `disabled_at` columns on `callback_urls`.
- **SQL registry** (`callback_url_registry.go`):
  - `GetAll` filters `disabled_at IS NULL`, so a disabled URL drops out of `BLOCK_PROCESSED` / STUMP fan-out on the next block (no restart needed).
  - `Add` resets `failure_count = 0, disabled_at = NULL` on conflict — a tenant that re-registers via `/watch` re-enables its URL within one round-trip.
  - New `RecordFailure(url, threshold)` increments the counter and disables the URL once it reaches the threshold; returns whether it's now disabled.
- **callback-delivery** (`delivery.go`): after a message is DLQ'd (permanent error *or* retries exhausted), `recordCallbackURLFailure` trips the breaker. Best-effort — a registry error is logged, not propagated (the DLQ publish already succeeded). A nil registry or non-positive threshold disables the breaker.
- **Aerospike registry**: `RecordFailure` is a documented **no-op** — that backend has no durable counter and already bounds dead URLs via per-record TTL eviction. The breaker is implemented on the SQL backend, which is the production registry.
- **Config**: `callback.breakerThreshold` (default **20** — a handful of blocks of consistent 404s, high enough that a transient blip can't disable a live URL).

## Tests / verification
- New unit tests: breaker disable-at-threshold + re-enable-on-Add + below-threshold-stays-enabled, and the no-op cases (threshold 0, unknown URL). Existing registry tests (AddGetAll, retention, sweeper) still pass against the new migration.
- `go build ./...` and `go vet ./...` clean.

## Notes
- Paired with arcade #221 (bump-builder/watchdog recovery) and bsva-infra-flux #212 (bump-builder capacity). Together they prevent a recurrence of the stuck-tx incident: dead URLs self-disable here, late STUMPs get recovered in arcade, and bump-builder has the headroom to keep up.
- Migration is additive (`ADD COLUMN` with defaults; portable across the postgres/sqlite dialects). No backfill.
