### PR TITLE
fix(p2p): reject announcements with invalid DataHub URLs; classify as permanent downstream

### DIFF
--- a/internal/block/subtree_worker.go
+++ b/internal/block/subtree_worker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bsv-blockchain/merkle-service/internal/kafka"
 	"github.com/bsv-blockchain/merkle-service/internal/logfields"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
+	"github.com/bsv-blockchain/merkle-service/internal/ssrfguard"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
 )
 
@@ -336,9 +337,22 @@ func (s *SubtreeWorkerService) handleMessage(ctx context.Context, msg *kafka.Mes
 	return nil
 }
 
+// isPermanentFetchErr reports whether a work-item failure is deterministic
+// for its DataHub URL — the announcing peer advertised an address that
+// fails SSRF/DNS validation (e.g. its cluster-internal service name,
+// http://asset:8090), so retrying the same URL can never succeed. These
+// route straight to the DLQ branch instead of burning the retry budget
+// (and stalling the per-block counter toward its TTL). Intake-side
+// validation in the p2p client drops such announcements before Kafka now;
+// this guards messages already in the topic and any future intake gap.
+func isPermanentFetchErr(err error) bool {
+	return errors.Is(err, ssrfguard.ErrInvalidURL) || errors.Is(err, ssrfguard.ErrBlockedAddress)
+}
+
 // handleTransientFailure either re-publishes the work item to subtree-work for
-// retry or, once max attempts is reached, parks it on subtree-work-dlq and
-// decrements the counter so BLOCK_PROCESSED can still fire (with a missing
+// retry or, once max attempts is reached OR the failure is permanent for the
+// work item's DataHub URL (isPermanentFetchErr), parks it on subtree-work-dlq
+// and decrements the counter so BLOCK_PROCESSED can still fire (with a missing
 // STUMP that arcade will surface as a BUMP build error rather than silent loss).
 //
 // On the DLQ branch the counter is decremented BEFORE the DLQ publish. If the
@@ -354,7 +368,7 @@ func (s *SubtreeWorkerService) handleTransientFailure(ctx context.Context, workM
 	nextAttempt := workMsg.AttemptCount + 1
 	maxAttempts := s.maxAttempts()
 
-	if nextAttempt >= maxAttempts {
+	if nextAttempt >= maxAttempts || isPermanentFetchErr(cause) {
 		s.Logger.Error(
 			"subtree work item exceeded max attempts, routing to DLQ",
 			logfields.SubtreeHash(workMsg.SubtreeHash),

--- a/internal/block/subtree_worker_handle_message_test.go
+++ b/internal/block/subtree_worker_handle_message_test.go
@@ -1027,3 +1027,39 @@ func TestHandleMessage_BlockProcessedEmitFailure_AtMaxAttempts_DLQPathReturnsErr
 		t.Errorf("expected counter Decrement called once on DLQ path, got %d", got)
 	}
 }
+
+// TestHandleMessage_InvalidDataHubURL_DLQOnFirstAttempt verifies the
+// permanent-failure classification: a work item whose DataHub URL fails
+// SSRF validation (a peer announcing an unfetchable address) routes to the
+// DLQ branch on its FIRST attempt — no retry budget burned, counter still
+// decremented exactly once so BLOCK_PROCESSED can fire. Uses a bad-scheme
+// URL so validation fails syntactically with no DNS dependency.
+func TestHandleMessage_InvalidDataHubURL_DLQOnFirstAttempt(t *testing.T) {
+	cbMock := &callbackFailingProducer{}
+	retryMock := &callbackFailingProducer{}
+	dlqMock := &callbackFailingProducer{}
+
+	counter := newCountingSubtreeCounter()
+	_ = counter.Init("block-invalid-url", 1, nil)
+	counter.initCalls = 0
+
+	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, &stubStumpStore{}, counter, 5)
+	// Production wiring: the worker's client validates URLs via the SSRF guard.
+	svc.dataHubClient = datahub.NewClientWithSSRFGuard(5, 0, 0, 0, false, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	// Subtree NOT in the blob store → fetch path → SSRF validation fails.
+	value := makeWorkMessageBytes(t, "block-invalid-url", "aa11", "ftp://asset:8090/api/v1", 0)
+	if err := svc.handleMessage(context.Background(), &kafka.Message{Value: value}); err != nil {
+		t.Fatalf("handleMessage: expected nil after DLQ hand-off, got: %v", err)
+	}
+
+	if got := retryMock.sentCount(); got != 0 {
+		t.Errorf("invalid URL must not retry; expected 0 retry publishes, got %d", got)
+	}
+	if got := dlqMock.sentCount(); got != 1 {
+		t.Errorf("expected exactly 1 DLQ publish on first attempt, got %d", got)
+	}
+	if got := counter.decrementCount(); got != 1 {
+		t.Errorf("expected counter Decrement exactly once, got %d", got)
+	}
+}

--- a/internal/metrics/labels.go
+++ b/internal/metrics/labels.go
@@ -31,6 +31,8 @@ const (
 	OutcomeMiss             = "miss"
 	OutcomeEmpty            = "empty"
 	OutcomeHandlerError     = "handler_error"
+	OutcomeRejectedURL      = "rejected_url"
+	OutcomePublished        = "published"
 )
 
 // Unknown is the fallback label value when an input cannot be classified

--- a/internal/metrics/p2p.go
+++ b/internal/metrics/p2p.go
@@ -1,0 +1,27 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Announcement kind label values (bounded enum: the two teranode
+// announcement types merkle-service forwards into Kafka).
+const (
+	AnnouncementKindSubtree = "subtree"
+	AnnouncementKindBlock   = "block"
+)
+
+// P2PAnnouncementsTotal counts teranode announcements at p2p intake,
+// classified by kind (subtree|block) and outcome (published|rejected_url).
+// rejected_url means the announcing peer advertised a DataHub URL that
+// fails SSRF/DNS validation (e.g. its cluster-internal service name) —
+// the announcement is dropped before it can pollute the Kafka pipelines.
+var P2PAnnouncementsTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "merkle_p2p_announcements_total",
+		Help: "Teranode announcements at p2p intake, by kind and outcome.",
+	},
+	[]string{labelKind, labelOutcome},
+)
+
+func init() {
+	Registry.MustRegister(P2PAnnouncementsTotal)
+}

--- a/internal/p2p/client.go
+++ b/internal/p2p/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"net"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -18,6 +19,7 @@ import (
 	"github.com/bsv-blockchain/merkle-service/internal/config"
 	"github.com/bsv-blockchain/merkle-service/internal/kafka"
 	"github.com/bsv-blockchain/merkle-service/internal/logfields"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
 	"github.com/bsv-blockchain/merkle-service/internal/ssrfguard"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
@@ -73,6 +75,19 @@ type Client struct {
 	// nodeStatusReceived counts every node_status message handled, exposed
 	// via Health.Details so operators can see discovery is alive.
 	nodeStatusReceived atomic.Int64
+
+	// lookupIP resolves hostnames for announcement DataHub URL validation.
+	// nil means net.LookupIP (production); tests inject a stub so hermetic
+	// hostnames don't hit real DNS.
+	lookupIP func(host string) ([]net.IP, error)
+
+	// validatedDataHubURLs caches announcement DataHub URLs that passed
+	// SSRF/DNS validation, value = expiry UnixNano. Subtree announcements
+	// arrive continuously, so without this every announcement would pay a
+	// synchronous DNS lookup. Only successes are cached; rejections re-run
+	// so a peer that fixes its DNS is accepted as soon as it resolves.
+	// Mirrors validatedURLs in the datahub HTTP client.
+	validatedDataHubURLs sync.Map
 
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
@@ -450,6 +465,45 @@ func (c *Client) processBlockMessages(ctx context.Context, ch <-chan teranode.Bl
 	}
 }
 
+// announcementURLValidationTTL bounds how long a successful SSRF/DNS
+// validation of an announcement DataHub URL is trusted before being
+// re-checked. Matches the datahub HTTP client's validation TTL posture.
+const announcementURLValidationTTL = 5 * time.Minute
+
+// validAnnouncementDataHubURL reports whether an announcement's DataHub URL
+// passes the same SSRF/DNS validation the discovery path applies
+// (handleNodeStatusMessage) and the fetchers re-apply at fetch time. A bad
+// URL here — typically a peer advertising its cluster-internal service name
+// like http://asset:8090 — is deterministic: every downstream fetch fails,
+// burning the retry budget straight into the DLQ (and the alert on it) for
+// BOTH the SEEN and STUMP pipelines. Rejecting at intake keeps the
+// announcement out of Kafka entirely.
+//
+// Successful validations are cached for announcementURLValidationTTL;
+// rejections always re-run so a peer that fixes its config is accepted on
+// its next announcement.
+func (c *Client) validAnnouncementDataHubURL(kind, peerID, rawURL string) bool {
+	if exp, ok := c.validatedDataHubURLs.Load(rawURL); ok {
+		if time.Now().UnixNano() < exp.(int64) {
+			return true
+		}
+		c.validatedDataHubURLs.Delete(rawURL)
+	}
+	if err := ssrfguard.ValidateURL(rawURL, c.allowPrivateIPs, c.lookupIP); err != nil {
+		metrics.P2PAnnouncementsTotal.WithLabelValues(kind, metrics.OutcomeRejectedURL).Inc()
+		c.Logger.Warn(
+			"rejected announcement with invalid datahub url",
+			"kind", kind,
+			logfields.PeerID(peerID),
+			logfields.DataHubURL(rawURL),
+			"error", err,
+		)
+		return false
+	}
+	c.validatedDataHubURLs.Store(rawURL, time.Now().Add(announcementURLValidationTTL).UnixNano())
+	return true
+}
+
 // handleSubtreeMessage maps a teranode SubtreeMessage to a Kafka SubtreeMessage and publishes it.
 //
 // Returns a non-nil error only for terminal/fatal conditions (currently
@@ -459,7 +513,8 @@ func (c *Client) handleSubtreeMessage(ctx context.Context, msg teranode.SubtreeM
 	// Root span: this announcement is the origin of its own trace (see
 	// startAnnouncementSpan). The hash is an ATTRIBUTE, never the span name,
 	// to keep cardinality bounded.
-	ctx, span := startAnnouncementSpan(ctx, "subtree announce",
+	ctx, span := startAnnouncementSpan(
+		ctx, "subtree announce",
 		attribute.String(logfields.KeySubtreeHash, msg.Hash),
 	)
 	defer span.End()
@@ -469,6 +524,16 @@ func (c *Client) handleSubtreeMessage(ctx context.Context, msg teranode.SubtreeM
 		logfields.SubtreeHash(msg.Hash),
 		logfields.DataHubURL(msg.DataHubURL),
 	)
+
+	// Subtrees ARE dropped on validation failure: the announced URL is
+	// authoritative for the subtree fetcher (no failover), so every fetch
+	// of this message is doomed — it would burn the retry budget straight
+	// into the DLQ. Other peers announce the same subtree independently,
+	// so a healthy copy still arrives.
+	if !c.validAnnouncementDataHubURL(metrics.AnnouncementKindSubtree, msg.PeerID, msg.DataHubURL) {
+		return nil
+	}
+	metrics.P2PAnnouncementsTotal.WithLabelValues(metrics.AnnouncementKindSubtree, metrics.OutcomePublished).Inc()
 
 	kafkaMsg := kafka.SubtreeMessage{
 		Hash:       msg.Hash,
@@ -506,7 +571,8 @@ func (c *Client) handleBlockMessage(ctx context.Context, msg teranode.BlockMessa
 	// Root span: this announcement is the origin of its own trace (see
 	// startAnnouncementSpan). The hash is an ATTRIBUTE, never the span name,
 	// to keep cardinality bounded.
-	ctx, span := startAnnouncementSpan(ctx, "block announce",
+	ctx, span := startAnnouncementSpan(
+		ctx, "block announce",
 		attribute.String(logfields.KeyBlockHash, msg.Hash),
 	)
 	defer span.End()
@@ -520,6 +586,15 @@ func (c *Client) handleBlockMessage(ctx context.Context, msg teranode.BlockMessa
 		logfields.BlockHeight(msg.Height),
 		logfields.DataHubURL(msg.DataHubURL),
 	)
+
+	// Blocks are validated but NEVER dropped: the block processor fails
+	// over across the DataHub registry (fetchBlockMetadataWithFailover), so
+	// a block announced with an unusable URL is still recoverable from a
+	// healthy peer. Dropping it here could lose the block entirely if no
+	// other peer re-announces. The WARN + rejected_url count still surface
+	// the misbehaving peer.
+	c.validAnnouncementDataHubURL(metrics.AnnouncementKindBlock, msg.PeerID, msg.DataHubURL)
+	metrics.P2PAnnouncementsTotal.WithLabelValues(metrics.AnnouncementKindBlock, metrics.OutcomePublished).Inc()
 
 	kafkaMsg := kafka.BlockMessage{
 		Hash:       msg.Hash,

--- a/internal/p2p/client_test.go
+++ b/internal/p2p/client_test.go
@@ -3,16 +3,21 @@ package p2p
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"sync"
 	"testing"
 	"time"
 
 	teranode "github.com/bsv-blockchain/teranode/services/p2p"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
 	"github.com/bsv-blockchain/merkle-service/internal/config"
 	"github.com/bsv-blockchain/merkle-service/internal/kafka"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 )
 
 // capturedMessage records a published key/value for assertion in tests.
@@ -70,6 +75,11 @@ func newTestClient(t *testing.T) (*Client, *mockSyncProducer, *mockSyncProducer)
 		false, // allowPrivateIPs
 		logger,
 	)
+	// Hermetic DNS: announcement DataHub URL validation resolves hostnames;
+	// map every test hostname to a public address so no test touches real DNS.
+	client.lookupIP = func(string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("203.0.113.10")}, nil
+	}
 
 	return client, mockSubtreeProducer, mockBlockProducer
 }
@@ -462,8 +472,11 @@ func TestHandleSubtreeMessage_PropagatesTerminalError(t *testing.T) {
 	producer := kafka.NewTestProducer(mockProducer, "subtree", logger)
 
 	client := NewClient(config.P2PConfig{}, producer, producer, nil, false, logger)
+	client.lookupIP = func(string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("203.0.113.10")}, nil
+	}
 
-	err := client.handleSubtreeMessage(context.Background(), teranode.SubtreeMessage{Hash: "h"})
+	err := client.handleSubtreeMessage(context.Background(), teranode.SubtreeMessage{Hash: "h", DataHubURL: "https://dh.example/api"})
 	if !errors.Is(err, ErrPublishExhausted) {
 		t.Fatalf("expected ErrPublishExhausted, got %v", err)
 	}
@@ -568,3 +581,109 @@ func (f *flakyProducer) Produce(_ context.Context, _ string, _ []byte) (int32, i
 }
 
 func (f *flakyProducer) Close() error { return nil }
+
+// --- announcement DataHub URL validation tests ---
+
+// unresolvableLookup simulates DNS failure for every host — the shape of a
+// peer announcing its cluster-internal service name (http://asset:8090).
+func unresolvableLookup(host string) ([]net.IP, error) {
+	return nil, fmt.Errorf("lookup %s: no such host", host)
+}
+
+// TestHandleSubtreeMessage_RejectsUnresolvableDataHubURL verifies the intake
+// guard: a subtree announcement whose DataHub URL cannot resolve is dropped
+// before Kafka — downstream fetches are doomed and used to burn straight
+// into the DLQ (and the alert on it).
+func TestHandleSubtreeMessage_RejectsUnresolvableDataHubURL(t *testing.T) {
+	client, mockProducer, _ := newTestClient(t)
+	client.lookupIP = unresolvableLookup
+
+	before := testutil.ToFloat64(metrics.P2PAnnouncementsTotal.WithLabelValues(metrics.AnnouncementKindSubtree, metrics.OutcomeRejectedURL))
+
+	msg := teranode.SubtreeMessage{
+		Hash:       "subtree-bad-peer",
+		DataHubURL: "http://asset:8090/api/v1",
+		PeerID:     "peer-bad",
+	}
+	if err := client.handleSubtreeMessage(context.Background(), msg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := mockProducer.getMessages(); len(got) != 0 {
+		t.Fatalf("expected announcement dropped, got %d published", len(got))
+	}
+	after := testutil.ToFloat64(metrics.P2PAnnouncementsTotal.WithLabelValues(metrics.AnnouncementKindSubtree, metrics.OutcomeRejectedURL))
+	if after-before != 1 {
+		t.Errorf("rejected_url counter delta = %v, want 1", after-before)
+	}
+}
+
+// TestHandleBlockMessage_PublishesDespiteInvalidDataHubURL verifies blocks
+// are validated but never dropped: the block processor fails over across the
+// DataHub registry, so the block is still recoverable from a healthy peer.
+func TestHandleBlockMessage_PublishesDespiteInvalidDataHubURL(t *testing.T) {
+	client, _, mockProducer := newTestClient(t)
+	client.lookupIP = unresolvableLookup
+
+	before := testutil.ToFloat64(metrics.P2PAnnouncementsTotal.WithLabelValues(metrics.AnnouncementKindBlock, metrics.OutcomeRejectedURL))
+
+	msg := teranode.BlockMessage{
+		Hash:       "block-bad-peer",
+		Height:     7,
+		DataHubURL: "http://asset:8090/api/v1",
+	}
+	if err := client.handleBlockMessage(context.Background(), msg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := mockProducer.getMessages(); len(got) != 1 {
+		t.Fatalf("expected block published despite invalid URL, got %d", len(got))
+	}
+	after := testutil.ToFloat64(metrics.P2PAnnouncementsTotal.WithLabelValues(metrics.AnnouncementKindBlock, metrics.OutcomeRejectedURL))
+	if after-before != 1 {
+		t.Errorf("rejected_url counter delta = %v, want 1 (validated even though published)", after-before)
+	}
+}
+
+// TestValidAnnouncementDataHubURL_CachesSuccess verifies a passing URL is
+// not re-resolved within the TTL — subtree announcements arrive continuously
+// and must not pay a DNS lookup each time.
+func TestValidAnnouncementDataHubURL_CachesSuccess(t *testing.T) {
+	client, _, _ := newTestClient(t)
+	calls := 0
+	client.lookupIP = func(string) ([]net.IP, error) {
+		calls++
+		return []net.IP{net.ParseIP("203.0.113.10")}, nil
+	}
+
+	for i := 0; i < 3; i++ {
+		if !client.validAnnouncementDataHubURL(metrics.AnnouncementKindSubtree, "peer", "https://dh.example/api") {
+			t.Fatalf("iteration %d: expected valid", i)
+		}
+	}
+	if calls != 1 {
+		t.Errorf("DNS lookups = %d, want 1 (cached after first success)", calls)
+	}
+}
+
+// TestValidAnnouncementDataHubURL_RejectionNotCached verifies rejections
+// re-run validation, so a peer that fixes its DNS is accepted on its next
+// announcement rather than being remembered as bad.
+func TestValidAnnouncementDataHubURL_RejectionNotCached(t *testing.T) {
+	client, _, _ := newTestClient(t)
+	healthy := false
+	client.lookupIP = func(host string) ([]net.IP, error) {
+		if healthy {
+			return []net.IP{net.ParseIP("203.0.113.10")}, nil
+		}
+		return nil, fmt.Errorf("lookup %s: no such host", host)
+	}
+
+	if client.validAnnouncementDataHubURL(metrics.AnnouncementKindSubtree, "peer", "https://dh.example/api") {
+		t.Fatal("expected rejection while unresolvable")
+	}
+	healthy = true
+	if !client.validAnnouncementDataHubURL(metrics.AnnouncementKindSubtree, "peer", "https://dh.example/api") {
+		t.Fatal("expected acceptance after DNS recovers")
+	}
+}

--- a/internal/p2p/tracing_test.go
+++ b/internal/p2p/tracing_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net"
 	"testing"
 
 	teranode "github.com/bsv-blockchain/teranode/services/p2p"
@@ -115,6 +116,9 @@ func TestHandleSubtreeMessage_SpanEndsAndRecordsErrorOnPublishExhaustion(t *test
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	failing := kafka.NewTestProducer(&mockSyncProducer{failErr: errors.New("kafka down")}, "subtree", logger)
 	client := NewClient(config.P2PConfig{}, failing, failing, nil, false, logger)
+	client.lookupIP = func(string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("203.0.113.10")}, nil
+	}
 
 	msg := teranode.SubtreeMessage{Hash: "subtree-fail", DataHubURL: "https://dh.example/st"}
 	if err := client.handleSubtreeMessage(context.Background(), msg); !errors.Is(err, ErrPublishExhausted) {

--- a/internal/subtree/processor.go
+++ b/internal/subtree/processor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bsv-blockchain/merkle-service/internal/logfields"
 	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
+	"github.com/bsv-blockchain/merkle-service/internal/ssrfguard"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
 )
 
@@ -350,6 +351,17 @@ func (p *Processor) handleMessage(ctx context.Context, msg *kafka.Message) error
 		// from the same host to short-circuit at the IsHealthy gate above
 		// once the threshold is reached.
 		if errors.Is(err, datahub.ErrNotFound) {
+			return p.handlePermanentFailure(ctx, subtreeMsg, "fetching subtree from DataHub", err, start)
+		}
+		// SSRF/DNS validation failures are equally permanent for that URL:
+		// the announcing peer advertised an address we can never resolve or
+		// are policy-bound to refuse (e.g. its cluster-internal service name,
+		// http://asset:8090). Retrying cannot help; burning the retry budget
+		// here is what used to land these in outcome="dlq" and page on-call.
+		// Intake-side validation (p2p client) drops these announcements
+		// before Kafka now — this guards messages already in the topic and
+		// any future intake gap.
+		if errors.Is(err, ssrfguard.ErrInvalidURL) || errors.Is(err, ssrfguard.ErrBlockedAddress) {
 			return p.handlePermanentFailure(ctx, subtreeMsg, "fetching subtree from DataHub", err, start)
 		}
 		return p.handleTransientFailure(ctx, subtreeMsg, "fetching subtree from DataHub", err, start)

--- a/internal/subtree/processor_test.go
+++ b/internal/subtree/processor_test.go
@@ -2477,3 +2477,113 @@ func TestHandleMessage_TransientErrorStillRetries(t *testing.T) {
 		t.Errorf("expected dlq delta=0, got %d", got)
 	}
 }
+
+// TestHandleMessage_InvalidDataHubURLGoesStraightToDLQ mirrors the 404
+// permanent-failure regression: an SSRF/DNS-invalid DataHub URL (a peer
+// announcing an address we can never fetch, e.g. its cluster-internal
+// service name) must NOT burn the retry budget into outcome="dlq" — it
+// routes straight to the DLQ topic as permanent_failure. Uses a bad-scheme
+// URL so validation fails syntactically with no DNS dependency.
+func TestHandleMessage_InvalidDataHubURLGoesStraightToDLQ(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	retryMock := &mockSyncProducer{}
+	dlqMock := &mockSyncProducer{}
+
+	p := &Processor{
+		cfg: &config.Config{
+			Subtree: config.SubtreeConfig{MaxAttempts: 5, StorageMode: "stream"},
+		},
+		registrationStore: &mockRegStore{},
+		seenCounterStore:  &mockSeenCounter{},
+		callbackProducer:  kafka.NewTestProducer(&mockSyncProducer{}, "callback-test", logger),
+		retryProducer:     kafka.NewTestProducer(retryMock, "subtree-test", logger),
+		dlqProducer:       kafka.NewTestProducer(dlqMock, "subtree-dlq-test", logger),
+		dataHubClient:     datahub.NewClientWithSSRFGuard(5, 0, 0, 0, false, logger),
+	}
+	p.InitBase("subtree-invalid-url-permanent-test")
+	p.Logger = logger
+
+	subtreeMsg := &kafka.SubtreeMessage{
+		Hash:         "subtree-invalid-url",
+		DataHubURL:   "ftp://asset:8090/api/v1", // bad scheme -> ssrfguard.ErrInvalidURL, no DNS
+		AttemptCount: 0,
+	}
+	value, encErr := subtreeMsg.Encode()
+	if encErr != nil {
+		t.Fatalf("encode subtree msg: %v", encErr)
+	}
+
+	beforePermanent := subtreeCount(metrics.OutcomePermanentFailure)
+	beforeDLQ := subtreeCount(metrics.OutcomeDLQ)
+	if err := p.handleMessage(t.Context(), &kafka.Message{Value: value}); err != nil {
+		t.Fatalf("handleMessage: expected nil (permanent → DLQ returns nil), got: %v", err)
+	}
+
+	if got := len(retryMock.getMessages()); got != 0 {
+		t.Errorf("invalid URL must not retry; expected 0 retry publishes, got %d", got)
+	}
+	if got := len(dlqMock.getMessages()); got != 1 {
+		t.Fatalf("expected exactly 1 DLQ publish, got %d", got)
+	}
+	if got := subtreeCount(metrics.OutcomePermanentFailure) - beforePermanent; got != 1 {
+		t.Errorf("expected permanent_failure delta=1, got %d", got)
+	}
+	if got := subtreeCount(metrics.OutcomeDLQ) - beforeDLQ; got != 0 {
+		t.Errorf("expected dlq delta=0 (must not count toward the DLQ alert), got %d", got)
+	}
+}
+
+// TestHandleMessage_ZeroTxidSubtreeIsProcessedNotDLQ pins the semantics the
+// on-call asked about when the DLQ alert first fired: a subtree with zero
+// txids (and by extension a block whose subtrees carry no registered
+// transactions) acks as outcome="processed" — it can never reach the DLQ
+// or the alert on it.
+func TestHandleMessage_ZeroTxidSubtreeIsProcessedNotDLQ(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// DataHub serves an EMPTY subtree payload: zero 32-byte hashes.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	retryMock := &mockSyncProducer{}
+	dlqMock := &mockSyncProducer{}
+
+	p := &Processor{
+		cfg: &config.Config{
+			Subtree: config.SubtreeConfig{MaxAttempts: 5, StorageMode: "stream"},
+		},
+		registrationStore: &mockRegStore{},
+		seenCounterStore:  &mockSeenCounter{},
+		callbackProducer:  kafka.NewTestProducer(&mockSyncProducer{}, "callback-test", logger),
+		retryProducer:     kafka.NewTestProducer(retryMock, "subtree-test", logger),
+		dlqProducer:       kafka.NewTestProducer(dlqMock, "subtree-dlq-test", logger),
+		dataHubClient:     datahub.NewClient(5, 0, logger),
+	}
+	p.InitBase("subtree-zero-txid-test")
+	p.Logger = logger
+
+	subtreeMsg := &kafka.SubtreeMessage{Hash: "subtree-empty", DataHubURL: server.URL}
+	value, encErr := subtreeMsg.Encode()
+	if encErr != nil {
+		t.Fatalf("encode subtree msg: %v", encErr)
+	}
+
+	beforeProcessed := subtreeCount(metrics.OutcomeProcessed)
+	beforeDLQ := subtreeCount(metrics.OutcomeDLQ)
+	if err := p.handleMessage(t.Context(), &kafka.Message{Value: value}); err != nil {
+		t.Fatalf("handleMessage: %v", err)
+	}
+
+	if got := subtreeCount(metrics.OutcomeProcessed) - beforeProcessed; got != 1 {
+		t.Errorf("expected processed delta=1, got %d", got)
+	}
+	if got := subtreeCount(metrics.OutcomeDLQ) - beforeDLQ; got != 0 {
+		t.Errorf("zero-txid subtree must never DLQ; got delta %d", got)
+	}
+	if got := len(retryMock.getMessages()) + len(dlqMock.getMessages()); got != 0 {
+		t.Errorf("expected no retry/DLQ publishes, got %d", got)
+	}
+}


### PR DESCRIPTION
## Context — the subtree-DLQ alert that fired at 18:09 GMT

Investigation of the `Merkle — subtree processing DLQ` alert (insight `11fe6902`). First, the suspected false-positive theory is **disproven**: blocks with zero registered transactions cannot fire this alert — zero-txid subtrees ack as `outcome="processed"` (`internal/subtree/processor.go:374-381`), and zero-registered subtrees emit no callbacks and ack the same way. A regression test now pins that.

What actually fired it: peers `12D3KooWK2oX…CkUn` and `12D3KooWM7Fe…RcfU` announce subtrees/blocks with `DataHubURL: http://asset:8090/api/v1` — their cluster-internal service name, unresolvable from our clusters. The **discovery** path already rejects these URLs (`ssrfguard.ValidateURL`), but **announcement intake** forwarded them into Kafka unvalidated. Every such subtree burned `maxAttempts=3` fetch attempts (`invalid DataHub URL: … lookup asset … no such host`) straight into `outcome="dlq"` → alert. The same URLs also stalled block-side subtree work items into counter-TTL expiry (`ALERT: subtree counter missing … block must be reprocessed`).

## Fix — three layers

1. **p2p intake validation** (root cause): announced DataHub URLs run through the same `ssrfguard.ValidateURL` as discovery, with TTL-cached positives (announcements are ~continuous) and an injectable resolver for hermetic tests.
   - **Subtree announcements with bad URLs are dropped** — the announced URL is authoritative for the subtree fetcher (no failover), and other peers announce the same subtree independently.
   - **Block announcements are never dropped** — the block processor fails over across the DataHub registry, so the block stays recoverable from a healthy peer; the bad URL is WARNed and counted.
   - New `merkle_p2p_announcements_total{kind, outcome}` counter (`published` | `rejected_url`).
2. **Subtree fetcher**: `ssrfguard.ErrInvalidURL` / `ErrBlockedAddress` now route to `handlePermanentFailure` like the existing 404 case — DLQ topic, `outcome="permanent_failure"`, no retry burn, **not counted by the alert**.
3. **Block subtree worker**: same classification jumps straight to the existing DLQ branch on the first attempt — counter still decremented exactly once, `BLOCK_PROCESSED` still fires, arcade's watchdog surfaces the missing STUMP.

## Tests

- Intake: bad-URL subtree dropped + counted; bad-URL block still published + counted; validation cache hits skip DNS; rejections re-validate (peer recovery).
- Subtree fetcher: invalid URL → `permanent_failure` delta 1, `dlq` delta 0, zero retries.
- Worker: invalid URL → DLQ branch on first attempt, counter decremented once.
- Zero-txid subtree → `processed`, never DLQ (the alert-false-positive theory, now pinned).
- Full suite + `magex lint` green.

## Post-deploy verification

`merkle_p2p_announcements_total{outcome="rejected_url"}` climbs while `merkle_subtree_messages_total{outcome="dlq"}` stays flat; the A1b alert stays silent; `subtree counter missing` errors stop.

## Ops note

If those two peer IDs are BSVA-run teranodes, their asset-service public URL config is the true root cause (`http://asset:8090` leaking into announcements) — worth checking regardless of this hardening.