### PR TITLE
fix(kafka): crash on persistent UNKNOWN_TOPIC_ID and keep dispatching through fetch errors

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -62,7 +62,7 @@ func main() {
 	// block-processor so /reprocess can't be coerced into probing
 	// loopback/RFC1918 addresses unless the operator opted in via
 	// datahub.allowPrivateIPs.
-	blockProducer, err := kafka.NewProducer(cfg.Kafka.Brokers, cfg.Kafka.BlockTopic, cfg.Kafka.TopicRetention(), logger)
+	blockProducer, err := kafka.NewProducer(cfg.Kafka.Brokers, cfg.Kafka.BlockTopic, cfg.Kafka.TopicPartitions(), cfg.Kafka.TopicRetention(), logger)
 	if err != nil {
 		log.Fatal("failed to create block producer: ", err)
 	}

--- a/cmd/merkle-service/main.go
+++ b/cmd/merkle-service/main.go
@@ -42,13 +42,13 @@ func main() {
 	}
 	defer func() { _ = registry.Close() }()
 
-	subtreeProducer, err := kafka.NewProducer(cfg.Kafka.Brokers, cfg.Kafka.SubtreeTopic, cfg.Kafka.TopicRetention(), logger)
+	subtreeProducer, err := kafka.NewProducer(cfg.Kafka.Brokers, cfg.Kafka.SubtreeTopic, cfg.Kafka.TopicPartitions(), cfg.Kafka.TopicRetention(), logger)
 	if err != nil {
 		log.Fatal("failed to create subtree producer: ", err)
 	}
 	defer func() { _ = subtreeProducer.Close() }()
 
-	blockProducer, err := kafka.NewProducer(cfg.Kafka.Brokers, cfg.Kafka.BlockTopic, cfg.Kafka.TopicRetention(), logger)
+	blockProducer, err := kafka.NewProducer(cfg.Kafka.Brokers, cfg.Kafka.BlockTopic, cfg.Kafka.TopicPartitions(), cfg.Kafka.TopicRetention(), logger)
 	if err != nil {
 		log.Fatal("failed to create block producer: ", err)
 	}

--- a/cmd/p2p-client/main.go
+++ b/cmd/p2p-client/main.go
@@ -46,13 +46,13 @@ func run() error {
 	defer func() { _ = telemetryShutdown(context.Background()) }()
 
 	// Create Kafka producers for subtree and block topics.
-	subtreeProducer, err := kafka.NewProducer(cfg.Kafka.Brokers, cfg.Kafka.SubtreeTopic, cfg.Kafka.TopicRetention(), logger)
+	subtreeProducer, err := kafka.NewProducer(cfg.Kafka.Brokers, cfg.Kafka.SubtreeTopic, cfg.Kafka.TopicPartitions(), cfg.Kafka.TopicRetention(), logger)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = subtreeProducer.Close() }()
 
-	blockProducer, err := kafka.NewProducer(cfg.Kafka.Brokers, cfg.Kafka.BlockTopic, cfg.Kafka.TopicRetention(), logger)
+	blockProducer, err := kafka.NewProducer(cfg.Kafka.Brokers, cfg.Kafka.BlockTopic, cfg.Kafka.TopicPartitions(), cfg.Kafka.TopicRetention(), logger)
 	if err != nil {
 		return err
 	}

--- a/internal/block/processor.go
+++ b/internal/block/processor.go
@@ -99,6 +99,7 @@ func (p *Processor) Init(cfg interface{}) error {
 	subtreeWorkProducer, err := kafka.NewProducer(
 		p.kafkaCfg.Brokers,
 		p.kafkaCfg.SubtreeWorkTopic,
+		p.kafkaCfg.TopicPartitions(),
 		p.kafkaCfg.TopicRetention(),
 		p.Logger,
 	)
@@ -111,6 +112,7 @@ func (p *Processor) Init(cfg interface{}) error {
 	callbackProducer, err := kafka.NewProducer(
 		p.kafkaCfg.Brokers,
 		p.kafkaCfg.CallbackTopic,
+		p.kafkaCfg.TopicPartitions(),
 		p.kafkaCfg.TopicRetention(),
 		p.Logger,
 	)

--- a/internal/block/subtree_worker.go
+++ b/internal/block/subtree_worker.go
@@ -130,6 +130,7 @@ func (s *SubtreeWorkerService) Init(_ interface{}) error {
 	callbackProducer, err := kafka.NewProducer(
 		s.kafkaCfg.Brokers,
 		s.kafkaCfg.CallbackTopic,
+		s.kafkaCfg.TopicPartitions(),
 		s.kafkaCfg.TopicRetention(),
 		s.Logger,
 	)
@@ -141,6 +142,7 @@ func (s *SubtreeWorkerService) Init(_ interface{}) error {
 	retryProducer, err := kafka.NewProducer(
 		s.kafkaCfg.Brokers,
 		s.kafkaCfg.SubtreeWorkTopic,
+		s.kafkaCfg.TopicPartitions(),
 		s.kafkaCfg.TopicRetention(),
 		s.Logger,
 	)
@@ -156,6 +158,7 @@ func (s *SubtreeWorkerService) Init(_ interface{}) error {
 	dlqProducer, err := kafka.NewProducer(
 		s.kafkaCfg.Brokers,
 		dlqTopic,
+		s.kafkaCfg.TopicPartitions(),
 		s.kafkaCfg.TopicRetention(),
 		s.Logger,
 	)

--- a/internal/callback/callback_integration_test.go
+++ b/internal/callback/callback_integration_test.go
@@ -107,7 +107,7 @@ func TestCallbackDelivery_SuccessfulCallback(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	// Now publish a CallbackTopicMessage to Kafka.
-	producer, err := kafka.NewProducer(brokers, stumpsTopic, nil, slog.Default())
+	producer, err := kafka.NewProducer(brokers, stumpsTopic, nil, nil, slog.Default())
 	if err != nil {
 		t.Skipf("Kafka not available; skipping: %v", err)
 	}
@@ -213,7 +213,7 @@ func TestCallbackDelivery_RetryOnFailure(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	// Now publish the CallbackTopicMessage.
-	producer, err := kafka.NewProducer(brokers, stumpsTopic, nil, slog.Default())
+	producer, err := kafka.NewProducer(brokers, stumpsTopic, nil, nil, slog.Default())
 	if err != nil {
 		t.Skipf("Kafka not available; skipping: %v", err)
 	}

--- a/internal/callback/delivery.go
+++ b/internal/callback/delivery.go
@@ -209,6 +209,7 @@ func (d *DeliveryService) Init(_ interface{}) error {
 	dlqProducer, err := kafka.NewProducer(
 		d.cfg.Kafka.Brokers,
 		d.cfg.Kafka.CallbackDLQTopic,
+		d.cfg.Kafka.TopicPartitions(),
 		d.cfg.Kafka.TopicRetention(),
 		d.Logger,
 	)
@@ -223,6 +224,7 @@ func (d *DeliveryService) Init(_ interface{}) error {
 	retryProducer, err := kafka.NewProducer(
 		d.cfg.Kafka.Brokers,
 		d.cfg.Kafka.CallbackTopic,
+		d.cfg.Kafka.TopicPartitions(),
 		d.cfg.Kafka.TopicRetention(),
 		d.Logger,
 	)

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -156,7 +156,7 @@ func newAerospikeClient(t *testing.T, namespace string) *store.AerospikeClient {
 // newCallbackProducer creates a Kafka producer for the given callback topic.
 func newCallbackProducer(t *testing.T, topic string) *kafka.Producer {
 	t.Helper()
-	producer, err := kafka.NewProducer([]string{kafkaBroker}, topic, nil, testLogger())
+	producer, err := kafka.NewProducer([]string{kafkaBroker}, topic, nil, nil, testLogger())
 	if err != nil {
 		t.Skipf("Kafka not available: %v", err)
 	}

--- a/internal/kafka/consumer.go
+++ b/internal/kafka/consumer.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
@@ -22,6 +23,14 @@ import (
 // exits unexpectedly. Indirected through a package variable so tests can
 // substitute it without taking down the test runner.
 var exitFunc = func(code int) { os.Exit(code) }
+
+// unknownTopicIDCrashAfter is how long a consumed topic may persistently fail
+// fetches with UNKNOWN_TOPIC_ID before the consumer deliberately crashes the
+// process (see pollLoop). kgo pins a topic's UUID at cursor creation and never
+// adopts the new ID after an out-of-band delete+recreate — the client is in a
+// documented fatal state and only a fresh client recovers. A package variable
+// so tests can shrink the window.
+var unknownTopicIDCrashAfter = 30 * time.Second
 
 // MessageHandler is called for each consumed message.
 type MessageHandler func(ctx context.Context, msg *Message) error
@@ -197,6 +206,15 @@ type Consumer struct {
 	// workers; no mutex needed.
 	resumeAt map[topicPartition]time.Time
 
+	// unknownTopicSince records, per topic, when fetches first failed with
+	// UNKNOWN_TOPIC_ID. kgo never adopts a recreated topic's new UUID, so
+	// once this error persists past unknownTopicIDCrashAfter the client is
+	// unrecoverable and the poll loop exits to trigger the F-053 crash guard
+	// (scale-ovh wedge of 15 Jul 2026: the redpanda operator delete+recreated
+	// every topic under four running consumers, which then heartbeated for an
+	// hour while consuming nothing). Poll-goroutine-owned; no mutex needed.
+	unknownTopicSince map[string]time.Time
+
 	cancelMu   sync.Mutex // teranode #638: guard the cancel func against races
 	cancel     context.CancelFunc
 	consumeCtx context.Context //nolint:containedctx // handed to workers created by rebalance callbacks
@@ -235,14 +253,15 @@ func NewConsumer(brokers []string, groupID string, topics []string, handler Mess
 	}
 
 	c := &Consumer{
-		groupID:    groupID,
-		topics:     topics,
-		handler:    handler,
-		logger:     logger,
-		ready:      make(chan struct{}),
-		workers:    make(map[topicPartition]*partitionWorker),
-		rewindReqs: make(map[topicPartition]*kgo.Record),
-		resumeAt:   make(map[topicPartition]time.Time),
+		groupID:           groupID,
+		topics:            topics,
+		handler:           handler,
+		logger:            logger,
+		ready:             make(chan struct{}),
+		workers:           make(map[topicPartition]*partitionWorker),
+		rewindReqs:        make(map[topicPartition]*kgo.Record),
+		resumeAt:          make(map[topicPartition]time.Time),
+		unknownTopicSince: make(map[string]time.Time),
 	}
 
 	// Ensure the subscribed topics exist (at their configured partition count)
@@ -356,85 +375,145 @@ func (c *Consumer) pollLoop(ctx context.Context) {
 		fetches := c.client.PollFetches(pollCtx)
 		cancelPoll()
 
-		// teranode #636/#638: client-closed is franz's self-healing reconnect or
-		// our own shutdown — recover, do not treat as a fatal goroutine exit.
-		if fetches.IsClientClosed() {
+		if c.processFetches(ctx, fetches) {
 			return
 		}
+	}
+}
 
-		// A zero-length Fetches is kgo's one poll return that does NOT hold
-		// the rebalance-blocking poller (its fill raced a rebalance that
-		// drained the readied buffers and un-registered the poller), so the
-		// post-poll window is NOT revoke-safe here. Skip rewind application
-		// until the next tick, at most pollTick away.
-		if len(fetches) == 0 {
-			c.signalReady()
-			c.client.AllowRebalance()
+// processFetches handles one PollFetches result: error classification (and
+// the UNKNOWN_TOPIC_ID crash escalation), batch dispatch to the partition
+// workers, rewind application, and the closing AllowRebalance. It returns
+// true when the poll loop must exit (client closed or fatal error). Split
+// from pollLoop so tests can drive it with hand-built Fetches — mixed
+// records-plus-errors polls are timing-dependent to produce via a real
+// broker.
+func (c *Consumer) processFetches(ctx context.Context, fetches kgo.Fetches) bool {
+	// teranode #636/#638: client-closed is franz's self-healing reconnect or
+	// our own shutdown — recover, do not treat as a fatal goroutine exit.
+	if fetches.IsClientClosed() {
+		return true
+	}
+
+	// A zero-length Fetches is kgo's one poll return that does NOT hold
+	// the rebalance-blocking poller (its fill raced a rebalance that
+	// drained the readied buffers and un-registered the poller), so the
+	// post-poll window is NOT revoke-safe here. Skip rewind application
+	// until the next tick, at most pollTick away.
+	if len(fetches) == 0 {
+		c.signalReady()
+		c.client.AllowRebalance()
+		return false
+	}
+
+	if errs := fetches.Errors(); len(errs) > 0 {
+		if c.classifyFetchErrors(errs) {
+			return true
+		}
+	} else {
+		// First healthy poll signals readiness.
+		c.signalReady()
+	}
+
+	fetches.EachPartition(func(p kgo.FetchTopicPartition) {
+		if len(p.Records) == 0 {
+			return
+		}
+		// Records flowing again is proof the topic resolved (a brief
+		// UNKNOWN_TOPIC_ID during create propagation, not a recreation) —
+		// stop the crash countdown.
+		delete(c.unknownTopicSince, p.Topic)
+		w, ok := c.workers[topicPartition{p.Topic, p.Partition}]
+		if !ok {
+			// No worker (partition raced a revoke). Records are
+			// uncommitted, so the new owner redelivers them.
+			return
+		}
+		select {
+		case w.recs <- p.Records:
+		case <-ctx.Done():
+		}
+	})
+
+	// Apply worker-recorded rewinds while rebalances are still blocked
+	// (post-poll, pre-AllowRebalance) — the only window where SetOffsets
+	// cannot race a revoke. See rewindReqs.
+	c.applyRewinds()
+
+	// With BlockRebalanceOnPoll, rebalances wait until we explicitly allow
+	// them — after dispatch, so partitions never move mid-dispatch.
+	c.client.AllowRebalance()
+	return false
+}
+
+// classifyFetchErrors logs and counts one poll's fetch errors, runs the
+// UNKNOWN_TOPIC_ID crash escalation, and reports whether the poll loop must
+// exit (context canceled / client closed). Transient broker errors are left
+// for the client to self-heal; crucially they do NOT stop the caller from
+// dispatching whatever records arrived in the same poll — skipping dispatch
+// on a mixed records-plus-errors poll would permanently drop those records
+// (kgo has already advanced its in-memory fetch positions past them), letting
+// a later commit on the same partition seal the loss (F-030), and would
+// starve every healthy partition for as long as one partition kept erroring
+// (the scale-ovh wedge of 15 Jul 2026).
+func (c *Consumer) classifyFetchErrors(errs []kgo.FetchError) (fatal bool) {
+	var crashTopic string
+	var crashSince time.Time
+	for _, e := range errs {
+		// Our own pollTick deadline: an idle tick, not a broker error.
+		// Only the fake fetch kgo injects for the poll context (no
+		// topic, partition -1) qualifies — a real topic/partition
+		// error that merely wraps DeadlineExceeded (e.g. an
+		// offset-validation timeout) must still be counted and
+		// logged below.
+		if e.Topic == "" && e.Partition < 0 && errors.Is(e.Err, context.DeadlineExceeded) {
 			continue
 		}
-
-		if errs := fetches.Errors(); len(errs) > 0 {
-			fatal := false
-			tickOnly := true
-			for _, e := range errs {
-				// Our own pollTick deadline: an idle tick, not a broker error.
-				// Only the fake fetch kgo injects for the poll context (no
-				// topic, partition -1) qualifies — a real topic/partition
-				// error that merely wraps DeadlineExceeded (e.g. an
-				// offset-validation timeout) must still be counted and
-				// logged below.
-				if e.Topic == "" && e.Partition < 0 && errors.Is(e.Err, context.DeadlineExceeded) {
-					continue
-				}
-				tickOnly = false
-				if errors.Is(e.Err, context.Canceled) || errors.Is(e.Err, kgo.ErrClientClosed) {
-					fatal = true
-					continue
-				}
-				metrics.IncKafkaConsumerError(e.Topic, metrics.KafkaErrorBroker)
-				c.logger.Error("franz fetch error", "topic", e.Topic, "partition", e.Partition, "error", e.Err)
-			}
-			if fatal {
-				return
-			}
-			if !tickOnly {
-				// Transient fetch errors: let the client self-heal and poll again.
-				c.applyRewinds()
-				c.client.AllowRebalance()
-				continue
-			}
-			// Idle tick: fall through — rewind application and AllowRebalance
-			// below still run.
-		} else {
-			// First healthy poll signals readiness.
-			c.signalReady()
+		if errors.Is(e.Err, context.Canceled) || errors.Is(e.Err, kgo.ErrClientClosed) {
+			fatal = true
+			continue
 		}
-
-		fetches.EachPartition(func(p kgo.FetchTopicPartition) {
-			if len(p.Records) == 0 {
-				return
+		metrics.IncKafkaConsumerError(e.Topic, metrics.KafkaErrorBroker)
+		c.logger.Error("franz fetch error", "topic", e.Topic, "partition", e.Partition, "error", e.Err)
+		if errors.Is(e.Err, kerr.UnknownTopicID) {
+			first, seen := c.unknownTopicSince[e.Topic]
+			switch {
+			case !seen:
+				c.unknownTopicSince[e.Topic] = time.Now()
+			case time.Since(first) > unknownTopicIDCrashAfter && crashTopic == "":
+				crashTopic, crashSince = e.Topic, first
 			}
-			w, ok := c.workers[topicPartition{p.Topic, p.Partition}]
-			if !ok {
-				// No worker (partition raced a revoke). Records are
-				// uncommitted, so the new owner redelivers them.
-				return
-			}
-			select {
-			case w.recs <- p.Records:
-			case <-ctx.Done():
-			}
-		})
-
-		// Apply worker-recorded rewinds while rebalances are still blocked
-		// (post-poll, pre-AllowRebalance) — the only window where SetOffsets
-		// cannot race a revoke. See rewindReqs.
-		c.applyRewinds()
-
-		// With BlockRebalanceOnPoll, rebalances wait until we explicitly allow
-		// them — after dispatch, so partitions never move mid-dispatch.
-		c.client.AllowRebalance()
+		}
 	}
+	if fatal {
+		return true
+	}
+	if crashTopic != "" {
+		// The topic was deleted (and possibly recreated) out from under this
+		// client; kgo pins the old UUID and will never consume the topic
+		// again. Crash so the orchestrator restarts the pod: the fresh client
+		// adopts the new topic ID and EnsureTopics re-creates a still-missing
+		// topic.
+		c.logger.Error(
+			"UNKNOWN_TOPIC_ID persisted past recovery window; topic was recreated or deleted out-of-band — crashing so the restarted pod recovers",
+			"group", c.groupID,
+			"topic", crashTopic,
+			"since", crashSince,
+			"window", unknownTopicIDCrashAfter,
+		)
+		exitFunc(1)
+		// exitFunc never returns in production. Under a test stub it does:
+		// initiate the normal shutdown sequence instead of exiting the poll
+		// loop directly — the loop MUST keep polling until the
+		// watcher-initiated close completes or the group leave deadlocks
+		// under BlockRebalanceOnPoll (see Start).
+		c.cancelMu.Lock()
+		if c.cancel != nil {
+			c.cancel()
+		}
+		c.cancelMu.Unlock()
+	}
+	return false
 }
 
 // applyRewinds performs the client side of every pending rewind and resumes

--- a/internal/kafka/fetch_error_dispatch_test.go
+++ b/internal/kafka/fetch_error_dispatch_test.go
@@ -1,0 +1,93 @@
+package kafka
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// TestProcessFetches_DispatchesRecordsDespiteFetchErrors pins the second
+// lesson of the scale-ovh wedge of 15 Jul 2026: a poll whose Fetches carry
+// BOTH records and a per-partition error must still dispatch the records.
+//
+// The old poll loop `continue`d past dispatch whenever any non-tick fetch
+// error was present. That starved every healthy partition for as long as one
+// partition kept erroring — and worse: kgo advances its in-memory fetch
+// positions for records the moment PollFetches returns them, so records
+// skipped this way are never re-fetched in-session; a later commit on the
+// same partition then seals the loss permanently (F-030 violation).
+//
+// Driven through processFetches with hand-built Fetches because a real
+// broker delivers the mixed records-plus-errors poll only under timing
+// races; the shape itself is what must be handled.
+func TestProcessFetches_DispatchesRecordsDespiteFetchErrors(t *testing.T) {
+	const healthyTopic = "healthy-topic"
+	const wedgedTopic = "wedged-topic"
+
+	// A real (kfake-backed) client so processFetches' AllowRebalance and
+	// rewind plumbing run against genuine kgo internals; the Fetches under
+	// test are injected, not polled.
+	cluster, err := kfake.NewCluster(kfake.NumBrokers(1), kfake.SeedTopics(1, healthyTopic))
+	if err != nil {
+		t.Fatalf("starting kfake cluster: %v", err)
+	}
+	defer cluster.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	var handled atomic.Int64
+	handler := func(context.Context, *Message) error {
+		handled.Add(1)
+		return nil
+	}
+
+	c, err := NewConsumer(cluster.ListenAddrs(), "dispatch-group", []string{healthyTopic}, handler, nil, nil, logger)
+	if err != nil {
+		t.Fatalf("NewConsumer: %v", err)
+	}
+	defer func() { _ = c.closeClient() }()
+
+	// Register a worker for the healthy partition by hand — the consumer is
+	// deliberately not Started, so processFetches (normally poll-goroutine
+	// code) can be driven synchronously here.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tp := topicPartition{healthyTopic, 0}
+	w := newPartitionWorker(c, tp, ctx)
+	c.workers[tp] = w
+	go w.run()
+	defer w.stop()
+
+	fetches := kgo.Fetches{{
+		Topics: []kgo.FetchTopic{
+			{
+				Topic: wedgedTopic,
+				Partitions: []kgo.FetchPartition{
+					{Partition: 0, Err: kerr.UnknownTopicID},
+				},
+			},
+			{
+				Topic: healthyTopic,
+				Partitions: []kgo.FetchPartition{
+					{Partition: 0, Records: []*kgo.Record{
+						{Topic: healthyTopic, Partition: 0, Offset: 0, Value: []byte("must-not-be-dropped")},
+					}},
+				},
+			},
+		},
+	}}
+
+	if exit := c.processFetches(ctx, fetches); exit {
+		t.Fatal("processFetches reported a fatal exit for a transient per-partition error")
+	}
+
+	waitFor(t, "record dispatched despite concurrent fetch error", 5*time.Second,
+		func() bool { return handled.Load() == 1 })
+}

--- a/internal/kafka/kafka_integration_test.go
+++ b/internal/kafka/kafka_integration_test.go
@@ -57,7 +57,7 @@ func TestKafka_ProduceConsumeRoundTrip(t *testing.T) {
 	topic := uniqueTopic(t, "integ_roundtrip")
 	ensureTopicExists(t, topic)
 
-	producer, err := kafka.NewProducer(brokers, topic, nil, slog.Default())
+	producer, err := kafka.NewProducer(brokers, topic, nil, nil, slog.Default())
 	if err != nil {
 		t.Skipf("Kafka not available: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestKafka_ProduceMultipleConsumeInOrder(t *testing.T) {
 	topic := uniqueTopic(t, "integ_order")
 	ensureTopicExists(t, topic)
 
-	producer, err := kafka.NewProducer(brokers, topic, nil, slog.Default())
+	producer, err := kafka.NewProducer(brokers, topic, nil, nil, slog.Default())
 	if err != nil {
 		t.Skipf("Kafka not available: %v", err)
 	}
@@ -185,7 +185,7 @@ func TestKafka_ConsumerGroupOffsetManagement(t *testing.T) {
 	topic := uniqueTopic(t, "integ_offset")
 	ensureTopicExists(t, topic)
 
-	producer, err := kafka.NewProducer(brokers, topic, nil, slog.Default())
+	producer, err := kafka.NewProducer(brokers, topic, nil, nil, slog.Default())
 	if err != nil {
 		t.Skipf("Kafka not available: %v", err)
 	}

--- a/internal/kafka/nil_logger_test.go
+++ b/internal/kafka/nil_logger_test.go
@@ -17,7 +17,7 @@ func TestNewProducer_NilLoggerIsSafe(t *testing.T) {
 	}
 	defer cluster.Close()
 
-	p, err := NewProducer(cluster.ListenAddrs(), "nil-logger-producer-test", nil, nil)
+	p, err := NewProducer(cluster.ListenAddrs(), "nil-logger-producer-test", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewProducer: %v", err)
 	}

--- a/internal/kafka/producer.go
+++ b/internal/kafka/producer.go
@@ -173,6 +173,15 @@ type Producer struct {
 // so accepting nil here without defaulting would turn the first publish into a
 // panic.
 //
+// partitions optionally maps topic names to the partition count each should be
+// created with (config.KafkaConfig.TopicPartitions), exactly as NewConsumer
+// takes it; only this producer's target topic is looked up. Pass nil for
+// topics with no configured width (they are created at 1 partition). Without
+// this, a producer that started before any consumer created the work topics
+// 1-partition wide (scale-ovh, 15 Jul 2026: the subtree topic's on-disk
+// layout showed partition 0 from the producer's create and partitions 1+ from
+// a later consumer grow, remapping keys mid-stream).
+//
 // retentionMs optionally maps topic names to the retention.ms a topic should
 // be CREATED with (source: KafkaConfig.TopicRetention); existing topics are
 // never altered. This matters most here: the DLQ topics are producer-only, so
@@ -180,7 +189,7 @@ type Producer struct {
 // configs on a fresh cluster they inherit the broker default retention
 // (15 minutes on dev-ovh-1), silently expiring dead letters. Pass nil only in
 // unit tests.
-func NewProducer(brokers []string, topic string, retentionMs map[string]int64, logger *slog.Logger) (*Producer, error) {
+func NewProducer(brokers []string, topic string, partitions map[string]int32, retentionMs map[string]int64, logger *slog.Logger) (*Producer, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -195,7 +204,7 @@ func NewProducer(brokers []string, topic string, retentionMs map[string]int64, l
 	// NewConsumer: a transient failure is logged, not fatal — auto-creating
 	// brokers still work without it.
 	ensureCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	if eErr := EnsureTopics(ensureCtx, brokers, []string{topic}, nil, retentionMs, logger); eErr != nil {
+	if eErr := EnsureTopics(ensureCtx, brokers, []string{topic}, partitions, retentionMs, logger); eErr != nil {
 		logger.Warn("could not pre-create producer topic; relying on broker auto-create",
 			"topic", topic, "error", eErr)
 	}

--- a/internal/kafka/producer_batch_test.go
+++ b/internal/kafka/producer_batch_test.go
@@ -90,7 +90,7 @@ func TestPublishBatch_KgoRoundTrip(t *testing.T) {
 	defer cluster.Close()
 	brokers := cluster.ListenAddrs()
 
-	prod, err := NewProducer(brokers, topic, nil, discardLogger())
+	prod, err := NewProducer(brokers, topic, nil, nil, discardLogger())
 	if err != nil {
 		t.Fatalf("creating producer: %v", err)
 	}

--- a/internal/kafka/producer_ensure_test.go
+++ b/internal/kafka/producer_ensure_test.go
@@ -6,7 +6,9 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
 )
 
 // TestNewProducer_EnsuresTopicOnStartup reproduces the dev-ovh-1 incident of
@@ -29,7 +31,7 @@ func TestNewProducer_EnsuresTopicOnStartup(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	p, err := NewProducer(cluster.ListenAddrs(), "ensure-dlq-test", nil, logger)
+	p, err := NewProducer(cluster.ListenAddrs(), "ensure-dlq-test", nil, nil, logger)
 	if err != nil {
 		t.Fatalf("NewProducer: %v", err)
 	}
@@ -37,5 +39,48 @@ func TestNewProducer_EnsuresTopicOnStartup(t *testing.T) {
 
 	if err := p.Publish(context.Background(), "key", []byte("parked message")); err != nil {
 		t.Fatalf("publish to producer-only topic must succeed on a broker with auto-create disabled: %v", err)
+	}
+}
+
+// TestNewProducer_EnsuresTopicAtConfiguredPartitionCount pins the partition
+// width of producer-created topics. Until the scale-ovh incident of 15 Jul
+// 2026, NewProducer ensured its topic with a nil partitions map, so a
+// producer that started before any consumer created the work topic at 1
+// partition — observed live on dev-ovh-1: the subtree topic's on-disk
+// partition dirs showed partition 0 created by one controller command and
+// partitions 1+ grafted on later by a consumer's grow, remapping every key
+// mid-stream. A producer must create its topic at the same configured width
+// consumers use (config.KafkaConfig.TopicPartitions).
+func TestNewProducer_EnsuresTopicAtConfiguredPartitionCount(t *testing.T) {
+	const topic = "work-topic"
+	const want = 24
+
+	cluster, err := kfake.NewCluster(kfake.NumBrokers(1))
+	if err != nil {
+		t.Fatalf("starting kfake cluster: %v", err)
+	}
+	defer cluster.Close()
+	brokers := cluster.ListenAddrs()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	p, err := NewProducer(brokers, topic, map[string]int32{topic: want}, nil, logger)
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	adm, err := kgo.NewClient(kgo.SeedBrokers(brokers...))
+	if err != nil {
+		t.Fatalf("admin client: %v", err)
+	}
+	defer adm.Close()
+	details, err := kadm.NewClient(adm).ListTopics(context.Background(), topic)
+	if err != nil {
+		t.Fatalf("listing topics: %v", err)
+	}
+	got := len(details[topic].Partitions)
+	if got != want {
+		t.Fatalf("producer-created topic %s has %d partitions, want %d", topic, got, want)
 	}
 }

--- a/internal/kafka/publish_bench_integration_test.go
+++ b/internal/kafka/publish_bench_integration_test.go
@@ -50,7 +50,7 @@ func BenchmarkPublishFanout(b *testing.B) {
 	}
 	adminClient.Close()
 
-	prod, err := kafka.NewProducer([]string{brokers}, topic, nil, logger)
+	prod, err := kafka.NewProducer([]string{brokers}, topic, nil, nil, logger)
 	if err != nil {
 		b.Skipf("Kafka not available at %s: %v", brokers, err)
 	}

--- a/internal/kafka/topic_recreation_test.go
+++ b/internal/kafka/topic_recreation_test.go
@@ -82,8 +82,8 @@ func TestConsumer_CrashesOnPersistentUnknownTopicID(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	if err := c.Start(ctx); err != nil {
-		t.Fatalf("Start: %v", err)
+	if sErr := c.Start(ctx); sErr != nil {
+		t.Fatalf("Start: %v", sErr)
 	}
 	defer func() { _ = c.Stop() }()
 
@@ -95,8 +95,8 @@ func TestConsumer_CrashesOnPersistentUnknownTopicID(t *testing.T) {
 
 	// Healthy baseline: the consumer must be demonstrably consuming before
 	// the wedge, so the crash below cannot be a startup artifact.
-	if err := prod.ProduceSync(context.Background(), &kgo.Record{Value: []byte("pre")}).FirstErr(); err != nil {
-		t.Fatalf("producing baseline record: %v", err)
+	if pErr := prod.ProduceSync(context.Background(), &kgo.Record{Value: []byte("pre")}).FirstErr(); pErr != nil {
+		t.Fatalf("producing baseline record: %v", pErr)
 	}
 	waitFor(t, "baseline record consumed", 15*time.Second,
 		func() bool { return handled.Load() > 0 })

--- a/internal/kafka/topic_recreation_test.go
+++ b/internal/kafka/topic_recreation_test.go
@@ -1,0 +1,150 @@
+package kafka
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// TestConsumer_CrashesOnPersistentUnknownTopicID reproduces the scale-ovh
+// wedge of 15 Jul 2026: the redpanda operator (reconciling Topic CRs)
+// deleted and recreated every merkle topic while the services were running.
+// kgo pins a consumed topic's UUID at cursor creation and deliberately never
+// adopts the recreated topic's new ID (kgo source.go: "a recreated topic
+// stalls loudly (UNKNOWN_TOPIC_ID) ... and the user must purge+re-add"), so
+// every consumer spun on UNKNOWN_TOPIC_ID fetch errors — ~10/s per partition,
+// group Stable via background heartbeats, zero commits, for an hour — while
+// the old poll loop classified the error as transient forever.
+//
+// The broker symptom is injected with a kfake fetch Control rather than a
+// real out-of-band delete+recreate: a real recreation on kfake wedges the
+// consumer just as hard (verified while writing this test) but SILENTLY —
+// kgo's fetch session goes quiescent after a single stripped error, so the
+// persistent UNKNOWN_TOPIC_ID stream redpanda produces never reaches
+// PollFetches. The Control replays the observed redpanda behavior: every
+// fetch response fails every requested partition with UNKNOWN_TOPIC_ID.
+//
+// The contract pinned here: when UNKNOWN_TOPIC_ID persists past
+// unknownTopicIDCrashAfter, the consumer crashes the process (exitFunc, the
+// F-053 zombie guard) so the orchestrator restarts it — a fresh client adopts
+// the new topic ID and NewConsumer's EnsureTopics re-creates the topic if it
+// is missing outright. Both wedge variants heal on restart.
+func TestConsumer_CrashesOnPersistentUnknownTopicID(t *testing.T) {
+	const topic = "recreated-topic"
+	const partitions = 2
+
+	cluster, err := kfake.NewCluster(
+		kfake.NumBrokers(1),
+		kfake.SeedTopics(partitions, topic),
+	)
+	if err != nil {
+		t.Fatalf("starting kfake cluster: %v", err)
+	}
+	defer cluster.Close()
+	brokers := cluster.ListenAddrs()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Shrink the escalation window so the test completes quickly; production
+	// default is restored on cleanup.
+	origCrashAfter := unknownTopicIDCrashAfter
+	unknownTopicIDCrashAfter = 2 * time.Second
+	defer func() { unknownTopicIDCrashAfter = origCrashAfter }()
+
+	// F-053 crash-guard stub (see redelivery_test.go).
+	exitCh := make(chan int, 1)
+	origExit := exitFunc
+	exitFunc = func(code int) {
+		select {
+		case exitCh <- code:
+		default:
+		}
+	}
+	defer func() { exitFunc = origExit }()
+
+	var handled atomic.Int64
+	handler := func(context.Context, *Message) error {
+		handled.Add(1)
+		return nil
+	}
+
+	c, err := NewConsumer(brokers, "recreate-group", []string{topic}, handler, nil, nil, logger)
+	if err != nil {
+		t.Fatalf("NewConsumer: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := c.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = c.Stop() }()
+
+	prod, err := kgo.NewClient(kgo.SeedBrokers(brokers...), kgo.DefaultProduceTopic(topic))
+	if err != nil {
+		t.Fatalf("creating producer: %v", err)
+	}
+	defer prod.Close()
+
+	// Healthy baseline: the consumer must be demonstrably consuming before
+	// the wedge, so the crash below cannot be a startup artifact.
+	if err := prod.ProduceSync(context.Background(), &kgo.Record{Value: []byte("pre")}).FirstErr(); err != nil {
+		t.Fatalf("producing baseline record: %v", err)
+	}
+	waitFor(t, "baseline record consumed", 15*time.Second,
+		func() bool { return handled.Load() > 0 })
+
+	// Wedge the broker: from now on every fetch fails every requested
+	// partition with UNKNOWN_TOPIC_ID, as redpanda does when the fetch
+	// carries the UUID of a deleted-and-recreated topic.
+	cluster.ControlKey(int16(kmsg.Fetch), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.KeepControl()
+		req := kreq.(*kmsg.FetchRequest)
+		resp := req.ResponseKind().(*kmsg.FetchResponse)
+		for _, rt := range req.Topics {
+			st := kmsg.NewFetchResponseTopic()
+			st.Topic = rt.Topic
+			st.TopicID = rt.TopicID
+			for _, rp := range rt.Partitions {
+				sp := kmsg.NewFetchResponseTopicPartition()
+				sp.Partition = rp.Partition
+				sp.ErrorCode = kerr.UnknownTopicID.Code
+				st.Partitions = append(st.Partitions, sp)
+			}
+			resp.Topics = append(resp.Topics, st)
+		}
+		return resp, nil, true
+	})
+
+	// The consumer is now wedged on UNKNOWN_TOPIC_ID. It must escalate to a
+	// process crash once the error persists past the (shrunken) threshold.
+	select {
+	case code := <-exitCh:
+		if code != 1 {
+			t.Fatalf("crash guard fired with exit code %d, want 1", code)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatalf("consumer never crashed on persistent UNKNOWN_TOPIC_ID (handled=%d) — zombie state",
+			handled.Load())
+	}
+}
+
+// waitFor polls cond until it is true or the timeout elapses.
+func waitFor(t *testing.T, what string, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}

--- a/internal/subtree/processor.go
+++ b/internal/subtree/processor.go
@@ -133,6 +133,7 @@ func (p *Processor) Init(_ interface{}) error {
 	callbackProducer, err := kafka.NewProducer(
 		p.cfg.Kafka.Brokers,
 		p.cfg.Kafka.CallbackTopic,
+		p.cfg.Kafka.TopicPartitions(),
 		p.cfg.Kafka.TopicRetention(),
 		p.Logger,
 	)
@@ -147,6 +148,7 @@ func (p *Processor) Init(_ interface{}) error {
 	retryProducer, err := kafka.NewProducer(
 		p.cfg.Kafka.Brokers,
 		p.cfg.Kafka.SubtreeTopic,
+		p.cfg.Kafka.TopicPartitions(),
 		p.cfg.Kafka.TopicRetention(),
 		p.Logger,
 	)
@@ -161,6 +163,7 @@ func (p *Processor) Init(_ interface{}) error {
 	dlqProducer, err := kafka.NewProducer(
 		p.cfg.Kafka.Brokers,
 		p.cfg.Kafka.SubtreeDLQTopic,
+		p.cfg.Kafka.TopicPartitions(),
 		p.cfg.Kafka.TopicRetention(),
 		p.Logger,
 	)

--- a/test/scale/production_test.go
+++ b/test/scale/production_test.go
@@ -235,7 +235,7 @@ func runProductionScaleTest(t *testing.T, fixtureDir string, timeout time.Durati
 	}
 
 	// ---- Phase A: SEEN (network observation) ----
-	subtreeProducer, err := kafka.NewProducer([]string{kafkaBroker}, subtreeTopic, nil, logger)
+	subtreeProducer, err := kafka.NewProducer([]string{kafkaBroker}, subtreeTopic, nil, nil, logger)
 	if err != nil {
 		t.Fatalf("failed to create subtree producer: %v", err)
 	}
@@ -281,7 +281,7 @@ func runProductionScaleTest(t *testing.T, fixtureDir string, timeout time.Durati
 	_, seenTxids := waitSeen()
 
 	// ---- Phase B: MINED (block processing) ----
-	blockProducer, err := kafka.NewProducer([]string{kafkaBroker}, blockTopic, nil, logger)
+	blockProducer, err := kafka.NewProducer([]string{kafkaBroker}, blockTopic, nil, nil, logger)
 	if err != nil {
 		t.Fatalf("failed to create block producer: %v", err)
 	}

--- a/test/scale/scale_test.go
+++ b/test/scale/scale_test.go
@@ -31,7 +31,7 @@ func testLogger() *slog.Logger {
 // TestMain performs environment checks before running scale tests.
 func TestMain(m *testing.M) {
 	// Check Kafka reachability.
-	p, err := kafka.NewProducer([]string{kafkaBroker}, "probe-topic", nil, slog.Default())
+	p, err := kafka.NewProducer([]string{kafkaBroker}, "probe-topic", nil, nil, slog.Default())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "SKIP: Kafka not reachable at %s: %v\n", kafkaBroker, err)
 		os.Exit(0)
@@ -219,7 +219,7 @@ func runScaleTest(t *testing.T, fixtureDir string, instanceCount int, timeout ti
 	stumpsDLQTopic := stumpsTopic + "-dlq"
 	subtreeWorkTopic := fmt.Sprintf("scale-subtree-work-%d", time.Now().UnixNano())
 
-	blockProducer, err := kafka.NewProducer([]string{kafkaBroker}, blockTopic, nil, logger)
+	blockProducer, err := kafka.NewProducer([]string{kafkaBroker}, blockTopic, nil, nil, logger)
 	if err != nil {
 		t.Fatalf("failed to create block producer: %v", err)
 	}


### PR DESCRIPTION
## Summary

Post-mortem fixes for the scale-ovh wedge of 15 Jul 2026: the redpanda operator (reconciling ArgoCD-managed Topic CRs at a 3s interval) deleted and recreated every merkle topic under the running services. All four consumer services spun on `UNKNOWN_TOPIC_ID` fetch errors for an hour — groups Stable via background heartbeats, zero commits, `subtree` backlog expiring under its 15-minute retention — the exact alive-but-silent zombie class #180 set out to kill. The #180 startup auto-creation worked as written; these are the layers it didn't cover.

- **Crash on persistent UNKNOWN_TOPIC_ID** (`consumer.go`): kgo pins a consumed topic's UUID at cursor creation and deliberately never adopts the new ID after a delete+recreate (kgo `source.go`; auto-adoption backed out in franz-go #908 — the client is documented as fatally stalled). The poll loop treated this as transient forever. It now tracks when each topic first failed and, past `unknownTopicIDCrashAfter` (30s), crashes via the F-053 `exitFunc` path — the restarted pod's fresh client adopts the new topic ID, and startup `EnsureTopics` re-creates a topic deleted outright. The crash initiates the normal cancel→watcher→close shutdown; exiting the poll loop directly deadlocks the group leave under `BlockRebalanceOnPoll`.
- **Dispatch records even when a partition errors** (`consumer.go`): the old loop `continue`d past dispatch on any non-tick fetch error. kgo advances its in-memory fetch positions when `PollFetches` returns, so skipped records were never re-fetched in-session and a later commit sealed the loss (F-030 violation); one erroring partition also starved every healthy one. Error classification (`classifyFetchErrors`) is now independent of dispatch.
- **Producers create topics at the configured width** (`producer.go` + 15 call sites): `NewProducer` ensured with a nil partitions map, creating work topics 1 partition wide when a producer started first — observed live in the subtree topic's on-disk revision layout. It now takes `config.KafkaConfig.TopicPartitions()` exactly as `NewConsumer` does.

**Infra follow-up (not in this PR):** the `redpanda-topics-merkle-service-*` ArgoCD apps' Topic CRs want 3 partitions for everything and fight merkle's own topic management — align them (callback=1 for STUMP/BLOCK_PROCESSED ordering, subtree=12, subtree-work=24, add the missing subtree-work CR) or drop them; any CR re-apply repeats the recreation.

## Test Plan

- [x] `TestConsumer_CrashesOnPersistentUnknownTopicID` — kfake fetch Control replays redpanda's persistent UNKNOWN_TOPIC_ID stream (a real kfake delete+recreate wedges the consumer identically but silently — kgo's fetch session goes quiescent after one stripped error); asserts the stubbed `exitFunc` fires and `Stop()` still completes. Watched fail (30s zombie timeout) without the fix.
- [x] `TestProcessFetches_DispatchesRecordsDespiteFetchErrors` — hand-built mixed records+error poll; asserts the healthy partition's record is handled. Watched fail against the old skip-dispatch behavior.
- [x] `TestNewProducer_EnsuresTopicAtConfiguredPartitionCount` — producer-created topic has the configured 24 partitions. Watched fail (1 partition) with a nil map.
- [x] Full repo suite green (`go test ./...`), `go vet` clean.
- [x] Live remediation verified on scale-ovh: after rollout restarts all four groups commit again, zero fetch errors, block/callback lag 0.