### PR TITLE
fix(block): correct coinbase-BUMP composition for lifted final subtrees; prefer teranode's ready-made BUMP

### DIFF
--- a/internal/block/coinbase_bump.go
+++ b/internal/block/coinbase_bump.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	sdkchainhash "github.com/bsv-blockchain/go-sdk/chainhash"
+	sdktx "github.com/bsv-blockchain/go-sdk/transaction"
 	subtreepkg "github.com/bsv-blockchain/go-subtree"
 
 	"github.com/bsv-blockchain/merkle-service/internal/datahub"
@@ -45,6 +47,111 @@ func coinbaseTxIDFromHex(coinbaseHex string) ([]byte, error) {
 	return chainhash.DoubleHashB(raw), nil
 }
 
+// validateCoinbaseBUMP checks that a BRC-74 coinbase BUMP folds the given
+// coinbase txid to the given header merkle root at the given height. Used to
+// gate teranode's ready-made coinbase BUMP (from the block binary tail)
+// before preferring it over local reconstruction.
+func validateCoinbaseBUMP(bumpHex string, cbTxID []byte, merkleRoot *chainhash.Hash, height uint32) error {
+	raw, err := hex.DecodeString(bumpHex)
+	if err != nil {
+		return fmt.Errorf("decode coinbase BUMP hex: %w", err)
+	}
+	mp, err := sdktx.NewMerklePathFromBinary(raw)
+	if err != nil {
+		return fmt.Errorf("parse coinbase BUMP: %w", err)
+	}
+	if mp.BlockHeight != height {
+		return fmt.Errorf("coinbase BUMP height %d != block height %d", mp.BlockHeight, height)
+	}
+	cbh, err := sdkchainhash.NewHash(cbTxID)
+	if err != nil {
+		return fmt.Errorf("coinbase txid: %w", err)
+	}
+	root, err := mp.ComputeRoot(cbh)
+	if err != nil {
+		return fmt.Errorf("compute root from coinbase BUMP: %w", err)
+	}
+	if !bytes.Equal(root[:], merkleRoot[:]) {
+		return fmt.Errorf("coinbase BUMP folds to %s, want header root %s", root.String(), merkleRoot.String())
+	}
+	return nil
+}
+
+// verifySubtreeContentAddress checks that raw DataHub subtree bytes fold to
+// the subtree hash they were requested by. Subtrees are content-addressed
+// (the identifier in the block binary IS the placeholder-based subtree root),
+// so any peer-side truncation, reordering, or substitution is detectable
+// before the leaves are used to build proofs. Callers treat a mismatch like
+// a fetch failure so failover/retry continues to the next peer.
+func verifySubtreeContentAddress(raw []byte, subtreeHash string) error {
+	nodes, err := datahub.ParseRawNodes(raw)
+	if err != nil {
+		return fmt.Errorf("parse subtree %s: %w", subtreeHash, err)
+	}
+	want, err := chainhash.NewHashFromStr(subtreeHash)
+	if err != nil {
+		return fmt.Errorf("subtree hash %s: %w", subtreeHash, err)
+	}
+	got := (&subtreepkg.Subtree{Nodes: nodes}).RootHash()
+	if got == nil || !got.IsEqual(want) {
+		return fmt.Errorf("subtree content mismatch: served leaves fold to %s, want %s", got, want)
+	}
+	return nil
+}
+
+// subtreeHeight returns the natural merkle height of a subtree with n leaves:
+// the smallest h with 1<<h >= n (0 for a single leaf).
+func subtreeHeight(n int) int {
+	h := 0
+	for 1<<h < n {
+		h++
+	}
+	return h
+}
+
+// liftedSubtreeRoots returns the top-tree leaf hashes used to compose the
+// block merkle root: the subtree roots with the FINAL root lifted to the
+// first subtree's height when the final subtree is shorter. This mirrors
+// teranode's canonical computation (model.Block CheckMerkleRoot): only the
+// final subtree may be incomplete, and its root is self-hashed (H(r‖r)) once
+// per missing level so it occupies the slot of a same-capacity subtree.
+// Composing with UN-lifted roots produces a merkle root the canonical chain
+// disagrees with for every block whose final subtree holds at most half the
+// first subtree's capacity — the proof-corrupting bug found on the mainnet
+// 954978–956998 backlog.
+//
+// The final subtree's leaf count is derived from the block's total tx count:
+// teranode enforces that every non-final subtree is complete at the first
+// subtree's (power-of-two) length.
+func liftedSubtreeRoots(roots []chainhash.Hash, sub0Leaves int, totalTxCount uint64) ([]chainhash.Hash, error) {
+	n := len(roots)
+	if n <= 1 {
+		return roots, nil
+	}
+	if sub0Leaves <= 0 || !subtreepkg.IsPowerOfTwo(sub0Leaves) {
+		return nil, fmt.Errorf("first subtree leaf count %d is not a power of two", sub0Leaves)
+	}
+	finalLeaves := int(totalTxCount) - (n-1)*sub0Leaves //nolint:gosec // tx counts are far below int range
+	if finalLeaves <= 0 || finalLeaves > sub0Leaves {
+		return nil, fmt.Errorf("inconsistent block shape: %d txs across %d subtrees of %d leaves implies %d leaves in the final subtree",
+			totalTxCount, n, sub0Leaves, finalLeaves)
+	}
+	lift := subtreeHeight(sub0Leaves) - subtreeHeight(finalLeaves)
+	if lift <= 0 {
+		return roots, nil
+	}
+	out := append([]chainhash.Hash(nil), roots...)
+	lifted := out[n-1]
+	for i := 0; i < lift; i++ {
+		buf := make([]byte, 0, 64)
+		buf = append(buf, lifted[:]...)
+		buf = append(buf, lifted[:]...)
+		copy(lifted[:], chainhash.DoubleHashB(buf))
+	}
+	out[n-1] = lifted
+	return out, nil
+}
+
 // buildCoinbaseSiblings returns the merkle-path sibling hashes proving the
 // coinbase transaction (subtree 0, leaf 0) up to the block merkle root:
 // subtree-0 internal siblings first (level 0 = leaf level), then the
@@ -54,7 +161,10 @@ func coinbaseTxIDFromHex(coinbaseHex string) ([]byte, error) {
 //
 // Because the coinbase sits at offset 0 it climbs the left spine, so every
 // returned sibling is the offset-1 node at its level. subtreeRoots are internal
-// byte order.
+// byte order and MUST already carry the final-subtree height-lift (see
+// liftedSubtreeRoots) — passing raw roots produces siblings that fold to a
+// root the canonical chain disagrees with whenever the final subtree is
+// shorter than half the first subtree's capacity.
 func buildCoinbaseSiblings(subtree0Nodes []subtreepkg.Node, subtreeRoots []chainhash.Hash) ([][]byte, error) {
 	if len(subtree0Nodes) == 0 {
 		return nil, fmt.Errorf("subtree 0 has no nodes")
@@ -142,6 +252,21 @@ func (p *Processor) buildBlockProcessedData(
 		return data
 	}
 
+	// Prefer teranode's ready-made coinbase BUMP from the block binary tail:
+	// it is authoritative (computed by the node from the full block, lift
+	// included) and available even when every peer has pruned the block's
+	// subtree data. Gate it behind full validation; on any mismatch fall
+	// back to local reconstruction below.
+	if meta.CoinbaseBUMPHex != "" {
+		if vErr := validateCoinbaseBUMP(meta.CoinbaseBUMPHex, cbTxID, merkleRoot, meta.Height); vErr != nil {
+			p.Logger.Warn("BLOCK_PROCESSED: upstream coinbase BUMP failed validation; reconstructing locally",
+				logfields.BlockHash(blockMsg.Hash), "error", vErr)
+		} else {
+			data.CoinbaseBUMP = meta.CoinbaseBUMPHex
+			return data
+		}
+	}
+
 	roots := make([]chainhash.Hash, len(meta.Subtrees))
 	for i, s := range meta.Subtrees {
 		h, hErr := chainhash.NewHashFromStr(s)
@@ -177,7 +302,17 @@ func (p *Processor) buildBlockProcessedData(
 		return data
 	}
 
-	siblings, err := buildCoinbaseSiblings(nodes, roots)
+	// Compose the top tree the way teranode does: lift the final subtree's
+	// root to the first subtree's height when it is shorter. Without this,
+	// the fold below cannot match the header root for lifted blocks.
+	topRoots, err := liftedSubtreeRoots(roots, len(nodes), meta.TransactionCount)
+	if err != nil {
+		p.Logger.Warn("BLOCK_PROCESSED: cannot determine top-tree shape; omitting coinbase BUMP",
+			logfields.BlockHash(blockMsg.Hash), "error", err)
+		return data
+	}
+
+	siblings, err := buildCoinbaseSiblings(nodes, topRoots)
 	if err != nil {
 		p.Logger.Warn("BLOCK_PROCESSED: could not build coinbase siblings; omitting coinbase BUMP",
 			logfields.BlockHash(blockMsg.Hash), "error", err)

--- a/internal/block/coinbase_bump_test.go
+++ b/internal/block/coinbase_bump_test.go
@@ -421,7 +421,7 @@ func TestBuildCoinbaseBUMP_LiftedFinalSubtree_FoldsToHeaderRoot(t *testing.T) {
 					nodes[0] = subtreepkg.Node{Hash: testHash(0)} // placeholder
 				}
 				subtreeNodes[i] = nodes
-				total += uint64(leaves)
+				total += uint64(leaves) //nolint:gosec // test shapes are tiny positive constants
 			}
 			headerRoot := teranodeStyleHeaderRoot(t, subtreeNodes, cb)
 

--- a/internal/block/coinbase_bump_test.go
+++ b/internal/block/coinbase_bump_test.go
@@ -347,3 +347,254 @@ func TestBuildBlockProcessedData_MetaHeaderPreferred(t *testing.T) {
 		t.Fatalf("MerkleRoot = %q, want meta-derived %q", data.MerkleRoot, metaRoot.String())
 	}
 }
+
+// teranodeStyleHeaderRoot computes the block merkle root the way teranode
+// does (model.Block CheckMerkleRoot): corrected subtree-0 root (real coinbase
+// at leaf 0), all middle roots as-is, and the FINAL root lifted to the first
+// subtree's height when its subtree is shorter.
+func teranodeStyleHeaderRoot(t *testing.T, subtreeNodes [][]subtreepkg.Node, cbTxID chainhash.Hash) chainhash.Hash {
+	t.Helper()
+	n := len(subtreeNodes)
+	tops := make([]subtreepkg.Node, n)
+	for i, nodes := range subtreeNodes {
+		if i == 0 {
+			real := append([]subtreepkg.Node(nil), nodes...)
+			real[0] = subtreepkg.Node{Hash: cbTxID}
+			tops[0] = subtreepkg.Node{Hash: rootOf(t, real)}
+			continue
+		}
+		root := rootOf(t, nodes)
+		if i == n-1 {
+			// lift to the first subtree's height
+			h0, hLast := 0, 0
+			for 1<<h0 < len(subtreeNodes[0]) {
+				h0++
+			}
+			for 1<<hLast < len(nodes) {
+				hLast++
+			}
+			lift := h0 - hLast
+			for l := 0; l < lift; l++ {
+				buf := append(append([]byte{}, root[:]...), root[:]...)
+				copy(root[:], chainhash.DoubleHashB(buf))
+			}
+		}
+		tops[i] = subtreepkg.Node{Hash: root}
+	}
+	if n == 1 {
+		return tops[0].Hash
+	}
+	return rootOf(t, tops)
+}
+
+// TestBuildCoinbaseBUMP_LiftedFinalSubtree_FoldsToHeaderRoot is the
+// regression test for the mainnet 954978–956998 proof-corruption bug: blocks
+// whose FINAL subtree is shorter than half the first subtree's capacity have
+// their final root height-lifted by teranode before top-tree composition.
+// The production path (liftedSubtreeRoots + buildCoinbaseSiblings +
+// CoinbaseRootFromSiblings) must reproduce the canonical header root for
+// these shapes — the pre-fix code did not (all-equal-size shapes only).
+func TestBuildCoinbaseBUMP_LiftedFinalSubtree_FoldsToHeaderRoot(t *testing.T) {
+	cases := []struct {
+		name   string
+		shapes []int // leaves per subtree; first must be a power of two
+	}{
+		{"2subtrees_lift1", []int{8, 3}},         // h3 vs h2 → lift 1
+		{"2subtrees_lift2", []int{8, 2}},         // h3 vs h1 → lift 2
+		{"2subtrees_lift3", []int{8, 1}},         // h3 vs h0 → lift 3
+		{"4subtrees_lift2", []int{8, 8, 8, 2}},   // mirrors block 955117 (…ed8668a5)
+		{"2subtrees_mainnet", []int{32, 13}},     // mirrors block 954978 (…2cd6) shape ratio
+		{"final_above_half_nolift", []int{8, 5}}, // h3 vs h3 → no lift; must still pass
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cb := testHash(999_999)
+			subtreeNodes := make([][]subtreepkg.Node, len(tc.shapes))
+			total := uint64(0)
+			for i, leaves := range tc.shapes {
+				nodes := make([]subtreepkg.Node, leaves)
+				for j := 0; j < leaves; j++ {
+					nodes[j] = subtreepkg.Node{Hash: testHash(uint64(i*10_000 + j + 1))}
+				}
+				if i == 0 {
+					nodes[0] = subtreepkg.Node{Hash: testHash(0)} // placeholder
+				}
+				subtreeNodes[i] = nodes
+				total += uint64(leaves)
+			}
+			headerRoot := teranodeStyleHeaderRoot(t, subtreeNodes, cb)
+
+			roots := make([]chainhash.Hash, len(subtreeNodes))
+			for i := range subtreeNodes {
+				roots[i] = rootOf(t, subtreeNodes[i])
+			}
+
+			// PRODUCTION path: lift, then siblings, then fold.
+			topRoots, err := liftedSubtreeRoots(roots, len(subtreeNodes[0]), total)
+			if err != nil {
+				t.Fatalf("liftedSubtreeRoots: %v", err)
+			}
+			siblings, err := buildCoinbaseSiblings(subtreeNodes[0], topRoots)
+			if err != nil {
+				t.Fatalf("buildCoinbaseSiblings: %v", err)
+			}
+			computed := stump.CoinbaseRootFromSiblings(cb[:], siblings)
+			if !bytes.Equal(computed, headerRoot[:]) {
+				gotHash, _ := chainhash.NewHash(computed)
+				t.Fatalf("folded root = %s, want canonical header root %s", gotHash, headerRoot)
+			}
+
+			// The encoded BUMP must parse with go-sdk and compute the same root.
+			encoded := stump.EncodeCoinbaseBUMP(123, cb[:], siblings)
+			mp, err := sdktx.NewMerklePathFromBinary(encoded)
+			if err != nil {
+				t.Fatalf("go-sdk parse: %v", err)
+			}
+			sdkCb, _ := sdkchainhash.NewHash(cb[:])
+			gotRoot, err := mp.ComputeRoot(sdkCb)
+			if err != nil {
+				t.Fatalf("go-sdk ComputeRoot: %v", err)
+			}
+			if !bytes.Equal(gotRoot[:], headerRoot[:]) {
+				t.Fatalf("go-sdk computed root = %s, want %s", gotRoot, &headerRoot)
+			}
+
+			// And WITHOUT the lift the old behavior must fail for lift>0 shapes
+			// (guards against the test silently passing for trivial reasons).
+			h0, hLast := 0, 0
+			for 1<<h0 < tc.shapes[0] {
+				h0++
+			}
+			for 1<<hLast < tc.shapes[len(tc.shapes)-1] {
+				hLast++
+			}
+			if h0 > hLast && len(tc.shapes) > 1 {
+				rawSiblings, err := buildCoinbaseSiblings(subtreeNodes[0], roots)
+				if err != nil {
+					t.Fatalf("buildCoinbaseSiblings(raw): %v", err)
+				}
+				if bytes.Equal(stump.CoinbaseRootFromSiblings(cb[:], rawSiblings), headerRoot[:]) {
+					t.Fatal("un-lifted fold unexpectedly matched — test shape does not exercise the lift")
+				}
+			}
+		})
+	}
+}
+
+// TestLiftedSubtreeRoots_Guards locks the failure modes: inconsistent shapes
+// must error (not silently produce wrong roots).
+func TestLiftedSubtreeRoots_Guards(t *testing.T) {
+	r := []chainhash.Hash{testHash(1), testHash(2)}
+	if _, err := liftedSubtreeRoots(r, 6, 9); err == nil {
+		t.Error("non-power-of-two first subtree must error")
+	}
+	if _, err := liftedSubtreeRoots(r, 8, 8); err == nil {
+		t.Error("txCount implying empty final subtree must error")
+	}
+	if _, err := liftedSubtreeRoots(r, 8, 99); err == nil {
+		t.Error("txCount implying oversized final subtree must error")
+	}
+	single := []chainhash.Hash{testHash(1)}
+	if out, err := liftedSubtreeRoots(single, 7, 7); err != nil || len(out) != 1 {
+		t.Errorf("single subtree must pass through unchanged: %v", err)
+	}
+}
+
+// buildTailFixture builds a single-subtree block scenario with a VALID
+// ready-made coinbase BUMP (what teranode ships in the block binary tail).
+func buildTailFixture(t *testing.T, height uint32) (meta *datahub.BlockMetadata, headerHex string, tailHex string) {
+	t.Helper()
+	coinbaseRaw, err := hex.DecodeString(genesisCoinbaseHex)
+	if err != nil {
+		t.Fatalf("decode coinbase: %v", err)
+	}
+	cbTxID := chainhash.DoubleHashB(coinbaseRaw)
+
+	nodes := []subtreepkg.Node{
+		{Hash: testHash(0)}, // placeholder
+		{Hash: testHash(1)},
+		{Hash: testHash(2)},
+		{Hash: testHash(3)},
+	}
+	placeholderRoot := rootOf(t, nodes)
+
+	real := append([]subtreepkg.Node(nil), nodes...)
+	var cbh chainhash.Hash
+	copy(cbh[:], cbTxID)
+	real[0] = subtreepkg.Node{Hash: cbh}
+	headerRoot := rootOf(t, real) // single subtree: corrected root IS the header root
+
+	siblings, err := buildCoinbaseSiblings(nodes, []chainhash.Hash{placeholderRoot})
+	if err != nil {
+		t.Fatalf("siblings: %v", err)
+	}
+	tail := stump.EncodeCoinbaseBUMP(uint64(height), cbTxID, siblings)
+
+	meta = &datahub.BlockMetadata{
+		Height:          height,
+		Subtrees:        []string{placeholderRoot.String()},
+		CoinbaseTxHex:   genesisCoinbaseHex,
+		CoinbaseBUMPHex: hex.EncodeToString(tail),
+	}
+	return meta, buildTestHeaderHex(headerRoot), hex.EncodeToString(tail)
+}
+
+// TestBuildBlockProcessedData_PrefersValidUpstreamCoinbaseBUMP: when the
+// block binary carries a valid ready-made coinbase BUMP, it is used verbatim
+// and NO subtree fetch happens — this is what keeps blocks recoverable after
+// every peer has pruned their subtree data. The processor is constructed
+// WITHOUT a datahub client: any fetch attempt would panic the test.
+func TestBuildBlockProcessedData_PrefersValidUpstreamCoinbaseBUMP(t *testing.T) {
+	p := newBlockDataTestProcessor(t) // no dataHubClient wired
+
+	meta, headerHex, tailHex := buildTailFixture(t, 954978)
+	meta.HeaderHex = headerHex
+	blockMsg := &kafka.BlockMessage{Hash: "tail-block"}
+
+	data := p.buildBlockProcessedData(context.Background(), blockMsg, meta, "http://unused")
+	if data.CoinbaseBUMP != tailHex {
+		t.Fatalf("expected the upstream coinbase BUMP to be used verbatim")
+	}
+	if data.MerkleRoot == "" {
+		t.Fatal("merkle root must still be populated")
+	}
+}
+
+// TestBuildBlockProcessedData_FallsBackWhenUpstreamBUMPInvalid: an upstream
+// BUMP that fails validation (here: wrong block height) must not be trusted —
+// the builder falls back to local reconstruction and still produces a valid
+// coinbase BUMP.
+func TestBuildBlockProcessedData_FallsBackWhenUpstreamBUMPInvalid(t *testing.T) {
+	p := newBlockDataTestProcessor(t)
+
+	meta, headerHex, tailHex := buildTailFixture(t, 954978)
+	meta.HeaderHex = headerHex
+	meta.Height = 954979 // tail encodes 954978 → height mismatch → invalid
+
+	// Reconstruction path needs subtree 0 from the datahub.
+	var subtreeRaw []byte
+	nodes := []subtreepkg.Node{{Hash: testHash(0)}, {Hash: testHash(1)}, {Hash: testHash(2)}, {Hash: testHash(3)}}
+	for _, n := range nodes {
+		subtreeRaw = append(subtreeRaw, n.Hash[:]...)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/subtree/") {
+			_, _ = w.Write(subtreeRaw)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+	p.dataHubClient = datahub.NewClient(5, 0, p.Logger)
+	meta.TransactionCount = 4
+
+	blockMsg := &kafka.BlockMessage{Hash: "tail-block-bad"}
+	data := p.buildBlockProcessedData(context.Background(), blockMsg, meta, server.URL)
+	if data.CoinbaseBUMP == "" {
+		t.Fatal("expected reconstruction fallback to produce a coinbase BUMP")
+	}
+	if data.CoinbaseBUMP == tailHex {
+		t.Fatal("invalid upstream BUMP must not be used verbatim")
+	}
+}

--- a/internal/block/failover_test.go
+++ b/internal/block/failover_test.go
@@ -319,6 +319,7 @@ func contentAddressOf(t *testing.T, raw []byte) string {
 	root := (&subtreepkg.Subtree{Nodes: nodes}).RootHash()
 	if root == nil {
 		t.Fatal("nil root")
+		return "" // unreachable after Fatal; guards the deref below
 	}
 	return root.String()
 }

--- a/internal/block/failover_test.go
+++ b/internal/block/failover_test.go
@@ -1,6 +1,7 @@
 package block
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"net/http"
@@ -8,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	subtreepkg "github.com/bsv-blockchain/go-subtree"
 
 	"github.com/bsv-blockchain/merkle-service/internal/cache"
 	"github.com/bsv-blockchain/merkle-service/internal/datahub"
@@ -224,6 +227,7 @@ func TestFetchSubtreeRawWithFailover_PrunedPreferredPeer(t *testing.T) {
 
 	want := make([]byte, 64) // two 32-byte nodes
 	want[0], want[32] = 0x01, 0x02
+	subtreeHash := contentAddressOf(t, want)
 	var goodHit bool
 	good := subtreeOnlyServer(want, &goodHit)
 	defer good.Close()
@@ -232,7 +236,7 @@ func TestFetchSubtreeRawWithFailover_PrunedPreferredPeer(t *testing.T) {
 	p := buildProcessorWithRegistry(t, &failingSyncProducer{failAt: -1}, reg)
 
 	raw, resolved, err := p.fetchSubtreeRawWithFailover(
-		context.Background(), "blk-pruned", testSubtreeHash, pruned.URL)
+		context.Background(), "blk-pruned", subtreeHash, pruned.URL)
 	if err != nil {
 		t.Fatalf("expected failover to the registry peer, got error: %v", err)
 	}
@@ -252,6 +256,7 @@ func TestFetchSubtreeRawWithFailover_PrunedPreferredPeer(t *testing.T) {
 func TestFetchSubtreeRawWithFailover_PreferredServes(t *testing.T) {
 	want := make([]byte, 32)
 	want[0] = 0xAB
+	subtreeHash := contentAddressOf(t, want)
 	good := subtreeOnlyServer(want, nil)
 	defer good.Close()
 
@@ -266,7 +271,7 @@ func TestFetchSubtreeRawWithFailover_PreferredServes(t *testing.T) {
 	p := buildProcessorWithRegistry(t, &failingSyncProducer{failAt: -1}, reg)
 
 	raw, resolved, err := p.fetchSubtreeRawWithFailover(
-		context.Background(), "blk", testSubtreeHash, good.URL)
+		context.Background(), "blk", subtreeHash, good.URL)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -300,5 +305,57 @@ func TestFetchSubtreeRawWithFailover_AllPeersMissing(t *testing.T) {
 	}
 	if !errors.Is(err, datahub.ErrNotFound) {
 		t.Errorf("error should wrap datahub.ErrNotFound, got: %v", err)
+	}
+}
+
+// contentAddressOf computes the content address (placeholder-based subtree
+// root) of raw DataHub subtree bytes — what a block binary would name them as.
+func contentAddressOf(t *testing.T, raw []byte) string {
+	t.Helper()
+	nodes, err := datahub.ParseRawNodes(raw)
+	if err != nil {
+		t.Fatalf("parse raw nodes: %v", err)
+	}
+	root := (&subtreepkg.Subtree{Nodes: nodes}).RootHash()
+	if root == nil {
+		t.Fatal("nil root")
+	}
+	return root.String()
+}
+
+// TestFetchSubtreeRawWithFailover_ContentMismatchFailsOver verifies the
+// content-address guard: a peer that serves parseable-but-WRONG subtree bytes
+// (truncated, reordered, or substituted) is treated like a failed fetch and
+// the loop continues to a peer serving the authentic leaves.
+func TestFetchSubtreeRawWithFailover_ContentMismatchFailsOver(t *testing.T) {
+	correct := make([]byte, 64)
+	correct[0], correct[32] = 0x01, 0x02
+	subtreeHash := contentAddressOf(t, correct)
+
+	wrong := make([]byte, 64)
+	wrong[0], wrong[32] = 0xEE, 0xFF // parseable, different content
+	liar := subtreeOnlyServer(wrong, nil)
+	defer liar.Close()
+
+	var goodHit bool
+	good := subtreeOnlyServer(correct, &goodHit)
+	defer good.Close()
+
+	reg := &stubDataHubRegistry{urls: []string{good.URL}}
+	p := buildProcessorWithRegistry(t, &failingSyncProducer{failAt: -1}, reg)
+
+	raw, resolved, err := p.fetchSubtreeRawWithFailover(
+		context.Background(), "blk-liar", subtreeHash, liar.URL)
+	if err != nil {
+		t.Fatalf("expected failover past the lying peer, got: %v", err)
+	}
+	if resolved != good.URL {
+		t.Errorf("resolved = %q, want honest peer %q", resolved, good.URL)
+	}
+	if !bytes.Equal(raw, correct) {
+		t.Error("returned bytes are not the authentic leaves")
+	}
+	if !goodHit {
+		t.Error("honest peer was never queried")
 	}
 }

--- a/internal/block/processor.go
+++ b/internal/block/processor.go
@@ -444,6 +444,17 @@ func (p *Processor) fetchSubtreeRawWithFailover(
 		raw, err := p.dataHubClient.FetchSubtreeRaw(probeCtx, a.url, subtreeHash)
 		cancel()
 		if err == nil {
+			// Content-address guard: served leaves must fold to the subtree
+			// hash they were requested by. A peer serving truncated or
+			// otherwise wrong bytes is treated like a failed fetch so the
+			// loop continues to the next peer instead of poisoning proofs.
+			if vErr := verifySubtreeContentAddress(raw, subtreeHash); vErr != nil {
+				lastErr = vErr
+				p.Logger.Warn("DataHub served subtree failing content-address verification; trying next peer",
+					logfields.BlockHash(blockHash), logfields.SubtreeHash(subtreeHash),
+					logfields.DataHubURL(a.url), "error", vErr)
+				continue
+			}
 			if a.url != preferredURL {
 				p.Logger.Info("subtree served by failover DataHub",
 					logfields.BlockHash(blockHash), logfields.SubtreeHash(subtreeHash),

--- a/internal/block/reprocess_test.go
+++ b/internal/block/reprocess_test.go
@@ -79,6 +79,9 @@ func TestProcessBlockSubtree_FilterURL_ScopesToRequester(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseRawTxids: %v", err)
 	}
+	// The DataHub fetch verifies content-addressing, so the requested
+	// subtree hash must be the served leaves' root.
+	subtreeHash := contentAddressOf(t, rawBytes)
 	const urlA = "https://arcade-a.example/cb"
 	const urlB = "https://arcade-b.example/cb"
 	regStore := &reprocessRegStore{byTxID: map[string][]store.CallbackEntry{
@@ -91,7 +94,7 @@ func TestProcessBlockSubtree_FilterURL_ScopesToRequester(t *testing.T) {
 
 	result, err := ProcessBlockSubtree(
 		context.Background(),
-		"st-fix", 1, "blk-fix", server.URL,
+		subtreeHash, 1, "blk-fix", server.URL,
 		datahub.NewClient(5, 0, testLogger()),
 		subtreeStore,
 		regStore,
@@ -131,6 +134,7 @@ func TestProcessBlockSubtree_FilterURL_NoMatch(t *testing.T) {
 	}))
 	defer server.Close()
 	txids, _ := datahub.ParseRawTxids(rawBytes)
+	subtreeHash := contentAddressOf(t, rawBytes)
 	regStore := &reprocessRegStore{byTxID: map[string][]store.CallbackEntry{
 		txids[0]: {{URL: "https://other.example/cb"}},
 	}}
@@ -140,7 +144,7 @@ func TestProcessBlockSubtree_FilterURL_NoMatch(t *testing.T) {
 
 	result, err := ProcessBlockSubtree(
 		context.Background(),
-		"st-fix", 1, "blk-fix", server.URL,
+		subtreeHash, 1, "blk-fix", server.URL,
 		datahub.NewClient(5, 0, testLogger()),
 		subtreeStore,
 		regStore,

--- a/internal/block/subtree_processor.go
+++ b/internal/block/subtree_processor.go
@@ -92,6 +92,12 @@ func ProcessBlockSubtree(
 		if err != nil {
 			return nil, fmt.Errorf("fetching subtree %s from DataHub: %w", subtreeHash, err)
 		}
+		// Content-address guard: STUMPs built from wrong leaves produce
+		// proofs the canonical chain rejects. Surface a mismatch as a fetch
+		// error so the normal retry/DLQ path handles it.
+		if vErr := verifySubtreeContentAddress(rawData, subtreeHash); vErr != nil {
+			return nil, fmt.Errorf("verifying subtree %s from DataHub: %w", subtreeHash, vErr)
+		}
 		// Store for potential future use.
 		if storeErr := subtreeStore.StoreSubtree(subtreeHash, rawData, blockHeight); storeErr != nil {
 			logger.Warn("failed to store fetched subtree", logfields.SubtreeHash(subtreeHash), "error", storeErr)

--- a/internal/block/subtree_worker_handle_message_test.go
+++ b/internal/block/subtree_worker_handle_message_test.go
@@ -368,7 +368,7 @@ func TestHandleMessage_CallbackPublishFailure_RetriesAndDoesNotDecrement(t *test
 	defer server.Close()
 
 	const blockHash = "block-cb-fail"
-	const subtreeHash = "subtree-cb-fail"
+	subtreeHash := contentAddressOf(t, subtreePayload)
 
 	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, 5)
 
@@ -420,7 +420,7 @@ func TestHandleMessage_CallbackPublishFailure_AtMaxAttempts_DLQAndDecrement(t *t
 	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, maxAttempts)
 
 	// AttemptCount = maxAttempts - 1 → next attempt is terminal → DLQ.
-	value := makeWorkMessageBytes(t, "block-dlq", "subtree-dlq", server.URL, maxAttempts-1)
+	value := makeWorkMessageBytes(t, "block-dlq", contentAddressOf(t, subtreePayload), server.URL, maxAttempts-1)
 	err := svc.handleMessage(context.Background(), &kafka.Message{Value: value})
 	if err != nil {
 		t.Fatalf("handleMessage at max attempts: expected nil error after DLQ publish, got: %v", err)
@@ -459,7 +459,7 @@ func TestHandleMessage_HappyPath_DecrementsExactlyOnce(t *testing.T) {
 
 	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, 5)
 
-	value := makeWorkMessageBytes(t, "block-happy", "subtree-happy", server.URL, 0)
+	value := makeWorkMessageBytes(t, "block-happy", contentAddressOf(t, subtreePayload), server.URL, 0)
 	if err := svc.handleMessage(context.Background(), &kafka.Message{Value: value}); err != nil {
 		t.Fatalf("handleMessage happy path: expected nil error, got: %v", err)
 	}
@@ -501,7 +501,7 @@ func TestHandleMessage_CounterNotFound_AcksWithoutRetry(t *testing.T) {
 
 	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, 5)
 
-	value := makeWorkMessageBytes(t, "block-gone", "subtree-gone", server.URL, 0)
+	value := makeWorkMessageBytes(t, "block-gone", contentAddressOf(t, subtreePayload), server.URL, 0)
 	if err := svc.handleMessage(context.Background(), &kafka.Message{Value: value}); err != nil {
 		t.Fatalf("handleMessage with missing counter: expected nil error (ack), got: %v", err)
 	}
@@ -531,7 +531,7 @@ func TestHandleMessage_StumpStoreFailure_RetriesAndDoesNotDecrement(t *testing.T
 
 	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, 5)
 
-	value := makeWorkMessageBytes(t, "block-blob-fail", "subtree-blob-fail", server.URL, 0)
+	value := makeWorkMessageBytes(t, "block-blob-fail", contentAddressOf(t, subtreePayload), server.URL, 0)
 	if err := svc.handleMessage(context.Background(), &kafka.Message{Value: value}); err != nil {
 		t.Fatalf("handleMessage stump-store failure: expected nil error (retry path), got: %v", err)
 	}
@@ -574,7 +574,7 @@ func TestHandleMessage_DecrementFailureOnSuccessPath_RetriesAndPreservesCount(t 
 
 	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, 5)
 
-	value := makeWorkMessageBytes(t, blockHash, "subtree-dec-fail", server.URL, 0)
+	value := makeWorkMessageBytes(t, blockHash, contentAddressOf(t, subtreePayload), server.URL, 0)
 	err := svc.handleMessage(context.Background(), &kafka.Message{Value: value})
 	if err != nil {
 		// Below max attempts, handleTransientFailure re-publishes for retry
@@ -633,7 +633,7 @@ func TestHandleMessage_DecrementFailureOnDLQPath_ReturnsError(t *testing.T) {
 	const maxAttempts = 3
 	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, maxAttempts)
 
-	value := makeWorkMessageBytes(t, blockHash, "subtree-dlq-dec-fail", server.URL, maxAttempts-1)
+	value := makeWorkMessageBytes(t, blockHash, contentAddressOf(t, subtreePayload), server.URL, maxAttempts-1)
 	err := svc.handleMessage(context.Background(), &kafka.Message{Value: value})
 	if err == nil {
 		t.Fatalf("expected non-nil error when Decrement fails on DLQ path so consumer redelivers, got nil")
@@ -684,7 +684,7 @@ func TestHandleMessage_HappyPath_DecrementToZeroEmitsBlockProcessed(t *testing.T
 	// Wire up urlRegistry so emitBlockProcessed has somewhere to publish.
 	svc.urlRegistry = &fakeURLRegistry{urls: []string{"http://cb.example.test/hook"}}
 
-	value := makeWorkMessageBytes(t, blockHash, "subtree-zero-emit", server.URL, 0)
+	value := makeWorkMessageBytes(t, blockHash, contentAddressOf(t, subtreePayload), server.URL, 0)
 	if err := svc.handleMessage(context.Background(), &kafka.Message{Value: value}); err != nil {
 		t.Fatalf("handleMessage happy path: expected nil error, got: %v", err)
 	}
@@ -893,7 +893,7 @@ func TestHandleMessage_BlockProcessedEmitFailure_RetriesAndDoesNotAck(t *testing
 	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, 5)
 	svc.urlRegistry = &fakeURLRegistry{urls: []string{"http://cb.example.test/hook"}}
 
-	value := makeWorkMessageBytes(t, blockHash, "subtree-emit-fail", server.URL, 0)
+	value := makeWorkMessageBytes(t, blockHash, contentAddressOf(t, subtreePayload), server.URL, 0)
 	if err := svc.handleMessage(context.Background(), &kafka.Message{Value: value}); err != nil {
 		// Below max attempts, handleTransientFailure re-publishes for retry
 		// and returns nil — the work item was redirected through the retry
@@ -951,7 +951,7 @@ func TestHandleMessage_BlockProcessedEmitRetry_ReEmitsOnRedelivery(t *testing.T)
 	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, 5)
 	svc.urlRegistry = &fakeURLRegistry{urls: []string{"http://cb.example.test/hook"}}
 
-	value := makeWorkMessageBytes(t, blockHash, "subtree-emit-retry", server.URL, 1)
+	value := makeWorkMessageBytes(t, blockHash, contentAddressOf(t, subtreePayload), server.URL, 1)
 	if err := svc.handleMessage(context.Background(), &kafka.Message{Value: value}); err != nil {
 		t.Fatalf("handleMessage on redelivery: expected nil, got: %v", err)
 	}
@@ -1008,7 +1008,7 @@ func TestHandleMessage_BlockProcessedEmitFailure_AtMaxAttempts_DLQPathReturnsErr
 	svc.urlRegistry = &fakeURLRegistry{urls: []string{"http://cb.example.test/hook"}}
 
 	// AttemptCount = maxAttempts - 1 → next attempt is terminal → DLQ.
-	value := makeWorkMessageBytes(t, blockHash, "subtree-emit-dlq", server.URL, maxAttempts-1)
+	value := makeWorkMessageBytes(t, blockHash, contentAddressOf(t, subtreePayload), server.URL, maxAttempts-1)
 	err := svc.handleMessage(context.Background(), &kafka.Message{Value: value})
 	if err == nil {
 		t.Fatalf("expected non-nil error so consumer redelivers when emit fails on DLQ path, got nil")

--- a/internal/datahub/client.go
+++ b/internal/datahub/client.go
@@ -242,6 +242,15 @@ type BlockMetadata struct {
 	// carries both.
 	HeaderHex     string `json:"header_hex,omitempty"`
 	CoinbaseTxHex string `json:"coinbase_tx_hex,omitempty"`
+
+	// CoinbaseBUMPHex is teranode's ready-made BRC-74 coinbase BUMP, carried
+	// in the block binary's tail. When present and valid it is the preferred
+	// source for the BLOCK_PROCESSED coinbase BUMP: it is authoritative (the
+	// node computed it from the full block, including the final-subtree
+	// height-lift) and it remains available even after every peer has pruned
+	// the block's subtree data — reconstruction from subtree 0 cannot make
+	// that guarantee.
+	CoinbaseBUMPHex string `json:"coinbase_bump_hex,omitempty"`
 }
 
 // FetchSubtreeRaw fetches raw binary subtree data from a DataHub endpoint.
@@ -343,6 +352,9 @@ func ParseBinaryBlockMetadata(data []byte) (*BlockMetadata, error) {
 	// hash to a bogus txid downstream.
 	if block.CoinbaseTx != nil && len(block.CoinbaseTx.Inputs) > 0 {
 		meta.CoinbaseTxHex = hex.EncodeToString(block.CoinbaseTx.Bytes())
+	}
+	if len(block.CoinbaseBUMP) > 0 {
+		meta.CoinbaseBUMPHex = hex.EncodeToString(block.CoinbaseBUMP)
 	}
 
 	return meta, nil


### PR DESCRIPTION
Closes #179.

## The bug (proven bit-for-bit against mainnet)

Teranode composes the block merkle root by **lifting the final subtree's root to the first subtree's height** when the final subtree is shorter — `model.Block CheckMerkleRoot` → `RootHashPadded`, one self-hash `H(r‖r)` per missing level. `buildBlockProcessedData` composed the top tree from the **raw** subtree roots (no lift), so for every block whose final subtree holds **≤ half the first subtree's capacity**, the reconstructed coinbase BUMP folds to a wrong root and self-validation (correctly) refuses to emit it → the block can never finalize downstream (arcade#185 path).

**Proof** — block 954978 (`…2cd6`, subtrees 32768 + 13687 leaves, heights 15 vs 14; all inputs content-address-verified, binaries byte-identical across 3 peers):
- raw-root fold → `a06736…` ≠ header `11e7a866…` (the exact prod failure)
- **one lift level** → `11e7a8660936c183…` = **header root, exactly**

The happy path never caught it: the unit tests only used equal-size subtrees, and typical live blocks are single-subtree. This stranded ~55 mainnet blocks (heights 954978–956998, the tx-blast era: huge subtree-0 + small tail subtree).

## The fix (three parts)

1. **Tail-first**: teranode's `/block/{hash}` binary carries a **ready-made BRC-74 coinbase BUMP** in its tail — `model.NewBlockFromBytes` already parses it into `block.CoinbaseBUMP`; we were discarding it. Now carried through as `BlockMetadata.CoinbaseBUMPHex` and **preferred** after full validation (parse + height match + folds coinbase txid to the header root). Critical property: it stays available **even after every peer has pruned the block's subtree data** — one of the 55 blocks (`…cb591b8a`) is in exactly that state and is recoverable through no other path.
2. **Lift-fixed reconstruction (fallback)**: `liftedSubtreeRoots` derives the final subtree's leaf count from the block tx count (teranode enforces all non-final subtrees complete at the first subtree's power-of-two length) and lifts the final root before `buildCoinbaseSiblings` composes the top tree. Guards reject inconsistent shapes (also catches truncated block binaries — we observed a peer serving one).
3. **Content-address verification** on every DataHub subtree fetch (served leaves must fold to the requested subtree hash — the identifier in the block binary IS the placeholder-based subtree root). The failover loop treats a mismatch as a failed fetch and moves to the next peer; the subtree-worker path surfaces it into the normal retry/DLQ flow. Previously, wrong bytes were folded blindly.

## Validation

- **Unit**: `TestBuildCoinbaseBUMP_LiftedFinalSubtree_FoldsToHeaderRoot` (lift 1–3 levels, 2–4 subtrees, mirrors both failing mainnet shapes; includes a negative assertion that the un-lifted fold fails, so the tests provably exercise the bug), `TestLiftedSubtreeRoots_Guards`, tail-first preference + invalid-tail fallback tests, content-mismatch failover test.
- **End-to-end against live mainnet** (the real `buildBlockProcessedData`): tail-first AND lift-fixed reconstruction produce BUMPs that go-sdk folds to the header root for every previously failing block tested (`…2cd6` lift-1, `…ed8668a5` lift-3, `…cb591b8a` tail-only) plus a healthy single-subtree control.
- `go build ./... && go vet ./... && go test ./... -count=1` all pass.

## Post-deploy

Re-drive the ~55 stuck bsva-us-1 blocks → tail-first emits valid coinbase BUMPs → blocks finalize. Note: **arcade has the sibling defect** in its compound-BUMP composition (uniform-height assumption) — filed separately; blocks whose tracked txs sit in a lifted final subtree also need that fix to fully MINE via STUMPs.