### PR TITLE
fix(block): fail over across DataHub peers when fetching subtree 0 for the coinbase BUMP

### DIFF
--- a/internal/block/coinbase_bump.go
+++ b/internal/block/coinbase_bump.go
@@ -154,8 +154,12 @@ func (p *Processor) buildBlockProcessedData(
 	}
 
 	// Fetch subtree 0's contents (the coinbase's subtree). Store it so the
-	// subtree worker doesn't re-fetch it later.
-	raw, err := p.dataHubClient.FetchSubtreeRaw(ctx, resolvedURL, meta.Subtrees[0])
+	// subtree worker doesn't re-fetch it later. Fails over across DataHub
+	// peers: the peer that served this block's metadata (resolvedURL) may have
+	// already pruned its subtree contents while another peer still serves them
+	// — without failover the coinbase BUMP would be dropped despite the data
+	// being available on the network.
+	raw, _, err := p.fetchSubtreeRawWithFailover(ctx, blockMsg.Hash, meta.Subtrees[0], resolvedURL)
 	if err != nil {
 		p.Logger.Warn("BLOCK_PROCESSED: could not fetch subtree 0; omitting coinbase BUMP",
 			logfields.BlockHash(blockMsg.Hash), "error", err)

--- a/internal/block/failover_test.go
+++ b/internal/block/failover_test.go
@@ -2,6 +2,7 @@ package block
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -190,5 +191,114 @@ func TestHandleMessage_FailoverAllPeersFailReturnsError(t *testing.T) {
 	if len(mockProducer.messages) != 0 {
 		t.Errorf("no subtree work should be published on metadata failure; got %d",
 			len(mockProducer.messages))
+	}
+}
+
+// subtreeOnlyServer serves raw subtree bytes at /subtree/* and 404s
+// everything else. served records whether it was hit.
+func subtreeOnlyServer(payload []byte, served *bool) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/subtree/") {
+			if served != nil {
+				*served = true
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(payload)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+}
+
+const testSubtreeHash = "078f3e8c684dfd1fe2e7e5a45a337c29bac886a00c0dc459be2a8f52c9078fde"
+
+// TestFetchSubtreeRawWithFailover_PrunedPreferredPeer is the coinbase-BUMP
+// scenario: the peer that served the block's metadata (preferred) has pruned
+// this block's subtree (404), but a registry peer still serves it. The fetch
+// must fail over to that peer instead of dropping the coinbase BUMP.
+func TestFetchSubtreeRawWithFailover_PrunedPreferredPeer(t *testing.T) {
+	pruned := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound) // subtree pruned here
+	}))
+	defer pruned.Close()
+
+	want := make([]byte, 64) // two 32-byte nodes
+	want[0], want[32] = 0x01, 0x02
+	var goodHit bool
+	good := subtreeOnlyServer(want, &goodHit)
+	defer good.Close()
+
+	reg := &stubDataHubRegistry{urls: []string{good.URL}}
+	p := buildProcessorWithRegistry(t, &failingSyncProducer{failAt: -1}, reg)
+
+	raw, resolved, err := p.fetchSubtreeRawWithFailover(
+		context.Background(), "blk-pruned", testSubtreeHash, pruned.URL)
+	if err != nil {
+		t.Fatalf("expected failover to the registry peer, got error: %v", err)
+	}
+	if resolved != good.URL {
+		t.Errorf("resolved = %q, want failover peer %q", resolved, good.URL)
+	}
+	if len(raw) != len(want) {
+		t.Errorf("raw len = %d, want %d", len(raw), len(want))
+	}
+	if !goodHit {
+		t.Error("failover peer was never queried")
+	}
+}
+
+// TestFetchSubtreeRawWithFailover_PreferredServes verifies no failover when
+// the preferred peer has the subtree (the common live-block case).
+func TestFetchSubtreeRawWithFailover_PreferredServes(t *testing.T) {
+	want := make([]byte, 32)
+	want[0] = 0xAB
+	good := subtreeOnlyServer(want, nil)
+	defer good.Close()
+
+	// A registry peer that would fail the test if it were ever queried.
+	other := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("registry peer should not be queried when the preferred peer serves")
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer other.Close()
+
+	reg := &stubDataHubRegistry{urls: []string{other.URL}}
+	p := buildProcessorWithRegistry(t, &failingSyncProducer{failAt: -1}, reg)
+
+	raw, resolved, err := p.fetchSubtreeRawWithFailover(
+		context.Background(), "blk", testSubtreeHash, good.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved != good.URL {
+		t.Errorf("resolved = %q, want preferred %q", resolved, good.URL)
+	}
+	if len(raw) != 32 {
+		t.Errorf("raw len = %d, want 32", len(raw))
+	}
+}
+
+// TestFetchSubtreeRawWithFailover_AllPeersMissing verifies a clean error
+// (wrapping datahub.ErrNotFound) when no peer has the subtree.
+func TestFetchSubtreeRawWithFailover_AllPeersMissing(t *testing.T) {
+	notFound := func() *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+	}
+	a, b := notFound(), notFound()
+	defer a.Close()
+	defer b.Close()
+
+	reg := &stubDataHubRegistry{urls: []string{b.URL}}
+	p := buildProcessorWithRegistry(t, &failingSyncProducer{failAt: -1}, reg)
+
+	_, _, err := p.fetchSubtreeRawWithFailover(
+		context.Background(), "blk", testSubtreeHash, a.URL)
+	if err == nil {
+		t.Fatal("expected error when every peer 404s")
+	}
+	if !errors.Is(err, datahub.ErrNotFound) {
+		t.Errorf("error should wrap datahub.ErrNotFound, got: %v", err)
 	}
 }

--- a/internal/block/processor.go
+++ b/internal/block/processor.go
@@ -382,6 +382,87 @@ func (p *Processor) handleMessage(ctx context.Context, msg *kafka.Message) error
 	return nil
 }
 
+// datahubAttempt is one candidate peer for a failover fetch. forceTry is
+// set for the preferred/announced peer so it is tried even when currently
+// marked unhealthy (a peer that recovered gets a chance to serve).
+type datahubAttempt struct {
+	url      string
+	forceTry bool
+}
+
+// datahubFailoverCandidates builds the ordered peer list for a failover
+// fetch: the preferred peer first (forced), then every distinct URL in the
+// DataHub registry. A registry scan failure is logged but non-fatal — the
+// preferred peer alone is still a valid attempt list.
+func (p *Processor) datahubFailoverCandidates(blockHash, preferredURL string) []datahubAttempt {
+	tried := make(map[string]struct{})
+	var attempts []datahubAttempt
+	if preferredURL != "" {
+		attempts = append(attempts, datahubAttempt{url: preferredURL, forceTry: true})
+		tried[preferredURL] = struct{}{}
+	}
+	if p.dataHubRegistry != nil {
+		registered, regErr := p.dataHubRegistry.GetAll()
+		if regErr != nil {
+			p.Logger.Warn("failed to list DataHub registry for failover",
+				logfields.BlockHash(blockHash), "error", regErr)
+		}
+		for _, u := range registered {
+			if u == "" {
+				continue
+			}
+			if _, ok := tried[u]; ok {
+				continue
+			}
+			tried[u] = struct{}{}
+			attempts = append(attempts, datahubAttempt{url: u})
+		}
+	}
+	return attempts
+}
+
+// fetchSubtreeRawWithFailover fetches a subtree's raw bytes, trying the
+// preferred peer (the one that served this block's metadata) first and then
+// the rest of the DataHub registry. This matters for the coinbase-BUMP path:
+// the peer that still has a block's metadata may have already pruned that
+// block's subtree contents, while another (longer-retention) peer still
+// serves it. Without failover the coinbase BUMP is dropped even though the
+// data is available elsewhere on the network. Returns the resolved URL that
+// served the subtree.
+func (p *Processor) fetchSubtreeRawWithFailover(
+	ctx context.Context,
+	blockHash, subtreeHash, preferredURL string,
+) ([]byte, string, error) {
+	attempts := p.datahubFailoverCandidates(blockHash, preferredURL)
+	ph := p.dataHubClient.PeerHealth()
+	var lastErr error
+	for _, a := range attempts {
+		if !a.forceTry && ph != nil && !ph.IsHealthy(a.url) {
+			continue
+		}
+		probeCtx, cancel := context.WithTimeout(ctx, blockFetchPerPeerTimeout)
+		raw, err := p.dataHubClient.FetchSubtreeRaw(probeCtx, a.url, subtreeHash)
+		cancel()
+		if err == nil {
+			if a.url != preferredURL {
+				p.Logger.Info("subtree served by failover DataHub",
+					logfields.BlockHash(blockHash), logfields.SubtreeHash(subtreeHash),
+					"preferredUrl", preferredURL, "resolvedUrl", a.url)
+			}
+			return raw, a.url, nil
+		}
+		lastErr = err
+		p.Logger.Debug("DataHub subtree failover candidate failed",
+			logfields.BlockHash(blockHash), logfields.SubtreeHash(subtreeHash),
+			logfields.DataHubURL(a.url),
+			"notFound", errors.Is(err, datahub.ErrNotFound), "error", err)
+	}
+	if lastErr == nil {
+		return nil, "", fmt.Errorf("no healthy DataHub peer available for subtree %s", subtreeHash)
+	}
+	return nil, "", lastErr
+}
+
 // fetchBlockMetadataWithFailover fetches block metadata, trying the
 // announced peer first and then known-good peers from the DataHub
 // registry. The announcing peer is honored even if it is currently
@@ -398,38 +479,7 @@ func (p *Processor) fetchBlockMetadataWithFailover(
 	ctx context.Context,
 	blockHash, announcedURL string,
 ) (*datahub.BlockMetadata, string, error) {
-	type attempt struct {
-		url      string
-		forceTry bool // announced URL: try even if currently unhealthy
-	}
-
-	tried := make(map[string]struct{})
-	var attempts []attempt
-	if announcedURL != "" {
-		attempts = append(attempts, attempt{url: announcedURL, forceTry: true})
-		tried[announcedURL] = struct{}{}
-	}
-
-	// Registry candidates only matter when there's an actual registry and
-	// at least one URL is registered. A scan failure should not abort the
-	// whole fetch — we still have the announced URL.
-	if p.dataHubRegistry != nil {
-		registered, regErr := p.dataHubRegistry.GetAll()
-		if regErr != nil {
-			p.Logger.Warn("failed to list DataHub registry for failover",
-				logfields.BlockHash(blockHash), "error", regErr)
-		}
-		for _, u := range registered {
-			if u == "" {
-				continue
-			}
-			if _, ok := tried[u]; ok {
-				continue
-			}
-			tried[u] = struct{}{}
-			attempts = append(attempts, attempt{url: u})
-		}
-	}
+	attempts := p.datahubFailoverCandidates(blockHash, announcedURL)
 
 	ph := p.dataHubClient.PeerHealth()
 	var lastErr error


### PR DESCRIPTION
## Problem

`buildBlockProcessedData` fetches subtree 0's contents — needed to build the coinbase BUMP — from a **single** peer (`resolvedURL`, the one that served the block metadata) with **no failover**. Block-metadata fetches already fail over across peers (`fetchBlockMetadataWithFailover`), but the subtree fetch did not. So a block whose metadata-serving peer has **pruned its subtree contents** logs `could not fetch subtree 0; omitting coinbase BUMP` — even when another peer on the network still serves that subtree.

Downstream: no coinbase BUMP in `BLOCK_PROCESSED` → arcade can't correct the subtree-0 root → multi-subtree blocks fail `ValidateCompoundRoot` and never MINE (**arcade#185**).

**Observed in production (bsva-us-1):** ~45 older blocks stuck exactly this way. Their announced peer (`bsva-ovh-eu-1`) had pruned subtree 0 (HTTP 404), while `gorillanode` still served the identical subtree (HTTP 200) — the data was on the network, merkle just wasn't asking the peer that had it. This is the residual behind the #185 fail-safe rejections that survived the v0.4.1 header/coinbase fix.

## Fix

Add `fetchSubtreeRawWithFailover`, mirroring the block-metadata failover: try the preferred peer first (forced, even if currently marked unhealthy), then the rest of the DataHub registry, skipping unhealthy candidates; return the resolved URL. Extract the shared candidate-list building into `datahubFailoverCandidates` so the metadata and subtree paths stay in sync.

This complements **#173 / v0.4.1** (which sourced the coinbase *txid* from the already-fetched block binary): the txid comes from the block, the coinbase sibling path needs subtree 0's leaves, and now **both** survive single-peer pruning.

## Tests

- `TestFetchSubtreeRawWithFailover_PrunedPreferredPeer` — preferred peer 404s the subtree, registry peer serves it → fails over, returns the bytes + resolved URL (the exact production scenario).
- `TestFetchSubtreeRawWithFailover_PreferredServes` — preferred peer has it → no failover, registry peer never queried.
- `TestFetchSubtreeRawWithFailover_AllPeersMissing` — every peer 404s → error wrapping `datahub.ErrNotFound`.

`go build ./... && go vet ./... && go test ./internal/block/ ./internal/datahub/` all pass. The refactor is covered by the existing `fetchBlockMetadataWithFailover` tests (unchanged behavior).

## Verification plan (post-deploy)

Re-drive the ~45 stuck bsva-us-1 blocks via `/reprocess`: with subtree-0 failover, merkle fetches it from a peer that still has it (gorillanode) → coinbase BUMP built → arcade's `ValidateCompoundRoot` passes → blocks finalize (stale count → 0). Also hardens all future blocks against announced-peer subtree pruning.