### PR TITLE
fix: consumer resilience under deep backlog — mid-batch commits, fencing recovery, ENOSPC backpressure, startup retry, explicit topic retention

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -62,7 +62,7 @@ func main() {
 	// block-processor so /reprocess can't be coerced into probing
 	// loopback/RFC1918 addresses unless the operator opted in via
 	// datahub.allowPrivateIPs.
-	blockProducer, err := kafka.NewProducer(cfg.Kafka.Brokers, cfg.Kafka.BlockTopic, logger)
+	blockProducer, err := kafka.NewProducer(cfg.Kafka.Brokers, cfg.Kafka.BlockTopic, cfg.Kafka.TopicRetention(), logger)
 	if err != nil {
 		log.Fatal("failed to create block producer: ", err)
 	}

--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -32,7 +32,7 @@ func main() {
 	}
 	defer func() { _ = telemetryShutdown(context.Background()) }()
 
-	registry, err := store.NewFromConfig(ctx, cfg, logger)
+	registry, err := store.NewFromConfigWithRetry(ctx, cfg, logger)
 	if err != nil {
 		log.Fatal("failed to build store registry: ", err)
 	}

--- a/cmd/block-processor/main.go
+++ b/cmd/block-processor/main.go
@@ -29,7 +29,7 @@ func main() {
 	}
 	defer func() { _ = telemetryShutdown(context.Background()) }()
 
-	registry, err := store.NewFromConfig(ctx, cfg, logger)
+	registry, err := store.NewFromConfigWithRetry(ctx, cfg, logger)
 	if err != nil {
 		log.Fatal("failed to build store registry: ", err)
 	}

--- a/cmd/callback-delivery/main.go
+++ b/cmd/callback-delivery/main.go
@@ -29,7 +29,7 @@ func main() {
 	}
 	defer func() { _ = telemetryShutdown(context.Background()) }()
 
-	registry, err := store.NewFromConfig(ctx, cfg, logger)
+	registry, err := store.NewFromConfigWithRetry(ctx, cfg, logger)
 	if err != nil {
 		log.Fatal("failed to build store registry: ", err)
 	}

--- a/cmd/merkle-service/main.go
+++ b/cmd/merkle-service/main.go
@@ -36,7 +36,7 @@ func main() {
 	}
 	defer func() { _ = telemetryShutdown(context.Background()) }()
 
-	registry, err := store.NewFromConfig(ctx, cfg, logger)
+	registry, err := store.NewFromConfigWithRetry(ctx, cfg, logger)
 	if err != nil {
 		log.Fatal("failed to build store registry: ", err)
 	}

--- a/cmd/merkle-service/main.go
+++ b/cmd/merkle-service/main.go
@@ -42,13 +42,13 @@ func main() {
 	}
 	defer func() { _ = registry.Close() }()
 
-	subtreeProducer, err := kafka.NewProducer(cfg.Kafka.Brokers, cfg.Kafka.SubtreeTopic, logger)
+	subtreeProducer, err := kafka.NewProducer(cfg.Kafka.Brokers, cfg.Kafka.SubtreeTopic, cfg.Kafka.TopicRetention(), logger)
 	if err != nil {
 		log.Fatal("failed to create subtree producer: ", err)
 	}
 	defer func() { _ = subtreeProducer.Close() }()
 
-	blockProducer, err := kafka.NewProducer(cfg.Kafka.Brokers, cfg.Kafka.BlockTopic, logger)
+	blockProducer, err := kafka.NewProducer(cfg.Kafka.Brokers, cfg.Kafka.BlockTopic, cfg.Kafka.TopicRetention(), logger)
 	if err != nil {
 		log.Fatal("failed to create block producer: ", err)
 	}

--- a/cmd/p2p-client/main.go
+++ b/cmd/p2p-client/main.go
@@ -46,13 +46,13 @@ func run() error {
 	defer func() { _ = telemetryShutdown(context.Background()) }()
 
 	// Create Kafka producers for subtree and block topics.
-	subtreeProducer, err := kafka.NewProducer(cfg.Kafka.Brokers, cfg.Kafka.SubtreeTopic, logger)
+	subtreeProducer, err := kafka.NewProducer(cfg.Kafka.Brokers, cfg.Kafka.SubtreeTopic, cfg.Kafka.TopicRetention(), logger)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = subtreeProducer.Close() }()
 
-	blockProducer, err := kafka.NewProducer(cfg.Kafka.Brokers, cfg.Kafka.BlockTopic, logger)
+	blockProducer, err := kafka.NewProducer(cfg.Kafka.Brokers, cfg.Kafka.BlockTopic, cfg.Kafka.TopicRetention(), logger)
 	if err != nil {
 		return err
 	}

--- a/cmd/subtree-fetcher/main.go
+++ b/cmd/subtree-fetcher/main.go
@@ -29,7 +29,7 @@ func main() {
 	}
 	defer func() { _ = telemetryShutdown(context.Background()) }()
 
-	registry, err := store.NewFromConfig(ctx, cfg, logger)
+	registry, err := store.NewFromConfigWithRetry(ctx, cfg, logger)
 	if err != nil {
 		log.Fatal("failed to build store registry: ", err)
 	}

--- a/cmd/subtree-worker/main.go
+++ b/cmd/subtree-worker/main.go
@@ -29,7 +29,7 @@ func main() {
 	}
 	defer func() { _ = telemetryShutdown(context.Background()) }()
 
-	registry, err := store.NewFromConfig(ctx, cfg, logger)
+	registry, err := store.NewFromConfigWithRetry(ctx, cfg, logger)
 	if err != nil {
 		log.Fatal("failed to build store registry: ", err)
 	}

--- a/config.yaml
+++ b/config.yaml
@@ -243,6 +243,17 @@ kafka:
   # Env: KAFKA_SUBTREE_WORK_PARTITIONS
   subtreeWorkPartitions: 24
 
+  # retention.ms applied when THIS service creates a topic (work topics and
+  # DLQ topics respectively). Applied at CREATE time only — existing topics
+  # are never altered, so GitOps-managed Topic CRDs stay authoritative.
+  # Without an explicit value, a fresh cluster's broker default applies
+  # silently (some clusters default to minutes, silently expiring queued work
+  # and dead letters). Defaults: 6 hours for work topics, 7 days for DLQs.
+  # Env: KAFKA_TOPIC_RETENTION_MS
+  topicRetentionMs: 21600000
+  # Env: KAFKA_DLQ_RETENTION_MS
+  dlqRetentionMs: 604800000
+
 # ---------------------------------------------------------------------------
 # P2P — Teranode network connectivity via go-teranode-p2p-client
 # ---------------------------------------------------------------------------
@@ -291,6 +302,13 @@ subtree:
   # Prevents reprocessing of subtrees already successfully handled.
   # Env: SUBTREE_DEDUP_CACHE_SIZE
   dedupCacheSize: 100000
+
+  # Base delay (ms) before a transient subtree failure is re-published for
+  # retry; doubles per attempt, capped at 30s, so the bounded retry budget
+  # spans real time instead of burning out in milliseconds. 0 disables the
+  # backoff (not recommended in production).
+  # Env: SUBTREE_RETRY_BACKOFF_BASE_MS
+  retryBackoffBaseMs: 1000
 
   # Caps how many matched txids are included (as a "txids" array) on the Info
   # log emitted for each SEEN_ON_NETWORK / SEEN_MULTIPLE_NODES batch published

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/twmb/franz-go v1.21.5
 	github.com/twmb/franz-go/pkg/kadm v1.18.0
 	github.com/twmb/franz-go/pkg/kfake v0.0.0-20260615024848-f17c00130060
+	github.com/twmb/franz-go/pkg/kmsg v1.13.1
 	go.opentelemetry.io/contrib/bridges/prometheus v0.69.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel v1.44.0
@@ -245,7 +246,6 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tklauser/go-sysconf v0.4.0 // indirect
 	github.com/tklauser/numcpus v0.12.0 // indirect
-	github.com/twmb/franz-go/pkg/kmsg v1.13.1 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad // indirect

--- a/internal/block/processor.go
+++ b/internal/block/processor.go
@@ -99,6 +99,7 @@ func (p *Processor) Init(cfg interface{}) error {
 	subtreeWorkProducer, err := kafka.NewProducer(
 		p.kafkaCfg.Brokers,
 		p.kafkaCfg.SubtreeWorkTopic,
+		p.kafkaCfg.TopicRetention(),
 		p.Logger,
 	)
 	if err != nil {
@@ -110,6 +111,7 @@ func (p *Processor) Init(cfg interface{}) error {
 	callbackProducer, err := kafka.NewProducer(
 		p.kafkaCfg.Brokers,
 		p.kafkaCfg.CallbackTopic,
+		p.kafkaCfg.TopicRetention(),
 		p.Logger,
 	)
 	if err != nil {
@@ -123,6 +125,7 @@ func (p *Processor) Init(cfg interface{}) error {
 		[]string{p.kafkaCfg.BlockTopic},
 		p.handleMessage,
 		nil, // 'block' is low-rate and deliberately stays at 1 partition
+		p.kafkaCfg.TopicRetention(),
 		p.Logger,
 	)
 	if err != nil {

--- a/internal/block/subtree_worker.go
+++ b/internal/block/subtree_worker.go
@@ -130,6 +130,7 @@ func (s *SubtreeWorkerService) Init(_ interface{}) error {
 	callbackProducer, err := kafka.NewProducer(
 		s.kafkaCfg.Brokers,
 		s.kafkaCfg.CallbackTopic,
+		s.kafkaCfg.TopicRetention(),
 		s.Logger,
 	)
 	if err != nil {
@@ -140,6 +141,7 @@ func (s *SubtreeWorkerService) Init(_ interface{}) error {
 	retryProducer, err := kafka.NewProducer(
 		s.kafkaCfg.Brokers,
 		s.kafkaCfg.SubtreeWorkTopic,
+		s.kafkaCfg.TopicRetention(),
 		s.Logger,
 	)
 	if err != nil {
@@ -154,6 +156,7 @@ func (s *SubtreeWorkerService) Init(_ interface{}) error {
 	dlqProducer, err := kafka.NewProducer(
 		s.kafkaCfg.Brokers,
 		dlqTopic,
+		s.kafkaCfg.TopicRetention(),
 		s.Logger,
 	)
 	if err != nil {
@@ -167,6 +170,7 @@ func (s *SubtreeWorkerService) Init(_ interface{}) error {
 		[]string{s.kafkaCfg.SubtreeWorkTopic},
 		s.handleMessage,
 		s.kafkaCfg.TopicPartitions(),
+		s.kafkaCfg.TopicRetention(),
 		s.Logger,
 	)
 	if err != nil {

--- a/internal/callback/callback_integration_test.go
+++ b/internal/callback/callback_integration_test.go
@@ -107,7 +107,7 @@ func TestCallbackDelivery_SuccessfulCallback(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	// Now publish a CallbackTopicMessage to Kafka.
-	producer, err := kafka.NewProducer(brokers, stumpsTopic, slog.Default())
+	producer, err := kafka.NewProducer(brokers, stumpsTopic, nil, slog.Default())
 	if err != nil {
 		t.Skipf("Kafka not available; skipping: %v", err)
 	}
@@ -213,7 +213,7 @@ func TestCallbackDelivery_RetryOnFailure(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	// Now publish the CallbackTopicMessage.
-	producer, err := kafka.NewProducer(brokers, stumpsTopic, slog.Default())
+	producer, err := kafka.NewProducer(brokers, stumpsTopic, nil, slog.Default())
 	if err != nil {
 		t.Skipf("Kafka not available; skipping: %v", err)
 	}

--- a/internal/callback/delivery.go
+++ b/internal/callback/delivery.go
@@ -209,6 +209,7 @@ func (d *DeliveryService) Init(_ interface{}) error {
 	dlqProducer, err := kafka.NewProducer(
 		d.cfg.Kafka.Brokers,
 		d.cfg.Kafka.CallbackDLQTopic,
+		d.cfg.Kafka.TopicRetention(),
 		d.Logger,
 	)
 	if err != nil {
@@ -222,6 +223,7 @@ func (d *DeliveryService) Init(_ interface{}) error {
 	retryProducer, err := kafka.NewProducer(
 		d.cfg.Kafka.Brokers,
 		d.cfg.Kafka.CallbackTopic,
+		d.cfg.Kafka.TopicRetention(),
 		d.Logger,
 	)
 	if err != nil {
@@ -236,6 +238,7 @@ func (d *DeliveryService) Init(_ interface{}) error {
 		[]string{d.cfg.Kafka.CallbackTopic},
 		d.handleMessage,
 		nil, // 'callback' must stay at 1 partition until a cross-partition BLOCK_PROCESSED barrier exists
+		d.cfg.Kafka.TopicRetention(),
 		d.Logger,
 	)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -285,6 +285,17 @@ const (
 	defaultSubtreeWorkPartitions = 24
 )
 
+// Default retention.ms applied when THIS service creates a topic (see
+// TopicRetention). Work topics get 6h — comfortably above any realistic
+// processing backlog; DLQ topics get 7d so dead letters survive long enough
+// for a human to notice and act. Without an explicit value a fresh cluster's
+// broker default applies silently — on dev-ovh-1 that default was 15
+// MINUTES, short enough to expire parked work and dead letters unseen.
+const (
+	defaultTopicRetentionMs int64 = 21_600_000  // 6h
+	defaultDLQRetentionMs   int64 = 604_800_000 // 7d
+)
+
 type KafkaConfig struct {
 	Brokers             []string `yaml:"brokers"             mapstructure:"brokers"`
 	SubtreeTopic        string   `yaml:"subtreeTopic"        mapstructure:"subtreetopic"`
@@ -310,6 +321,15 @@ type KafkaConfig struct {
 	// cross-partition delivery barrier exists (see docs/callback-topic-partition-design.md).
 	SubtreePartitions     int `yaml:"subtreePartitions"     mapstructure:"subtreepartitions"`
 	SubtreeWorkPartitions int `yaml:"subtreeWorkPartitions" mapstructure:"subtreeworkpartitions"`
+
+	// TopicRetentionMs / DLQRetentionMs set the retention.ms config applied
+	// when this service CREATES a topic (work topics and DLQ topics
+	// respectively — see TopicRetention). Applied at create time only:
+	// existing topics are never altered, so GitOps-managed Topic CRDs remain
+	// authoritative wherever they exist. Non-positive values fall back to the
+	// built-in defaults (6h / 7d).
+	TopicRetentionMs int64 `yaml:"topicRetentionMs" mapstructure:"topicretentionms"`
+	DLQRetentionMs   int64 `yaml:"dlqRetentionMs"   mapstructure:"dlqretentionms"`
 }
 
 // TopicPartitions maps each topic name to the partition count it should be
@@ -331,6 +351,34 @@ func (k KafkaConfig) TopicPartitions() map[string]int32 {
 	}
 	if k.SubtreeWorkTopic != "" {
 		m[k.SubtreeWorkTopic] = int32(work)
+	}
+	return m
+}
+
+// TopicRetention maps every configured topic name to the retention.ms it
+// should be CREATED with (EnsureTopics never alters existing topics): work
+// topics get TopicRetentionMs, DLQ topics get DLQRetentionMs, non-positive
+// values fall back to the built-in defaults (6h / 7d). Empty topic names are
+// skipped.
+func (k KafkaConfig) TopicRetention() map[string]int64 {
+	topicMs := k.TopicRetentionMs
+	if topicMs <= 0 {
+		topicMs = defaultTopicRetentionMs
+	}
+	dlqMs := k.DLQRetentionMs
+	if dlqMs <= 0 {
+		dlqMs = defaultDLQRetentionMs
+	}
+	m := make(map[string]int64, 7)
+	for _, topic := range []string{k.SubtreeTopic, k.BlockTopic, k.CallbackTopic, k.SubtreeWorkTopic} {
+		if topic != "" {
+			m[topic] = topicMs
+		}
+	}
+	for _, topic := range []string{k.CallbackDLQTopic, k.SubtreeDLQTopic, k.SubtreeWorkDLQTopic} {
+		if topic != "" {
+			m[topic] = dlqMs
+		}
 	}
 	return m
 }
@@ -568,6 +616,8 @@ func registerDefaults(v *viper.Viper) {
 	v.SetDefault("kafka.consumergroup", "merkle-service")
 	v.SetDefault("kafka.subtreepartitions", defaultSubtreePartitions)
 	v.SetDefault("kafka.subtreeworkpartitions", defaultSubtreeWorkPartitions)
+	v.SetDefault("kafka.topicretentionms", defaultTopicRetentionMs)
+	v.SetDefault("kafka.dlqretentionms", defaultDLQRetentionMs)
 
 	// P2P
 	v.SetDefault("p2p.network", "main")
@@ -728,6 +778,8 @@ func bindEnvVars(v *viper.Viper) {
 		"kafka.subtreeworktopic":    "KAFKA_SUBTREE_WORK_TOPIC",
 		"kafka.subtreeworkdlqtopic": "KAFKA_SUBTREE_WORK_DLQ_TOPIC",
 		"kafka.consumergroup":       "KAFKA_CONSUMER_GROUP",
+		"kafka.topicretentionms":    "KAFKA_TOPIC_RETENTION_MS",
+		"kafka.dlqretentionms":      "KAFKA_DLQ_RETENTION_MS",
 
 		// P2P
 		"p2p.network":               "P2P_NETWORK",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -366,6 +366,13 @@ type SubtreeConfig struct {
 	// permanently-failing subtree (e.g. DataHub 404) stalled the partition
 	// forever because the consumer doesn't MarkMessage on handler error.
 	MaxAttempts int `yaml:"maxAttempts" mapstructure:"maxattempts"`
+	// RetryBackoffBaseMs is the base delay before a transient subtree failure
+	// is re-published for retry; it doubles per attempt and is capped at 30s.
+	// Without it the whole MaxAttempts budget burned in ~300ms on dev-ovh-1
+	// (blob-store ENOSPC), turning a 15-minute disk incident into 1,406
+	// permanent dead letters. Default 1000. 0 disables the backoff (unit
+	// tests; not recommended in production).
+	RetryBackoffBaseMs int `yaml:"retryBackoffBaseMs" mapstructure:"retrybackoffbasems"`
 	// SeenTxidLogMax caps how many matched txids are included (as logfields.TxIDs)
 	// on the Info log emitted for each SEEN_ON_NETWORK / SEEN_MULTIPLE_NODES
 	// batch published to a callback URL. 0 disables the txids array entirely
@@ -581,6 +588,10 @@ func registerDefaults(v *viper.Viper) {
 	// (initial + 2 retries) gives us recovery from transient blips without
 	// turning into a self-inflicted DoS.
 	v.SetDefault("subtree.maxattempts", 3)
+	// 1s base, doubling per attempt (cap 30s): 3 attempts span ~3s of real
+	// time instead of ~300ms, giving transient blob-store/DataHub conditions
+	// a chance to clear before the DLQ.
+	v.SetDefault("subtree.retrybackoffbasems", 1000)
 	v.SetDefault("subtree.seentxidlogmax", 1000)
 
 	// Block
@@ -731,13 +742,14 @@ func bindEnvVars(v *viper.Viper) {
 		"p2p.msgbus.enablemdns":     "P2P_ENABLE_MDNS",
 
 		// Subtree
-		"subtree.storagemode":    "SUBTREE_STORAGE_MODE",
-		"subtree.dahoffset":      "SUBTREE_DAH_OFFSET",
-		"subtree.stumpdahoffset": "SUBTREE_STUMP_DAH_OFFSET",
-		"subtree.cachemaxmb":     "SUBTREE_CACHE_MAX_MB",
-		"subtree.dedupcachesize": "SUBTREE_DEDUP_CACHE_SIZE",
-		"subtree.maxattempts":    "SUBTREE_MAX_ATTEMPTS",
-		"subtree.seentxidlogmax": "SUBTREE_SEEN_TXID_LOG_MAX",
+		"subtree.storagemode":        "SUBTREE_STORAGE_MODE",
+		"subtree.dahoffset":          "SUBTREE_DAH_OFFSET",
+		"subtree.stumpdahoffset":     "SUBTREE_STUMP_DAH_OFFSET",
+		"subtree.cachemaxmb":         "SUBTREE_CACHE_MAX_MB",
+		"subtree.dedupcachesize":     "SUBTREE_DEDUP_CACHE_SIZE",
+		"subtree.maxattempts":        "SUBTREE_MAX_ATTEMPTS",
+		"subtree.retrybackoffbasems": "SUBTREE_RETRY_BACKOFF_BASE_MS",
+		"subtree.seentxidlogmax":     "SUBTREE_SEEN_TXID_LOG_MAX",
 
 		// Block
 		"block.workerpoolsize":      "BLOCK_WORKER_POOL_SIZE",

--- a/internal/config/topic_retention_test.go
+++ b/internal/config/topic_retention_test.go
@@ -1,0 +1,97 @@
+package config
+
+import "testing"
+
+func TestKafkaConfig_TopicRetention(t *testing.T) {
+	k := KafkaConfig{
+		SubtreeTopic:        "subtree",
+		BlockTopic:          "block",
+		CallbackTopic:       "callback",
+		CallbackDLQTopic:    "callback-dlq",
+		SubtreeDLQTopic:     "subtree-dlq",
+		SubtreeWorkTopic:    "subtree-work",
+		SubtreeWorkDLQTopic: "subtree-work-dlq",
+	}
+
+	t.Run("defaults: 6h for work topics, 7d for DLQs", func(t *testing.T) {
+		m := k.TopicRetention()
+		for _, topic := range []string{"subtree", "block", "callback", "subtree-work"} {
+			if got := m[topic]; got != defaultTopicRetentionMs {
+				t.Errorf("%s = %d, want %d", topic, got, defaultTopicRetentionMs)
+			}
+		}
+		for _, topic := range []string{"callback-dlq", "subtree-dlq", "subtree-work-dlq"} {
+			if got := m[topic]; got != defaultDLQRetentionMs {
+				t.Errorf("%s = %d, want %d", topic, got, defaultDLQRetentionMs)
+			}
+		}
+	})
+
+	t.Run("explicit values win", func(t *testing.T) {
+		k := k
+		k.TopicRetentionMs = 3_600_000
+		k.DLQRetentionMs = 86_400_000
+		m := k.TopicRetention()
+		if m["subtree-work"] != 3_600_000 {
+			t.Errorf("subtree-work = %d, want 3600000", m["subtree-work"])
+		}
+		if m["subtree-dlq"] != 86_400_000 {
+			t.Errorf("subtree-dlq = %d, want 86400000", m["subtree-dlq"])
+		}
+	})
+
+	t.Run("non-positive falls back to defaults", func(t *testing.T) {
+		k := k
+		k.TopicRetentionMs = 0
+		k.DLQRetentionMs = -1
+		m := k.TopicRetention()
+		if m["subtree"] != defaultTopicRetentionMs || m["subtree-dlq"] != defaultDLQRetentionMs {
+			t.Errorf("non-positive should fall back to defaults: %+v", m)
+		}
+	})
+
+	t.Run("empty topic names are skipped", func(t *testing.T) {
+		m := KafkaConfig{SubtreeTopic: "subtree"}.TopicRetention()
+		if len(m) != 1 {
+			t.Errorf("expected only the configured topic in the map, got %+v", m)
+		}
+		if _, ok := m[""]; ok {
+			t.Error("empty topic name must not appear in the retention map")
+		}
+	})
+}
+
+// TestLoad_TopicRetentionDefaults verifies the viper defaults for the new
+// keys: 6h for work topics, 7d for DLQs — so a fresh cluster's aggressive
+// broker default (dev-ovh-1: 15 minutes) can't silently apply to topics this
+// service creates.
+func TestLoad_TopicRetentionDefaults(t *testing.T) {
+	t.Setenv("CONFIG_FILE", "/nonexistent/config.yaml")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Kafka.TopicRetentionMs != 21_600_000 {
+		t.Errorf("kafka.topicRetentionMs default = %d, want 21600000 (6h)", cfg.Kafka.TopicRetentionMs)
+	}
+	if cfg.Kafka.DLQRetentionMs != 604_800_000 {
+		t.Errorf("kafka.dlqRetentionMs default = %d, want 604800000 (7d)", cfg.Kafka.DLQRetentionMs)
+	}
+}
+
+// TestLoad_TopicRetentionEnvOverride verifies the env var plumbing.
+func TestLoad_TopicRetentionEnvOverride(t *testing.T) {
+	t.Setenv("CONFIG_FILE", "/nonexistent/config.yaml")
+	t.Setenv("KAFKA_TOPIC_RETENTION_MS", "3600000")
+	t.Setenv("KAFKA_DLQ_RETENTION_MS", "86400000")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Kafka.TopicRetentionMs != 3_600_000 {
+		t.Errorf("KAFKA_TOPIC_RETENTION_MS override = %d, want 3600000", cfg.Kafka.TopicRetentionMs)
+	}
+	if cfg.Kafka.DLQRetentionMs != 86_400_000 {
+		t.Errorf("KAFKA_DLQ_RETENTION_MS override = %d, want 86400000", cfg.Kafka.DLQRetentionMs)
+	}
+}

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -156,7 +156,7 @@ func newAerospikeClient(t *testing.T, namespace string) *store.AerospikeClient {
 // newCallbackProducer creates a Kafka producer for the given callback topic.
 func newCallbackProducer(t *testing.T, topic string) *kafka.Producer {
 	t.Helper()
-	producer, err := kafka.NewProducer([]string{kafkaBroker}, topic, testLogger())
+	producer, err := kafka.NewProducer([]string{kafkaBroker}, topic, nil, testLogger())
 	if err != nil {
 		t.Skipf("Kafka not available: %v", err)
 	}

--- a/internal/kafka/admin.go
+++ b/internal/kafka/admin.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kerr"
@@ -33,6 +34,15 @@ const (
 // safe even if a producer lazily auto-created the topic at 1 partition first: the
 // next consumer start grows it to the configured width.
 //
+// retentionMs maps a topic name to the retention.ms it should be CREATED
+// with (source: KafkaConfig.TopicRetention). Applied at create time ONLY —
+// existing topics are never altered, so GitOps-managed Topic CRDs stay
+// authoritative wherever they exist. Topics absent from the map (or with a
+// non-positive value) are created with nil configs, i.e. the broker default —
+// which is exactly what bit dev-ovh-1: a fresh cluster's default retention of
+// 15 minutes silently applied to the work queues and DLQs this service
+// created, expiring parked messages and dead letters unseen.
+//
 // It is idempotent: an already-existing topic is success (kerr.TopicAlreadyExists
 // checked on both the call error and the per-topic response, per teranode #633 —
 // not a string match), and an already-wide-enough topic is success
@@ -46,7 +56,7 @@ const (
 // unconsumed (the previous sarama client created topics eagerly on first
 // metadata request). Explicit creation also works on brokers with
 // auto.create.topics.enable=false.
-func EnsureTopics(ctx context.Context, brokers, topics []string, partitions map[string]int32, logger *slog.Logger) error {
+func EnsureTopics(ctx context.Context, brokers, topics []string, partitions map[string]int32, retentionMs map[string]int64, logger *slog.Logger) error {
 	uniq := dedupeNonEmpty(topics)
 	if len(uniq) == 0 {
 		return nil
@@ -65,7 +75,18 @@ func EnsureTopics(ctx context.Context, brokers, topics []string, partitions map[
 			want = p
 		}
 
-		resp, cErr := admin.CreateTopic(ctx, want, defaultTopicReplication, nil, topic)
+		// Create-time-only topic configs; never sent to an existing topic
+		// (CreateTopic on one fails with TopicAlreadyExists below, and no
+		// AlterConfigs is ever issued).
+		var configs map[string]*string
+		var retention int64
+		if ms, ok := retentionMs[topic]; ok && ms > 0 {
+			retention = ms
+			v := strconv.FormatInt(ms, 10)
+			configs = map[string]*string{"retention.ms": &v}
+		}
+
+		resp, cErr := admin.CreateTopic(ctx, want, defaultTopicReplication, configs, topic)
 		existed := errors.Is(cErr, kerr.TopicAlreadyExists) || errors.Is(resp.Err, kerr.TopicAlreadyExists)
 		if cErr != nil && !existed {
 			return fmt.Errorf("ensure topic %s: %w", topic, cErr)
@@ -75,7 +96,7 @@ func EnsureTopics(ctx context.Context, brokers, topics []string, partitions map[
 		}
 		if !existed {
 			if logger != nil {
-				logger.Debug("created kafka topic", "topic", topic, "partitions", want)
+				logger.Debug("created kafka topic", "topic", topic, "partitions", want, "retentionMs", retention)
 			}
 			continue
 		}

--- a/internal/kafka/admin_test.go
+++ b/internal/kafka/admin_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kfake"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 // partitionCount returns how many partitions the topic currently has on the
@@ -28,6 +29,34 @@ func partitionCount(t *testing.T, brokers []string, topic string) int {
 	return len(td[topic].Partitions)
 }
 
+// topicRetentionMs returns the retention.ms EXPLICITLY set on the topic
+// (dynamic topic config, i.e. what CreateTopic configs / AlterConfigs wrote),
+// or nil when the topic only inherits the broker default.
+func topicRetentionMs(t *testing.T, brokers []string, topic string) *string {
+	t.Helper()
+	cl, err := kgo.NewClient(kgo.SeedBrokers(brokers...))
+	if err != nil {
+		t.Fatalf("admin client: %v", err)
+	}
+	defer cl.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	rcs, err := kadm.NewClient(cl).DescribeTopicConfigs(ctx, topic)
+	if err != nil {
+		t.Fatalf("describe topic configs: %v", err)
+	}
+	rc, err := rcs.On(topic, nil)
+	if err != nil {
+		t.Fatalf("describe topic configs for %s: %v", topic, err)
+	}
+	for _, c := range rc.Configs {
+		if c.Key == "retention.ms" && c.Source == kmsg.ConfigSourceDynamicTopicConfig {
+			return c.Value
+		}
+	}
+	return nil
+}
+
 // TestEnsureTopics_CreatesAtConfiguredWidth checks a fresh topic is created with
 // the partition count from the map, and that a topic absent from the map falls
 // back to the single-partition default.
@@ -41,7 +70,7 @@ func TestEnsureTopics_CreatesAtConfiguredWidth(t *testing.T) {
 
 	ctx := context.Background()
 	wide, narrow := "subtree-work", "block"
-	if err := EnsureTopics(ctx, brokers, []string{wide, narrow}, map[string]int32{wide: 8}, nil); err != nil {
+	if err := EnsureTopics(ctx, brokers, []string{wide, narrow}, map[string]int32{wide: 8}, nil, nil); err != nil {
 		t.Fatalf("EnsureTopics: %v", err)
 	}
 
@@ -67,7 +96,7 @@ func TestEnsureTopics_GrowsExistingTopic(t *testing.T) {
 	ctx := context.Background()
 
 	// Grow 2 -> 6.
-	if err := EnsureTopics(ctx, brokers, []string{topic}, map[string]int32{topic: 6}, nil); err != nil {
+	if err := EnsureTopics(ctx, brokers, []string{topic}, map[string]int32{topic: 6}, nil, nil); err != nil {
 		t.Fatalf("grow: %v", err)
 	}
 	if got := partitionCount(t, brokers, topic); got != 6 {
@@ -75,7 +104,7 @@ func TestEnsureTopics_GrowsExistingTopic(t *testing.T) {
 	}
 
 	// Idempotent: same target again is a no-op, not an error.
-	if err := EnsureTopics(ctx, brokers, []string{topic}, map[string]int32{topic: 6}, nil); err != nil {
+	if err := EnsureTopics(ctx, brokers, []string{topic}, map[string]int32{topic: 6}, nil, nil); err != nil {
 		t.Fatalf("re-ensure at same width: %v", err)
 	}
 	if got := partitionCount(t, brokers, topic); got != 6 {
@@ -84,10 +113,73 @@ func TestEnsureTopics_GrowsExistingTopic(t *testing.T) {
 
 	// Never shrink: a smaller target is ignored (InvalidPartitions treated as
 	// "already wide enough"), and must not error.
-	if err := EnsureTopics(ctx, brokers, []string{topic}, map[string]int32{topic: 3}, nil); err != nil {
+	if err := EnsureTopics(ctx, brokers, []string{topic}, map[string]int32{topic: 3}, nil, nil); err != nil {
 		t.Fatalf("smaller target should be a benign no-op, got: %v", err)
 	}
 	if got := partitionCount(t, brokers, topic); got != 6 {
 		t.Fatalf("after smaller target: %d partitions, want still 6 (never shrink)", got)
+	}
+}
+
+// TestEnsureTopics_SetsRetentionAtCreate is the regression test for the
+// dev-ovh-1 retention gap: topics were created with nil configs, so a fresh
+// cluster's broker default retention applied silently — on that cluster the
+// default was 15 MINUTES, which would expire queued work and dead letters
+// out from under the service. Topics created by EnsureTopics must carry an
+// explicit retention.ms from the retention map.
+func TestEnsureTopics_SetsRetentionAtCreate(t *testing.T) {
+	cluster, err := kfake.NewCluster(kfake.NumBrokers(1))
+	if err != nil {
+		t.Fatalf("kfake: %v", err)
+	}
+	defer cluster.Close()
+	brokers := cluster.ListenAddrs()
+
+	ctx := context.Background()
+	work, dlq, unmapped := "subtree-work", "subtree-dlq", "block"
+	retention := map[string]int64{work: 21_600_000, dlq: 604_800_000}
+	if err := EnsureTopics(ctx, brokers, []string{work, dlq, unmapped}, nil, retention, nil); err != nil {
+		t.Fatalf("EnsureTopics: %v", err)
+	}
+
+	if got := topicRetentionMs(t, brokers, work); got == nil || *got != "21600000" {
+		t.Errorf("%s retention.ms = %v, want 21600000", work, got)
+	}
+	if got := topicRetentionMs(t, brokers, dlq); got == nil || *got != "604800000" {
+		t.Errorf("%s retention.ms = %v, want 604800000", dlq, got)
+	}
+	// A topic absent from the retention map keeps the pre-fix behavior:
+	// created with no explicit retention config.
+	if got := topicRetentionMs(t, brokers, unmapped); got != nil {
+		t.Errorf("%s (absent from retention map) retention.ms = %q, want unset", unmapped, *got)
+	}
+}
+
+// TestEnsureTopics_NeverAltersExistingTopicRetention pins the GitOps
+// contract: retention is applied only at CREATE time. An already-existing
+// topic (owned by Topic CRDs in the scale clusters) must never have its
+// configs altered by a service startup.
+func TestEnsureTopics_NeverAltersExistingTopicRetention(t *testing.T) {
+	const topic = "subtree-work"
+	cluster, err := kfake.NewCluster(kfake.NumBrokers(1), kfake.SeedTopics(2, topic))
+	if err != nil {
+		t.Fatalf("kfake: %v", err)
+	}
+	defer cluster.Close()
+	brokers := cluster.ListenAddrs()
+
+	before := topicRetentionMs(t, brokers, topic)
+
+	ctx := context.Background()
+	if err := EnsureTopics(ctx, brokers, []string{topic}, map[string]int32{topic: 6}, map[string]int64{topic: 21_600_000}, nil); err != nil {
+		t.Fatalf("EnsureTopics: %v", err)
+	}
+
+	after := topicRetentionMs(t, brokers, topic)
+	switch {
+	case before == nil && after != nil:
+		t.Errorf("retention.ms was set on an existing topic: %q (must never alter existing topics)", *after)
+	case before != nil && (after == nil || *after != *before):
+		t.Errorf("retention.ms changed on an existing topic: before %v, after %v", *before, after)
 	}
 }

--- a/internal/kafka/commit_progress_test.go
+++ b/internal/kafka/commit_progress_test.go
@@ -52,7 +52,7 @@ func newCommitTestConsumer(handler MessageHandler, cc *commitCapture) *Consumer 
 }
 
 // recsRange builds n consecutive records starting at offset 0 on topic
-// "test" partition 0 (see rec in consumer_test.go).
+// testTopic partition 0 (see rec in consumer_test.go).
 func recsRange(n int) []*kgo.Record {
 	out := make([]*kgo.Record, n)
 	for i := range out {
@@ -74,7 +74,7 @@ func TestPartitionWorker_CommitsProgressMidBatch(t *testing.T) {
 	c := newCommitTestConsumer(handler, cc)
 
 	const total = 2*commitEvery + 20 // three chunks: full, full, partial
-	w := newPartitionWorker(c, topicPartition{"test", 0}, context.Background())
+	w := newPartitionWorker(c, topicPartition{testTopic, 0}, context.Background())
 	w.process(recsRange(total))
 
 	batches := cc.get()
@@ -116,7 +116,7 @@ func TestPartitionWorker_MidBatchFailureCommitsPrefixOnly(t *testing.T) {
 	cc := &commitCapture{}
 	c := newCommitTestConsumer(handler, cc)
 
-	tp := topicPartition{"test", 0}
+	tp := topicPartition{testTopic, 0}
 	w := newPartitionWorker(c, tp, context.Background())
 	w.process(recsRange(3 * commitEvery))
 
@@ -152,7 +152,7 @@ func TestPartitionWorker_MidBatchFailureCommitsPrefixOnly(t *testing.T) {
 // handler latencies). Introspected via kgo's OptValue since franz options are
 // otherwise opaque.
 func TestConsumerOpts_BoundsFetchSizes(t *testing.T) {
-	client, err := kgo.NewClient(consumerOpts([]string{"localhost:9092"}, "test-group", []string{"test"})...)
+	client, err := kgo.NewClient(consumerOpts([]string{"localhost:9092"}, "test-group", []string{testTopic})...)
 	if err != nil {
 		t.Fatalf("building client: %v", err)
 	}
@@ -184,7 +184,7 @@ func TestPartitionWorker_StopSkipsRemainingChunks(t *testing.T) {
 		return nil
 	}
 	c = newCommitTestConsumer(handler, cc)
-	w = newPartitionWorker(c, topicPartition{"test", 0}, context.Background())
+	w = newPartitionWorker(c, topicPartition{testTopic, 0}, context.Background())
 
 	w.process(recsRange(3 * commitEvery))
 

--- a/internal/kafka/commit_progress_test.go
+++ b/internal/kafka/commit_progress_test.go
@@ -1,0 +1,198 @@
+package kafka
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// commitCapture records every commitRecords call a partition worker makes so
+// tests can assert on commit cadence, ordering, and contents without a broker.
+type commitCapture struct {
+	mu      sync.Mutex
+	batches [][]*kgo.Record
+	err     error // returned from every capture call when non-nil
+}
+
+func (cc *commitCapture) commit(_ context.Context, recs ...*kgo.Record) error {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	batch := make([]*kgo.Record, len(recs))
+	copy(batch, recs)
+	cc.batches = append(cc.batches, batch)
+	return cc.err
+}
+
+func (cc *commitCapture) get() [][]*kgo.Record {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	out := make([][]*kgo.Record, len(cc.batches))
+	copy(out, cc.batches)
+	return out
+}
+
+// newCommitTestConsumer builds a Consumer whose commit path is captured by cc
+// instead of hitting a broker. Only the fields the partition-worker path
+// touches are populated — the same struct-literal pattern the processBatch
+// unit tests use.
+func newCommitTestConsumer(handler MessageHandler, cc *commitCapture) *Consumer {
+	return &Consumer{
+		groupID:       "commit-progress-group",
+		handler:       handler,
+		logger:        discardLogger(),
+		workers:       make(map[topicPartition]*partitionWorker),
+		rewindReqs:    make(map[topicPartition]*kgo.Record),
+		resumeAt:      make(map[topicPartition]time.Time),
+		commitRecords: cc.commit,
+	}
+}
+
+// recsRange builds n consecutive records starting at offset 0 on topic
+// "test" partition 0 (see rec in consumer_test.go).
+func recsRange(n int) []*kgo.Record {
+	out := make([]*kgo.Record, n)
+	for i := range out {
+		out[i] = rec(int64(i))
+	}
+	return out
+}
+
+// TestPartitionWorker_CommitsProgressMidBatch is the regression test for the
+// dev-ovh-1 commit freeze (Jul 2026): with commits issued only after an entire
+// fetched batch completed, a 50k-message backlog with 1-2s handlers meant the
+// committed offset stayed frozen for the whole (hours-long) batch and every
+// pod restart reprocessed from scratch. The worker must instead commit the
+// successful prefix every commitEvery records, so progress is durable while a
+// long batch is still in flight.
+func TestPartitionWorker_CommitsProgressMidBatch(t *testing.T) {
+	handler := func(_ context.Context, _ *Message) error { return nil }
+	cc := &commitCapture{}
+	c := newCommitTestConsumer(handler, cc)
+
+	const total = 2*commitEvery + 20 // three chunks: full, full, partial
+	w := newPartitionWorker(c, topicPartition{"test", 0}, context.Background())
+	w.process(recsRange(total))
+
+	batches := cc.get()
+	if len(batches) != 3 {
+		t.Fatalf("expected 3 incremental commits (%d/%d/20 records), got %d", commitEvery, commitEvery, len(batches))
+	}
+	wantSizes := []int{commitEvery, commitEvery, 20}
+	next := int64(0)
+	for i, b := range batches {
+		if len(b) != wantSizes[i] {
+			t.Errorf("commit %d: %d records, want %d", i, len(b), wantSizes[i])
+		}
+		for _, r := range b {
+			if r.Offset != next {
+				t.Fatalf("commit %d: offset %d out of order, want %d", i, r.Offset, next)
+			}
+			next++
+		}
+	}
+	if next != total {
+		t.Errorf("committed %d records total, want %d", next, total)
+	}
+}
+
+// TestPartitionWorker_MidBatchFailureCommitsPrefixOnly pins F-030 semantics
+// under incremental commits: a failure inside a chunk commits only that
+// chunk's successful prefix, records the failed record as the rewind point,
+// and processes nothing after it.
+func TestPartitionWorker_MidBatchFailureCommitsPrefixOnly(t *testing.T) {
+	const failAt = commitEvery + 10 // second chunk, 10 records in
+	var calls int
+	handler := func(_ context.Context, m *Message) error {
+		calls++
+		if m.Offset == failAt {
+			return errors.New("boom")
+		}
+		return nil
+	}
+	cc := &commitCapture{}
+	c := newCommitTestConsumer(handler, cc)
+
+	tp := topicPartition{"test", 0}
+	w := newPartitionWorker(c, tp, context.Background())
+	w.process(recsRange(3 * commitEvery))
+
+	batches := cc.get()
+	if len(batches) != 2 {
+		t.Fatalf("expected 2 commits (first chunk + prefix of second), got %d", len(batches))
+	}
+	if got := len(batches[0]); got != commitEvery {
+		t.Errorf("first commit: %d records, want %d", got, commitEvery)
+	}
+	if got := len(batches[1]); got != 10 {
+		t.Errorf("second commit: %d records, want 10 (prefix before the failure)", got)
+	}
+	if last := batches[1][len(batches[1])-1].Offset; last != failAt-1 {
+		t.Errorf("last committed offset = %d, want %d (never past the failure)", last, failAt-1)
+	}
+	if calls != failAt+1 {
+		t.Errorf("handler invoked %d times, want %d (nothing after the failed record)", calls, failAt+1)
+	}
+
+	c.rewindMu.Lock()
+	req := c.rewindReqs[tp]
+	c.rewindMu.Unlock()
+	if req == nil || req.Offset != failAt {
+		t.Fatalf("rewind request = %v, want offset %d", req, failAt)
+	}
+}
+
+// TestConsumerOpts_BoundsFetchSizes verifies the consumer bounds how much
+// data one poll may return (per partition and total) instead of inheriting
+// kgo's 1 MiB / 50 MiB defaults — under a deep backlog those defaults hand a
+// worker thousands of records per batch (hours of work at incident-observed
+// handler latencies). Introspected via kgo's OptValue since franz options are
+// otherwise opaque.
+func TestConsumerOpts_BoundsFetchSizes(t *testing.T) {
+	client, err := kgo.NewClient(consumerOpts([]string{"localhost:9092"}, "test-group", []string{"test"})...)
+	if err != nil {
+		t.Fatalf("building client: %v", err)
+	}
+	defer client.Close()
+
+	if got := client.OptValue(kgo.FetchMaxPartitionBytes).(int32); got != fetchMaxPartitionBytes {
+		t.Errorf("FetchMaxPartitionBytes = %d, want %d", got, fetchMaxPartitionBytes)
+	}
+	if got := client.OptValue(kgo.FetchMaxBytes).(int32); got != fetchMaxBytes {
+		t.Errorf("FetchMaxBytes = %d, want %d", got, fetchMaxBytes)
+	}
+}
+
+// TestPartitionWorker_StopSkipsRemainingChunks verifies that a worker told to
+// stop (revoke, lost, shutdown) finishes and commits its current chunk but
+// does not start the next one — the uncommitted tail is redelivered to the
+// partition's next owner instead of holding the rebalance for the whole
+// fetched batch.
+func TestPartitionWorker_StopSkipsRemainingChunks(t *testing.T) {
+	cc := &commitCapture{}
+	var c *Consumer
+	var w *partitionWorker
+	var calls int
+	handler := func(_ context.Context, m *Message) error {
+		calls++
+		if m.Offset == 10 {
+			w.signalStop()
+		}
+		return nil
+	}
+	c = newCommitTestConsumer(handler, cc)
+	w = newPartitionWorker(c, topicPartition{"test", 0}, context.Background())
+
+	w.process(recsRange(3 * commitEvery))
+
+	if calls != commitEvery {
+		t.Errorf("handler invoked %d times, want %d (current chunk finishes, later chunks don't start)", calls, commitEvery)
+	}
+	batches := cc.get()
+	if len(batches) != 1 || len(batches[0]) != commitEvery {
+		t.Fatalf("expected exactly the current chunk committed, got %d commits: %v", len(batches), batches)
+	}
+}

--- a/internal/kafka/consumer.go
+++ b/internal/kafka/consumer.go
@@ -221,7 +221,12 @@ type Consumer struct {
 // should be created with (and grown to) by the startup EnsureTopics call; topics
 // absent from the map default to 1. Pass nil to create/keep every subscribed
 // topic at 1 partition.
-func NewConsumer(brokers []string, groupID string, topics []string, handler MessageHandler, partitions map[string]int32, logger *slog.Logger) (*Consumer, error) {
+// retentionMs optionally maps a subscribed topic name to the retention.ms it
+// should be CREATED with (source: KafkaConfig.TopicRetention); existing
+// topics are never altered. Pass nil to create topics with broker-default
+// retention (unit tests only — see EnsureTopics for why production callers
+// must pass the config-derived map).
+func NewConsumer(brokers []string, groupID string, topics []string, handler MessageHandler, partitions map[string]int32, retentionMs map[string]int64, logger *slog.Logger) (*Consumer, error) {
 	// A nil logger is replaced with slog.Default(): Start, the poll loop, and
 	// the partition workers log unconditionally, so accepting nil here without
 	// defaulting would panic at the first consumed message.
@@ -248,7 +253,7 @@ func NewConsumer(brokers []string, groupID string, topics []string, handler Mess
 	// still works via metadata refresh + producer-side auto-creation, just less
 	// promptly (and at the default partition count until a later start grows it).
 	ensureCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	if eErr := EnsureTopics(ensureCtx, brokers, topics, partitions, logger); eErr != nil {
+	if eErr := EnsureTopics(ensureCtx, brokers, topics, partitions, retentionMs, logger); eErr != nil {
 		logger.Warn("could not pre-create consumer topics; relying on auto-create",
 			"groupID", groupID, "topics", topics, "error", eErr)
 	}

--- a/internal/kafka/consumer.go
+++ b/internal/kafka/consumer.go
@@ -40,6 +40,34 @@ const handlerErrorBackoff = 500 * time.Millisecond
 // bounded per-partition message channel that back-pressured the fetcher.
 const workerChannelDepth = 5
 
+// commitEvery is how many records a partition worker handles before it
+// commits the successful prefix of its in-flight batch. Commits used to
+// happen only after an ENTIRE fetched batch completed; under the dev-ovh-1
+// backlog (50k messages, 1-2s per record on DataHub fetches) a single batch
+// took hours, the committed offset stayed frozen for 40+ minutes while
+// workers demonstrably processed work, and every pod restart reprocessed the
+// whole batch from scratch. Committing every commitEvery records bounds the
+// redelivery window to at most commitEvery records per partition without
+// measurably increasing broker commit load (one OffsetCommit per ~50 handler
+// calls). Prefix-commit semantics (F-030) are unchanged: a chunk's commit
+// still only covers records whose handler succeeded, in order.
+const commitEvery = 50
+
+// fetchMaxPartitionBytes / fetchMaxBytes bound how much data one poll may
+// return per partition and in total. kgo's defaults (1 MiB per partition,
+// 50 MiB total) let a deep backlog of small subtree announcements (~250 B
+// each) hand a worker thousands of records in a single batch — hours of work
+// at 1-2s per record. Bounding the fetch keeps dispatched batches to at most
+// a few hundred records so rewinds discard less and buffered memory stays at
+// worst workerChannelDepth x fetchMaxPartitionBytes per partition. A single
+// record/batch larger than the partition cap is still returned whole (kgo
+// guarantees progress), so large callback-topic records cannot wedge a
+// partition.
+const (
+	fetchMaxPartitionBytes int32 = 256 << 10 // 256 KiB
+	fetchMaxBytes          int32 = 8 << 20   // 8 MiB
+)
+
 // pollTick bounds how long a single PollFetches call may block waiting for
 // records. The poll loop must keep turning even when nothing is fetchable —
 // every partition paused mid-rewind, or simply no traffic — because rewind
@@ -79,6 +107,10 @@ func consumerOpts(brokers []string, groupID string, topics []string) []kgo.Opt {
 		kgo.HeartbeatInterval(3 * time.Second),
 		kgo.RebalanceTimeout(60 * time.Second),
 		kgo.FetchMaxWait(100 * time.Millisecond),
+		// Bound per-poll fetch sizes so a deep backlog cannot hand a worker an
+		// hours-long batch (see fetchMaxPartitionBytes).
+		kgo.FetchMaxPartitionBytes(fetchMaxPartitionBytes),
+		kgo.FetchMaxBytes(fetchMaxBytes),
 		// Sarama parity: sarama's default config sets
 		// Metadata.AllowAutoTopicCreation=true, so consumers of a
 		// not-yet-existing topic triggered broker-side auto-creation and
@@ -108,6 +140,11 @@ type Consumer struct {
 	topics  []string
 	handler MessageHandler
 	logger  *slog.Logger
+
+	// commitRecords is the offset-commit seam: kgo.Client.CommitRecords in
+	// production, a capture in unit tests (same indirection pattern as
+	// exitFunc). Partition workers call it for every committed chunk.
+	commitRecords func(ctx context.Context, recs ...*kgo.Record) error
 
 	readyOnce sync.Once
 	ready     chan struct{}
@@ -212,6 +249,7 @@ func NewConsumer(brokers []string, groupID string, topics []string, handler Mess
 		return nil, fmt.Errorf("failed to create consumer group %s: %w", groupID, err)
 	}
 	c.client = client
+	c.commitRecords = client.CommitRecords
 	return c, nil
 }
 
@@ -581,10 +619,19 @@ func (w *partitionWorker) run() {
 	}
 }
 
-// process runs the handler over one in-order batch, commits the successful
-// prefix, and rewinds the partition on the first failure (F-030: a failed
-// record and everything after it in the partition are redelivered; committed
-// offsets never advance past a failure).
+// process runs the handler over one in-order batch in chunks of commitEvery
+// records, committing each chunk's successful prefix as it completes, and
+// rewinds the partition on the first failure (F-030: a failed record and
+// everything after it in the partition are redelivered; committed offsets
+// never advance past a failure).
+//
+// Chunked commits are the fix for the dev-ovh-1 commit freeze (see
+// commitEvery): progress becomes durable DURING a long batch, not only after
+// it, so a restart or rebalance mid-batch redelivers at most the un-committed
+// tail instead of the whole batch. Between chunks the worker also checks for
+// a stop signal (revoke/lost/shutdown) and abandons the remaining chunks —
+// their records are uncommitted and are redelivered to the partition's next
+// owner.
 func (w *partitionWorker) process(recs []*kgo.Record) {
 	if len(recs) == 0 {
 		return
@@ -596,22 +643,55 @@ func (w *partitionWorker) process(recs []*kgo.Record) {
 		w.discardUntil = -1
 	}
 
-	committable, failed := processBatch(w.ctx, recs, w.c.handler, w.c.handleMetrics, w.c.logger, w.c.groupID)
+	for start := 0; start < len(recs); start += commitEvery {
+		end := start + commitEvery
+		if end > len(recs) {
+			end = len(recs)
+		}
 
-	if len(committable) > 0 {
-		if err := w.c.client.CommitRecords(w.ctx, committable...); err != nil {
-			// Commit failure leaves offsets uncommitted; on the next
-			// rebalance/restart the group resumes from the last committed
-			// offset, so already-handled records are simply redelivered
-			// (at-least-once; handlers are idempotent).
-			if !errors.Is(err, context.Canceled) {
-				w.c.logger.Error("offset commit failed",
-					"group", w.c.groupID, "topic", w.tp.topic, "partition", w.tp.partition, "error", err)
-			}
+		committable, failed := processBatch(w.ctx, recs[start:end], w.c.handler, w.c.handleMetrics, w.c.logger, w.c.groupID)
+
+		if len(committable) > 0 {
+			w.commit(committable)
+		}
+		if failed != nil {
+			w.rewind(failed)
+			return // later chunks are redelivered after the rewind
+		}
+
+		// Stop between chunks when the worker is quitting: the uncommitted
+		// tail is redelivered, and the revoke/shutdown that signaled us is
+		// not held for the rest of a potentially huge batch.
+		select {
+		case <-w.quit:
+			return
+		case <-w.ctx.Done():
+			return
+		default:
 		}
 	}
-	if failed != nil {
-		w.rewind(failed)
+}
+
+// commit commits one in-order chunk of successfully-handled records. A commit
+// failure leaves the offsets uncommitted; on the next rebalance/restart the
+// group resumes from the last committed offset, so already-handled records
+// are simply redelivered (at-least-once; handlers are idempotent). That makes
+// a failed commit WARN-worthy, not fatal — but it MUST be visible: on
+// dev-ovh-1, members fenced during slow processing kept working partitions
+// they no longer owned and their rejected commits were the only signal.
+func (w *partitionWorker) commit(recs []*kgo.Record) {
+	if err := w.c.commitRecords(w.ctx, recs...); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return // shutdown/lost-partition teardown, not a broker rejection
+		}
+		w.c.logger.Warn("offset commit failed; records will be redelivered",
+			"group", w.c.groupID,
+			"topic", w.tp.topic,
+			"partition", w.tp.partition,
+			"firstOffset", recs[0].Offset,
+			"lastOffset", recs[len(recs)-1].Offset,
+			"error", err,
+		)
 	}
 }
 

--- a/internal/kafka/consumer.go
+++ b/internal/kafka/consumer.go
@@ -68,6 +68,25 @@ const (
 	fetchMaxBytes          int32 = 8 << 20   // 8 MiB
 )
 
+// Group-liveness timeouts. The values must satisfy kgo's (and the broker's)
+// constraint sessionTimeout >= 3x heartbeatInterval.
+//
+// The original sarama-parity values — SessionTimeout 10s, RebalanceTimeout
+// 60s — fenced healthy members under load on dev-ovh-1: slow handlers (1-2s
+// per record, DataHub fetches) filled the depth-5 worker channels, the poll
+// loop blocked dispatching, rebalances couldn't be serviced within the 60s
+// rebalance window, and the coordinator fenced members one by one until the
+// 24-partition group had collapsed 5 -> 1 with every pod still Running.
+// Heartbeats stay at 3s (background goroutine, cheap), so a genuinely dead
+// pod is still detected in sessionTimeout; the wider rebalanceTimeout only
+// extends how long a LIVE member may take to finish its in-flight chunk and
+// rejoin during a rebalance.
+const (
+	sessionTimeout    = 30 * time.Second
+	heartbeatInterval = 3 * time.Second
+	rebalanceTimeout  = 5 * time.Minute
+)
+
 // pollTick bounds how long a single PollFetches call may block waiting for
 // records. The poll loop must keep turning even when nothing is fetchable —
 // every partition paused mid-rewind, or simply no traffic — because rewind
@@ -102,10 +121,12 @@ func consumerOpts(brokers []string, groupID string, topics []string) []kgo.Opt {
 		// commit each successfully-handled record explicitly (see
 		// partitionWorker.process).
 		kgo.DisableAutoCommit(),
-		// Explicit timeout defaults sarama provided for free (teranode #633).
-		kgo.SessionTimeout(10 * time.Second),
-		kgo.HeartbeatInterval(3 * time.Second),
-		kgo.RebalanceTimeout(60 * time.Second),
+		// Explicit timeouts sarama provided defaults for (teranode #633),
+		// widened to survive slow processing without fencing — see the
+		// sessionTimeout const block.
+		kgo.SessionTimeout(sessionTimeout),
+		kgo.HeartbeatInterval(heartbeatInterval),
+		kgo.RebalanceTimeout(rebalanceTimeout),
 		kgo.FetchMaxWait(100 * time.Millisecond),
 		// Bound per-poll fetch sizes so a deep backlog cannot hand a worker an
 		// hours-long batch (see fetchMaxPartitionBytes).
@@ -490,25 +511,37 @@ func (c *Consumer) partitionsAssigned(_ context.Context, _ *kgo.Client, assigned
 }
 
 // partitionsRevoked stops the workers for revoked partitions and waits for
-// them to finish their in-flight batch (whose successes they commit) before
+// them to finish their in-flight chunk (whose successes they commit) before
 // the rebalance hands the partitions to another member.
 func (c *Consumer) partitionsRevoked(_ context.Context, _ *kgo.Client, revoked map[string][]int32) {
-	c.stopWorkers(revoked)
+	c.stopWorkers(revoked, false)
 }
 
 // partitionsLost is like revoked, but the partitions are already owned by
-// others (session expiry, fencing) — workers are stopped; their final commits
-// may fail, which is fine: uncommitted work is redelivered (at-least-once).
+// others (session expiry, fencing) — there is nothing to drain FOR, so each
+// worker's context is canceled to abort its in-flight handler. Pre-fix,
+// fenced dev-ovh-1 pods kept processing partitions they no longer owned
+// (13-14 cores of work whose commits the broker rejected) because a lost
+// partition's handlers ran to completion exactly like a graceful revoke's.
+// Final commits may fail, which is fine: uncommitted work is redelivered
+// (at-least-once).
 func (c *Consumer) partitionsLost(_ context.Context, _ *kgo.Client, lost map[string][]int32) {
-	c.stopWorkers(lost)
+	c.stopWorkers(lost, true)
 }
 
-func (c *Consumer) stopWorkers(tps map[string][]int32) {
+// stopWorkers stops and drains the workers for the given partitions. With
+// cancelInFlight (partitions LOST), each worker's context is canceled first
+// so ctx-honoring handlers abort promptly; on a graceful revoke the in-flight
+// chunk completes and commits before the partition moves.
+func (c *Consumer) stopWorkers(tps map[string][]int32, cancelInFlight bool) {
 	var stopped []*partitionWorker
 	for topic, parts := range tps {
 		for _, part := range parts {
 			tp := topicPartition{topic, part}
 			if w, ok := c.workers[tp]; ok {
+				if cancelInFlight {
+					w.cancel()
+				}
 				w.signalStop()
 				stopped = append(stopped, w)
 				delete(c.workers, tp)
@@ -569,10 +602,16 @@ func (c *Consumer) handleMetrics(topic string, valueLen int) func(outcome string
 // partition's commit logic and records failure rewinds (applied on the poll
 // goroutine), so a handler stall or failure affects only this partition.
 type partitionWorker struct {
-	c    *Consumer
-	tp   topicPartition
-	ctx  context.Context //nolint:containedctx // worker lifetime == consume ctx
-	recs chan []*kgo.Record
+	c  *Consumer
+	tp topicPartition
+	// ctx is the worker's OWN cancelable child of the consume context.
+	// Canceled on partitions-lost (fencing/session expiry) so in-flight
+	// handlers abort instead of finishing work on a partition another member
+	// already owns; left alone on graceful revoke, where the in-flight chunk
+	// drains and commits. Released via run's deferred cancel either way.
+	ctx    context.Context //nolint:containedctx // worker lifetime == worker goroutine
+	cancel context.CancelFunc
+	recs   chan []*kgo.Record
 
 	quitOnce sync.Once
 	quit     chan struct{}
@@ -585,11 +624,13 @@ type partitionWorker struct {
 	discardUntil int64
 }
 
-func newPartitionWorker(c *Consumer, tp topicPartition, ctx context.Context) *partitionWorker {
+func newPartitionWorker(c *Consumer, tp topicPartition, parent context.Context) *partitionWorker {
+	ctx, cancel := context.WithCancel(parent)
 	return &partitionWorker{
 		c:            c,
 		tp:           tp,
 		ctx:          ctx,
+		cancel:       cancel,
 		recs:         make(chan []*kgo.Record, workerChannelDepth),
 		quit:         make(chan struct{}),
 		done:         make(chan struct{}),
@@ -609,6 +650,10 @@ func (w *partitionWorker) stop() {
 
 func (w *partitionWorker) run() {
 	defer close(w.done)
+	// Release the worker's child context so it detaches from the consume
+	// context's children list (rebalances create and destroy workers for the
+	// process lifetime). No-op when partitionsLost already canceled it.
+	defer w.cancel()
 	for {
 		select {
 		case <-w.quit:

--- a/internal/kafka/consumer_test.go
+++ b/internal/kafka/consumer_test.go
@@ -14,10 +14,14 @@ func discardLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
-// rec builds a single-partition record at the given offset on topic "test".
+// testTopic is the topic name shared by the broker-free unit tests in this
+// package (record fixtures, struct-literal consumers/workers).
+const testTopic = "test"
+
+// rec builds a single-partition record at the given offset on topic testTopic.
 func rec(offset int64) *kgo.Record {
 	return &kgo.Record{
-		Topic:     "test",
+		Topic:     testTopic,
 		Partition: 0,
 		Offset:    offset,
 		Value:     []byte("v"),
@@ -121,7 +125,7 @@ func TestProcessBatch_FirstMessageError(t *testing.T) {
 // partition_concurrency_test.go, because franz options are opaque and cannot
 // be introspected the way sarama's *Config struct could.
 func TestConsumerOpts_AcceptedByClient(t *testing.T) {
-	client, err := kgo.NewClient(consumerOpts([]string{"localhost:9092"}, "test-group", []string{"test"})...)
+	client, err := kgo.NewClient(consumerOpts([]string{"localhost:9092"}, "test-group", []string{testTopic})...)
 	if err != nil {
 		t.Fatalf("consumerOpts produced an invalid franz option set: %v", err)
 	}

--- a/internal/kafka/fencing_test.go
+++ b/internal/kafka/fencing_test.go
@@ -1,0 +1,159 @@
+package kafka
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// TestConsumerOpts_SurvivesSlowProcessing pins the group-liveness timeouts
+// against the dev-ovh-1 fencing collapse: with SessionTimeout(10s) /
+// RebalanceTimeout(60s), slow handlers (1-2s each, feeding depth-5 worker
+// channels) blocked the poll loop long enough that rebalances could not be
+// serviced within 60s — the coordinator fenced members one by one until a
+// 24-partition group had collapsed 5 -> 1 while every pod stayed Running.
+// The consumer must tolerate minutes of slow processing before being fenced.
+// Introspected via kgo's OptValue since franz options are otherwise opaque.
+func TestConsumerOpts_SurvivesSlowProcessing(t *testing.T) {
+	client, err := kgo.NewClient(consumerOpts([]string{"localhost:9092"}, "test-group", []string{"test"})...)
+	if err != nil {
+		t.Fatalf("building client: %v", err)
+	}
+	defer client.Close()
+
+	session := client.OptValue(kgo.SessionTimeout).(time.Duration)
+	heartbeat := client.OptValue(kgo.HeartbeatInterval).(time.Duration)
+	rebalance := client.OptValue(kgo.RebalanceTimeout).(time.Duration)
+
+	if session != 30*time.Second {
+		t.Errorf("SessionTimeout = %v, want 30s", session)
+	}
+	if heartbeat != 3*time.Second {
+		t.Errorf("HeartbeatInterval = %v, want 3s", heartbeat)
+	}
+	if rebalance != 5*time.Minute {
+		t.Errorf("RebalanceTimeout = %v, want 5m", rebalance)
+	}
+	// kgo/broker constraint the options must keep satisfying.
+	if session < 3*heartbeat {
+		t.Errorf("SessionTimeout %v must be >= 3x HeartbeatInterval %v", session, heartbeat)
+	}
+}
+
+// TestConsumer_PartitionsLostCancelsInFlightHandler covers the fenced-pod
+// half of the incident: when partitions are LOST (session expiry, fencing) —
+// not gracefully revoked — the previous behavior let in-flight handlers run
+// to completion on partitions the member no longer owned. Fenced dev-ovh-1
+// pods kept burning 13-14 cores processing stolen partitions whose commits
+// could never land. A lost partition must cancel its worker's context so the
+// in-flight handler aborts promptly.
+func TestConsumer_PartitionsLostCancelsInFlightHandler(t *testing.T) {
+	started := make(chan struct{})
+	handlerErr := make(chan error, 1)
+	handler := func(ctx context.Context, _ *Message) error {
+		close(started)
+		<-ctx.Done() // simulates a slow DataHub fetch that honors ctx
+		handlerErr <- ctx.Err()
+		return ctx.Err()
+	}
+	cc := &commitCapture{}
+	c := newCommitTestConsumer(handler, cc)
+
+	tp := topicPartition{"test", 0}
+	w := newPartitionWorker(c, tp, context.Background())
+	c.workers[tp] = w
+	go w.run()
+	w.recs <- recsRange(1)
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler never started")
+	}
+
+	lostDone := make(chan struct{})
+	go func() {
+		c.partitionsLost(context.Background(), nil, map[string][]int32{tp.topic: {tp.partition}})
+		close(lostDone)
+	}()
+
+	select {
+	case err := <-handlerErr:
+		if err == nil {
+			t.Error("handler ctx.Err() = nil, want cancellation")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("in-flight handler was not canceled on partitions-lost — a fenced pod would keep processing a partition it no longer owns")
+	}
+	select {
+	case <-lostDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("partitionsLost did not return after the worker drained")
+	}
+	if _, ok := c.workers[tp]; ok {
+		t.Error("lost partition's worker still registered")
+	}
+}
+
+// TestConsumer_PartitionsRevokedDrainsWithoutCancel pins the ordinary-rebalance
+// contract that must NOT change: a graceful revoke lets the in-flight chunk
+// finish and commit before the partition moves — no context cancellation, no
+// lost work.
+func TestConsumer_PartitionsRevokedDrainsWithoutCancel(t *testing.T) {
+	const total = 3
+	started := make(chan struct{})
+	var startOnce sync.Once
+	var mu sync.Mutex
+	var ctxErrs []error
+	handler := func(ctx context.Context, _ *Message) error {
+		startOnce.Do(func() { close(started) })
+		time.Sleep(100 * time.Millisecond) // slow-ish handler, does not watch ctx
+		mu.Lock()
+		ctxErrs = append(ctxErrs, ctx.Err())
+		mu.Unlock()
+		return nil
+	}
+	cc := &commitCapture{}
+	c := newCommitTestConsumer(handler, cc)
+
+	tp := topicPartition{"test", 0}
+	w := newPartitionWorker(c, tp, context.Background())
+	c.workers[tp] = w
+	go w.run()
+	w.recs <- recsRange(total)
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler never started")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		c.partitionsRevoked(context.Background(), nil, map[string][]int32{tp.topic: {tp.partition}})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("partitionsRevoked did not return")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(ctxErrs) != total {
+		t.Fatalf("handler completed %d records, want %d (graceful revoke drains the in-flight chunk)", len(ctxErrs), total)
+	}
+	for i, err := range ctxErrs {
+		if err != nil {
+			t.Errorf("record %d: handler ctx canceled during graceful revoke: %v", i, err)
+		}
+	}
+	batches := cc.get()
+	if len(batches) != 1 || len(batches[0]) != total {
+		t.Fatalf("expected the drained chunk committed before the partition moved, got %v", batches)
+	}
+}

--- a/internal/kafka/fencing_test.go
+++ b/internal/kafka/fencing_test.go
@@ -18,7 +18,7 @@ import (
 // The consumer must tolerate minutes of slow processing before being fenced.
 // Introspected via kgo's OptValue since franz options are otherwise opaque.
 func TestConsumerOpts_SurvivesSlowProcessing(t *testing.T) {
-	client, err := kgo.NewClient(consumerOpts([]string{"localhost:9092"}, "test-group", []string{"test"})...)
+	client, err := kgo.NewClient(consumerOpts([]string{"localhost:9092"}, "test-group", []string{testTopic})...)
 	if err != nil {
 		t.Fatalf("building client: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestConsumer_PartitionsLostCancelsInFlightHandler(t *testing.T) {
 	cc := &commitCapture{}
 	c := newCommitTestConsumer(handler, cc)
 
-	tp := topicPartition{"test", 0}
+	tp := topicPartition{testTopic, 0}
 	w := newPartitionWorker(c, tp, context.Background())
 	c.workers[tp] = w
 	go w.run()
@@ -119,7 +119,7 @@ func TestConsumer_PartitionsRevokedDrainsWithoutCancel(t *testing.T) {
 	cc := &commitCapture{}
 	c := newCommitTestConsumer(handler, cc)
 
-	tp := topicPartition{"test", 0}
+	tp := topicPartition{testTopic, 0}
 	w := newPartitionWorker(c, tp, context.Background())
 	c.workers[tp] = w
 	go w.run()

--- a/internal/kafka/kafka_integration_test.go
+++ b/internal/kafka/kafka_integration_test.go
@@ -57,7 +57,7 @@ func TestKafka_ProduceConsumeRoundTrip(t *testing.T) {
 	topic := uniqueTopic(t, "integ_roundtrip")
 	ensureTopicExists(t, topic)
 
-	producer, err := kafka.NewProducer(brokers, topic, slog.Default())
+	producer, err := kafka.NewProducer(brokers, topic, nil, slog.Default())
 	if err != nil {
 		t.Skipf("Kafka not available: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestKafka_ProduceConsumeRoundTrip(t *testing.T) {
 		return nil
 	}
 
-	consumer, err := kafka.NewConsumer(brokers, groupID, []string{topic}, handler, nil, slog.Default())
+	consumer, err := kafka.NewConsumer(brokers, groupID, []string{topic}, handler, nil, nil, slog.Default())
 	if err != nil {
 		t.Skipf("Kafka not available: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestKafka_ProduceMultipleConsumeInOrder(t *testing.T) {
 	topic := uniqueTopic(t, "integ_order")
 	ensureTopicExists(t, topic)
 
-	producer, err := kafka.NewProducer(brokers, topic, slog.Default())
+	producer, err := kafka.NewProducer(brokers, topic, nil, slog.Default())
 	if err != nil {
 		t.Skipf("Kafka not available: %v", err)
 	}
@@ -139,7 +139,7 @@ func TestKafka_ProduceMultipleConsumeInOrder(t *testing.T) {
 		return nil
 	}
 
-	consumer, err := kafka.NewConsumer(brokers, groupID, []string{topic}, handler, nil, slog.Default())
+	consumer, err := kafka.NewConsumer(brokers, groupID, []string{topic}, handler, nil, nil, slog.Default())
 	if err != nil {
 		t.Skipf("Kafka not available: %v", err)
 	}
@@ -185,7 +185,7 @@ func TestKafka_ConsumerGroupOffsetManagement(t *testing.T) {
 	topic := uniqueTopic(t, "integ_offset")
 	ensureTopicExists(t, topic)
 
-	producer, err := kafka.NewProducer(brokers, topic, slog.Default())
+	producer, err := kafka.NewProducer(brokers, topic, nil, slog.Default())
 	if err != nil {
 		t.Skipf("Kafka not available: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestKafka_ConsumerGroupOffsetManagement(t *testing.T) {
 		return nil
 	}
 
-	consumer1, err := kafka.NewConsumer(brokers, groupID, []string{topic}, handler1, nil, slog.Default())
+	consumer1, err := kafka.NewConsumer(brokers, groupID, []string{topic}, handler1, nil, nil, slog.Default())
 	if err != nil {
 		t.Fatalf("failed to create consumer1: %v", err)
 	}
@@ -264,7 +264,7 @@ func TestKafka_ConsumerGroupOffsetManagement(t *testing.T) {
 		return nil
 	}
 
-	consumer2, err := kafka.NewConsumer(brokers, groupID, []string{topic}, handler2, nil, slog.Default())
+	consumer2, err := kafka.NewConsumer(brokers, groupID, []string{topic}, handler2, nil, nil, slog.Default())
 	if err != nil {
 		t.Fatalf("failed to create consumer2: %v", err)
 	}

--- a/internal/kafka/nil_logger_test.go
+++ b/internal/kafka/nil_logger_test.go
@@ -17,7 +17,7 @@ func TestNewProducer_NilLoggerIsSafe(t *testing.T) {
 	}
 	defer cluster.Close()
 
-	p, err := NewProducer(cluster.ListenAddrs(), "nil-logger-producer-test", nil)
+	p, err := NewProducer(cluster.ListenAddrs(), "nil-logger-producer-test", nil, nil)
 	if err != nil {
 		t.Fatalf("NewProducer: %v", err)
 	}
@@ -44,7 +44,7 @@ func TestNewConsumer_NilLoggerIsSafe(t *testing.T) {
 
 	handler := func(ctx context.Context, msg *Message) error { return nil }
 
-	c, err := NewConsumer(cluster.ListenAddrs(), "nil-logger-group", []string{"nil-logger-consumer-test"}, handler, nil, nil)
+	c, err := NewConsumer(cluster.ListenAddrs(), "nil-logger-group", []string{"nil-logger-consumer-test"}, handler, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewConsumer: %v", err)
 	}

--- a/internal/kafka/partition_concurrency_test.go
+++ b/internal/kafka/partition_concurrency_test.go
@@ -95,7 +95,7 @@ func TestConsumer_PartitionsProcessConcurrently(t *testing.T) {
 		return nil
 	}
 
-	consumer, err := NewConsumer(brokers, "partition-concurrency-group", []string{topic}, handler, nil, discardLogger())
+	consumer, err := NewConsumer(brokers, "partition-concurrency-group", []string{topic}, handler, nil, nil, discardLogger())
 	if err != nil {
 		t.Fatalf("creating consumer: %v", err)
 	}

--- a/internal/kafka/producer.go
+++ b/internal/kafka/producer.go
@@ -172,7 +172,15 @@ type Producer struct {
 // is replaced with slog.Default(): Publish and PublishBatch log unconditionally,
 // so accepting nil here without defaulting would turn the first publish into a
 // panic.
-func NewProducer(brokers []string, topic string, logger *slog.Logger) (*Producer, error) {
+//
+// retentionMs optionally maps topic names to the retention.ms a topic should
+// be CREATED with (source: KafkaConfig.TopicRetention); existing topics are
+// never altered. This matters most here: the DLQ topics are producer-only, so
+// this call is the only place they are ever created — created with nil
+// configs on a fresh cluster they inherit the broker default retention
+// (15 minutes on dev-ovh-1), silently expiring dead letters. Pass nil only in
+// unit tests.
+func NewProducer(brokers []string, topic string, retentionMs map[string]int64, logger *slog.Logger) (*Producer, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -187,7 +195,7 @@ func NewProducer(brokers []string, topic string, logger *slog.Logger) (*Producer
 	// NewConsumer: a transient failure is logged, not fatal — auto-creating
 	// brokers still work without it.
 	ensureCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	if eErr := EnsureTopics(ensureCtx, brokers, []string{topic}, nil, logger); eErr != nil {
+	if eErr := EnsureTopics(ensureCtx, brokers, []string{topic}, nil, retentionMs, logger); eErr != nil {
 		logger.Warn("could not pre-create producer topic; relying on broker auto-create",
 			"topic", topic, "error", eErr)
 	}

--- a/internal/kafka/producer_batch_test.go
+++ b/internal/kafka/producer_batch_test.go
@@ -90,7 +90,7 @@ func TestPublishBatch_KgoRoundTrip(t *testing.T) {
 	defer cluster.Close()
 	brokers := cluster.ListenAddrs()
 
-	prod, err := NewProducer(brokers, topic, discardLogger())
+	prod, err := NewProducer(brokers, topic, nil, discardLogger())
 	if err != nil {
 		t.Fatalf("creating producer: %v", err)
 	}

--- a/internal/kafka/producer_ensure_test.go
+++ b/internal/kafka/producer_ensure_test.go
@@ -29,7 +29,7 @@ func TestNewProducer_EnsuresTopicOnStartup(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	p, err := NewProducer(cluster.ListenAddrs(), "ensure-dlq-test", logger)
+	p, err := NewProducer(cluster.ListenAddrs(), "ensure-dlq-test", nil, logger)
 	if err != nil {
 		t.Fatalf("NewProducer: %v", err)
 	}

--- a/internal/kafka/publish_bench_integration_test.go
+++ b/internal/kafka/publish_bench_integration_test.go
@@ -50,7 +50,7 @@ func BenchmarkPublishFanout(b *testing.B) {
 	}
 	adminClient.Close()
 
-	prod, err := kafka.NewProducer([]string{brokers}, topic, logger)
+	prod, err := kafka.NewProducer([]string{brokers}, topic, nil, logger)
 	if err != nil {
 		b.Skipf("Kafka not available at %s: %v", brokers, err)
 	}

--- a/internal/kafka/redelivery_test.go
+++ b/internal/kafka/redelivery_test.go
@@ -80,7 +80,7 @@ func TestConsumer_RedeliversFailedRecordAndTail(t *testing.T) {
 		return nil
 	}
 
-	consumer, err := NewConsumer(brokers, "redeliver-group", []string{topic}, handler, nil, discardLogger())
+	consumer, err := NewConsumer(brokers, "redeliver-group", []string{topic}, handler, nil, nil, discardLogger())
 	if err != nil {
 		t.Fatalf("creating consumer: %v", err)
 	}

--- a/internal/kafka/rewind_liveness_test.go
+++ b/internal/kafka/rewind_liveness_test.go
@@ -87,7 +87,7 @@ func TestConsumer_RewindStormSurvivesRebalance(t *testing.T) {
 		return errors.New("permanent handler failure (storm)")
 	}
 
-	c1, err := NewConsumer(brokers, "storm-group", []string{topic}, failingHandler, nil, logger)
+	c1, err := NewConsumer(brokers, "storm-group", []string{topic}, failingHandler, nil, nil, logger)
 	if err != nil {
 		t.Fatalf("NewConsumer(c1): %v", err)
 	}
@@ -114,7 +114,7 @@ func TestConsumer_RewindStormSurvivesRebalance(t *testing.T) {
 	// Membership churn mid-storm: join and leave a second member twice,
 	// forcing revokes/assigns to interleave with in-flight rewinds.
 	for i := 0; i < 2; i++ {
-		c2, cErr := NewConsumer(brokers, "storm-group", []string{topic}, failingHandler, nil, logger)
+		c2, cErr := NewConsumer(brokers, "storm-group", []string{topic}, failingHandler, nil, nil, logger)
 		if cErr != nil {
 			t.Fatalf("NewConsumer(c2 #%d): %v", i, cErr)
 		}

--- a/internal/metrics/labels.go
+++ b/internal/metrics/labels.go
@@ -33,6 +33,11 @@ const (
 	OutcomeHandlerError     = "handler_error"
 	OutcomeRejectedURL      = "rejected_url"
 	OutcomePublished        = "published"
+	// OutcomeParkedDiskFull counts subtree messages parked in Kafka (handler
+	// error, no ack, no DLQ) because the blob store reported a full
+	// filesystem — an operational condition that retention-protected Kafka
+	// rides out, unlike the un-replayable DLQ.
+	OutcomeParkedDiskFull = "parked_disk_full"
 )
 
 // Unknown is the fallback label value when an input cannot be classified

--- a/internal/store/factory.go
+++ b/internal/store/factory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/bsv-blockchain/merkle-service/internal/config"
 )
@@ -42,6 +43,65 @@ func NewFromConfig(ctx context.Context, cfg *config.Config, logger *slog.Logger)
 	default:
 		return nil, fmt.Errorf("unknown store backend %q", cfg.Store.Backend)
 	}
+}
+
+// Startup retry policy for NewFromConfigWithRetry: 5 attempts with the
+// backoff doubling from 8s — 8+16+32+64 = 120s of waiting, so a binary rides
+// out ~2 minutes of backend unavailability before giving up.
+const (
+	registryRetryAttempts  = 5
+	registryRetryBaseDelay = 8 * time.Second
+)
+
+// NewFromConfigWithRetry is NewFromConfig with a bounded startup retry. Every
+// binary builds its store registry first thing at startup, and a transient
+// backend blip there used to exit the process immediately: on dev-ovh-1 the
+// api-server pods crash-looped 5-7 times each on a single Aerospike
+// "command execution timed out" while the cluster recovered from the disk
+// incident. A slow backend at boot is an operational condition to wait out,
+// not a configuration error — but a persistent failure must still fail
+// startup so the orchestrator surfaces it.
+func NewFromConfigWithRetry(ctx context.Context, cfg *config.Config, logger *slog.Logger) (*Registry, error) {
+	return newRegistryWithRetry(ctx, registryRetryAttempts, registryRetryBaseDelay, logger, func() (*Registry, error) {
+		return NewFromConfig(ctx, cfg, logger)
+	})
+}
+
+// newRegistryWithRetry runs build up to attempts times, sleeping baseDelay
+// (doubling per attempt) between failures. Every failed attempt is logged so
+// a crash-looping pod's history is visible in the log stream, not just the
+// restart counter. The context aborts a pending wait (SIGTERM mid-backoff).
+func newRegistryWithRetry(ctx context.Context, attempts int, baseDelay time.Duration, logger *slog.Logger, build func() (*Registry, error)) (*Registry, error) {
+	var lastErr error
+	delay := baseDelay
+	for attempt := 1; attempt <= attempts; attempt++ {
+		r, err := build()
+		if err == nil {
+			if attempt > 1 {
+				logger.Info("store registry built after retry", "attempt", attempt)
+			}
+			return r, nil
+		}
+		lastErr = err
+		if attempt == attempts {
+			break
+		}
+		logger.Warn("failed to build store registry; backing off before retry",
+			"attempt", attempt,
+			"maxAttempts", attempts,
+			"retryIn", delay.String(),
+			"error", err,
+		)
+		t := time.NewTimer(delay)
+		select {
+		case <-t.C:
+		case <-ctx.Done():
+			t.Stop()
+			return nil, fmt.Errorf("store registry build aborted while backing off: %w", ctx.Err())
+		}
+		delay *= 2
+	}
+	return nil, fmt.Errorf("store registry build failed after %d attempts: %w", attempts, lastErr)
 }
 
 // newAerospikeRegistry constructs every Aerospike-backed store plus the

--- a/internal/store/factory_retry_test.go
+++ b/internal/store/factory_retry_test.go
@@ -1,0 +1,92 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func retryTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestNewRegistryWithRetry_RecoversFromTransientFailure is the regression
+// test for the api-server crash-loop: on dev-ovh-1, a transient Aerospike
+// "command execution timed out" during startup exited the process immediately
+// (no retry), and k8s restart-looped every api-server pod 5-7 times. Startup
+// must retry the registry build with backoff instead of failing on the first
+// attempt.
+func TestNewRegistryWithRetry_RecoversFromTransientFailure(t *testing.T) {
+	var calls int
+	build := func() (*Registry, error) {
+		calls++
+		if calls < 3 {
+			return nil, errors.New("aerospike client: failed to connect: command execution timed out")
+		}
+		return &Registry{}, nil
+	}
+
+	r, err := newRegistryWithRetry(context.Background(), 5, time.Millisecond, retryTestLogger(), build)
+	if err != nil {
+		t.Fatalf("expected recovery after transient failures, got: %v", err)
+	}
+	if r == nil {
+		t.Fatal("expected a registry, got nil")
+	}
+	if calls != 3 {
+		t.Errorf("build called %d times, want 3 (two failures + one success)", calls)
+	}
+}
+
+// TestNewRegistryWithRetry_ExhaustsAttempts verifies a persistent failure
+// still fails startup — after the full attempt budget — and that the error
+// reports the attempt count and wraps the last cause.
+func TestNewRegistryWithRetry_ExhaustsAttempts(t *testing.T) {
+	cause := errors.New("aerospike client: failed to connect")
+	var calls int
+	build := func() (*Registry, error) {
+		calls++
+		return nil, cause
+	}
+
+	r, err := newRegistryWithRetry(context.Background(), 4, time.Millisecond, retryTestLogger(), build)
+	if err == nil {
+		t.Fatalf("expected an error after exhausting attempts, got registry %v", r)
+	}
+	if calls != 4 {
+		t.Errorf("build called %d times, want 4", calls)
+	}
+	if !errors.Is(err, cause) {
+		t.Errorf("returned error must wrap the last build failure, got: %v", err)
+	}
+}
+
+// TestNewRegistryWithRetry_AbortsOnContextCancel verifies shutdown (SIGTERM
+// during a crash-loop) interrupts the backoff wait instead of holding the
+// process for the remaining schedule.
+func TestNewRegistryWithRetry_AbortsOnContextCancel(t *testing.T) {
+	build := func() (*Registry, error) {
+		return nil, errors.New("still down")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	begin := time.Now()
+	_, err := newRegistryWithRetry(ctx, 5, time.Minute, retryTestLogger(), build)
+	if err == nil {
+		t.Fatal("expected an error when the context is canceled mid-backoff")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error must wrap context.Canceled, got: %v", err)
+	}
+	if elapsed := time.Since(begin); elapsed > 5*time.Second {
+		t.Fatalf("retry loop did not abort on cancel (took %v)", elapsed)
+	}
+}

--- a/internal/subtree/processor.go
+++ b/internal/subtree/processor.go
@@ -133,6 +133,7 @@ func (p *Processor) Init(_ interface{}) error {
 	callbackProducer, err := kafka.NewProducer(
 		p.cfg.Kafka.Brokers,
 		p.cfg.Kafka.CallbackTopic,
+		p.cfg.Kafka.TopicRetention(),
 		p.Logger,
 	)
 	if err != nil {
@@ -146,6 +147,7 @@ func (p *Processor) Init(_ interface{}) error {
 	retryProducer, err := kafka.NewProducer(
 		p.cfg.Kafka.Brokers,
 		p.cfg.Kafka.SubtreeTopic,
+		p.cfg.Kafka.TopicRetention(),
 		p.Logger,
 	)
 	if err != nil {
@@ -159,6 +161,7 @@ func (p *Processor) Init(_ interface{}) error {
 	dlqProducer, err := kafka.NewProducer(
 		p.cfg.Kafka.Brokers,
 		p.cfg.Kafka.SubtreeDLQTopic,
+		p.cfg.Kafka.TopicRetention(),
 		p.Logger,
 	)
 	if err != nil {
@@ -172,6 +175,7 @@ func (p *Processor) Init(_ interface{}) error {
 		[]string{p.cfg.Kafka.SubtreeTopic},
 		p.handleMessage,
 		p.cfg.Kafka.TopicPartitions(),
+		p.cfg.Kafka.TopicRetention(),
 		p.Logger,
 	)
 	if err != nil {

--- a/internal/subtree/processor.go
+++ b/internal/subtree/processor.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
+	"syscall"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -184,6 +186,7 @@ func (p *Processor) Init(_ interface{}) error {
 		"subtreeDLQTopic", p.cfg.Kafka.SubtreeDLQTopic,
 		"callbackTopic", p.cfg.Kafka.CallbackTopic,
 		"maxAttempts", p.cfg.Subtree.MaxAttempts,
+		"retryBackoffBaseMs", p.cfg.Subtree.RetryBackoffBaseMs,
 		"cacheEnabled", p.regCache != nil,
 	)
 
@@ -421,12 +424,99 @@ func (p *Processor) handleMessage(ctx context.Context, msg *kafka.Message) error
 	return nil
 }
 
+// subtreeRetryBackoffCap bounds the exponential retry backoff (see
+// retryBackoff) so a high AttemptCount can never park a partition worker for
+// minutes at a time.
+const subtreeRetryBackoffCap = 30 * time.Second
+
+// retryBackoff returns how long to wait before retry attempt `attempt`
+// (1-based): RetryBackoffBaseMs doubling per attempt, capped at
+// subtreeRetryBackoffCap. 0 when the backoff is disabled (base <= 0, or a
+// struct-literal test cfg). On dev-ovh-1 the whole 3-attempt budget burned in
+// ~300ms against a disk that stayed full for 15 minutes — retries must span
+// real time to have any chance of outliving the condition they're retrying.
+func (p *Processor) retryBackoff(attempt int) time.Duration {
+	if p.cfg == nil || p.cfg.Subtree.RetryBackoffBaseMs <= 0 {
+		return 0
+	}
+	base := time.Duration(p.cfg.Subtree.RetryBackoffBaseMs) * time.Millisecond
+	if attempt < 1 {
+		attempt = 1
+	}
+	// Doubling past attempt ~32 overflows the shift; anything that far in is
+	// at the cap regardless.
+	if attempt > 30 {
+		return subtreeRetryBackoffCap
+	}
+	d := base << uint(attempt-1)
+	if d > subtreeRetryBackoffCap || d <= 0 {
+		return subtreeRetryBackoffCap
+	}
+	return d
+}
+
+// waitBackoff sleeps for d, returning early with ctx.Err() when the context
+// dies first (shutdown, lost partition — see the kafka consumer's
+// partitions-lost cancellation). d <= 0 returns immediately.
+func waitBackoff(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// isDiskFull reports whether err is a full-filesystem condition: ENOSPC (via
+// the wrapped errno chain) or a quota/space error that only survived as text.
+func isDiskFull(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.ENOSPC) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "no space left on device") ||
+		strings.Contains(msg, "disk quota exceeded")
+}
+
 // handleTransientFailure bumps AttemptCount and either re-publishes the
-// message to the subtree topic or, once MaxAttempts has been reached, parks
-// it on subtree-dlq. Returns nil on successful hand-off so the consumer acks
-// the original offset; returns an error only when the producer itself is
-// broken (partition stall is preferable to silent loss in that case).
+// message to the subtree topic (after an exponential backoff — see
+// retryBackoff) or, once MaxAttempts has been reached, parks it on
+// subtree-dlq. Returns nil on successful hand-off so the consumer acks the
+// original offset; returns an error only when the producer itself is broken
+// (partition stall is preferable to silent loss in that case).
+//
+// Full-disk failures are the exception to all of the above: they are an
+// operational condition, not bad data, so they never consume the retry
+// budget and never route to the DLQ (which has no replay — on dev-ovh-1 a
+// 15-minute ENOSPC window dead-lettered 1,406 subtrees, permanently losing
+// every registered tx's callbacks). Instead the message is PARKED: an error
+// is returned, the consumer doesn't advance past the record, and topic
+// retention keeps it safe in Kafka until the disk recovers.
 func (p *Processor) handleTransientFailure(ctx context.Context, subtreeMsg *kafka.SubtreeMessage, stage string, cause error, start time.Time) error {
+	if isDiskFull(cause) {
+		p.Logger.Warn(
+			"blob store full; parking subtree message in Kafka until space recovers (never DLQ)",
+			logfields.SubtreeHash(subtreeMsg.Hash),
+			"stage", stage,
+			"attemptCount", subtreeMsg.AttemptCount,
+			"error", cause,
+		)
+		metrics.ObserveSubtreeProcessing(metrics.OutcomeParkedDiskFull, time.Since(start))
+		// Throttle the redelivery loop; AttemptCount is not bumped (the
+		// message is never re-published), so this stays near the base delay
+		// per redelivery on top of the consumer's own rewind backoff.
+		_ = waitBackoff(ctx, p.retryBackoff(subtreeMsg.AttemptCount+1))
+		return fmt.Errorf("%s: blob store full, parking message for redelivery: %w", stage, cause)
+	}
+
 	nextAttempt := subtreeMsg.AttemptCount + 1
 	maxAttempts := p.cfg.Subtree.MaxAttempts
 	if maxAttempts <= 0 {
@@ -450,14 +540,23 @@ func (p *Processor) handleTransientFailure(ctx context.Context, subtreeMsg *kafk
 		return nil
 	}
 
+	backoff := p.retryBackoff(nextAttempt)
 	p.Logger.Warn(
 		"subtree message transient failure, re-publishing for retry",
 		logfields.SubtreeHash(subtreeMsg.Hash),
 		"stage", stage,
 		"attemptCount", subtreeMsg.AttemptCount,
 		"nextAttempt", nextAttempt,
+		"backoffMs", backoff.Milliseconds(),
 		"error", cause,
 	)
+	// Wait BEFORE the hand-off so the retry budget spans real time (1s/2s/4s…
+	// rather than back-to-back republish→refetch cycles). An interrupted wait
+	// returns an error without publishing: the unacked original is redelivered,
+	// so nothing is lost or duplicated by aborting here.
+	if waitErr := waitBackoff(ctx, backoff); waitErr != nil {
+		return fmt.Errorf("interrupted while backing off before subtree retry: %w", waitErr)
+	}
 	subtreeMsg.AttemptCount = nextAttempt
 	data, encErr := subtreeMsg.Encode()
 	if encErr != nil {

--- a/internal/subtree/processor_backpressure_test.go
+++ b/internal/subtree/processor_backpressure_test.go
@@ -1,0 +1,289 @@
+package subtree
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/merkle-service/internal/cache"
+	"github.com/bsv-blockchain/merkle-service/internal/config"
+	"github.com/bsv-blockchain/merkle-service/internal/datahub"
+	"github.com/bsv-blockchain/merkle-service/internal/kafka"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
+)
+
+// failingSubtreeStore implements store.SubtreeStore, failing every write with
+// storeErr. Used to drive the "storing subtree" transient-failure stage the
+// way a full blob-store volume did on dev-ovh-1.
+type failingSubtreeStore struct {
+	storeErr error
+	calls    int
+}
+
+func (f *failingSubtreeStore) StoreSubtree(string, []byte, uint64) error {
+	f.calls++
+	return f.storeErr
+}
+
+func (f *failingSubtreeStore) StoreSubtreeFromReader(string, io.Reader, int64, uint64) error {
+	f.calls++
+	return f.storeErr
+}
+func (f *failingSubtreeStore) GetSubtree(string) ([]byte, error) { return nil, f.storeErr }
+func (f *failingSubtreeStore) GetSubtreeReader(string) (io.ReadCloser, error) {
+	return nil, f.storeErr
+}
+func (f *failingSubtreeStore) DeleteSubtree(string) error          { return nil }
+func (f *failingSubtreeStore) ScheduleDelete(string, uint64) error { return nil }
+func (f *failingSubtreeStore) SetCurrentBlockHeight(uint64)        {}
+
+// enospcErr is what a full filesystem actually returns from a blob write: an
+// *fs.PathError wrapping syscall.ENOSPC, further wrapped by the store layer.
+func enospcErr() error {
+	return fmt.Errorf("writing blob: %w", &fs.PathError{Op: "write", Path: "/data/subtrees/ab/cd.subtree", Err: syscall.ENOSPC})
+}
+
+// TestRetryBackoff_ExponentialWithCap pins the backoff schedule: base doubles
+// per attempt and is capped at subtreeRetryBackoffCap. On dev-ovh-1 the three
+// retry attempts of a blob-store write burned in ~300ms, so a 15-minute disk
+// incident converted 1,406 subtrees into dead letters.
+func TestRetryBackoff_ExponentialWithCap(t *testing.T) {
+	p := &Processor{cfg: &config.Config{Subtree: config.SubtreeConfig{RetryBackoffBaseMs: 1000}}}
+
+	cases := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{1, 1 * time.Second},
+		{2, 2 * time.Second},
+		{3, 4 * time.Second},
+		{6, 30 * time.Second},  // 32s capped
+		{50, 30 * time.Second}, // shift overflow guard
+	}
+	for _, tc := range cases {
+		if got := p.retryBackoff(tc.attempt); got != tc.want {
+			t.Errorf("retryBackoff(%d) = %v, want %v", tc.attempt, got, tc.want)
+		}
+	}
+
+	// 0 disables (struct-literal test configs); nil cfg likewise.
+	p.cfg.Subtree.RetryBackoffBaseMs = 0
+	if got := p.retryBackoff(3); got != 0 {
+		t.Errorf("retryBackoff with base 0 = %v, want 0 (disabled)", got)
+	}
+	if got := (&Processor{}).retryBackoff(3); got != 0 {
+		t.Errorf("retryBackoff with nil cfg = %v, want 0", got)
+	}
+}
+
+// TestHandleTransientFailure_BacksOffBeforeRetry verifies a transient failure
+// waits its backoff before re-publishing, so the bounded retry budget spans
+// real time instead of ~100ms per attempt.
+func TestHandleTransientFailure_BacksOffBeforeRetry(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	retryMock := &mockSyncProducer{}
+	dlqMock := &mockSyncProducer{}
+	p := &Processor{
+		cfg: &config.Config{
+			Subtree: config.SubtreeConfig{MaxAttempts: 3, RetryBackoffBaseMs: 60},
+		},
+		retryProducer: kafka.NewTestProducer(retryMock, "subtree-test", logger),
+		dlqProducer:   kafka.NewTestProducer(dlqMock, "subtree-dlq-test", logger),
+	}
+	p.InitBase("subtree-backoff-test")
+	p.Logger = logger
+
+	msg := &kafka.SubtreeMessage{Hash: "subtree-backoff", AttemptCount: 1} // next attempt 2 -> base*2
+	begin := time.Now()
+	if err := p.handleTransientFailure(context.Background(), msg, "storing subtree", errors.New("blip"), time.Now()); err != nil {
+		t.Fatalf("handleTransientFailure: %v", err)
+	}
+	if elapsed := time.Since(begin); elapsed < 120*time.Millisecond {
+		t.Errorf("retry republished after %v, want >= 120ms backoff (attempt 2, base 60ms)", elapsed)
+	}
+	if got := len(retryMock.getMessages()); got != 1 {
+		t.Errorf("expected 1 retry publish after backoff, got %d", got)
+	}
+	if got := len(dlqMock.getMessages()); got != 0 {
+		t.Errorf("expected 0 DLQ publishes, got %d", got)
+	}
+}
+
+// TestHandleTransientFailure_BackoffAbortsOnContextCancel verifies a canceled
+// consumer context (shutdown, lost partition) interrupts the backoff and
+// surfaces an error WITHOUT re-publishing — the unacked original is
+// redelivered instead, so nothing is lost or duplicated by the abort.
+func TestHandleTransientFailure_BackoffAbortsOnContextCancel(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	retryMock := &mockSyncProducer{}
+	dlqMock := &mockSyncProducer{}
+	p := &Processor{
+		cfg: &config.Config{
+			Subtree: config.SubtreeConfig{MaxAttempts: 3, RetryBackoffBaseMs: 60_000},
+		},
+		retryProducer: kafka.NewTestProducer(retryMock, "subtree-test", logger),
+		dlqProducer:   kafka.NewTestProducer(dlqMock, "subtree-dlq-test", logger),
+	}
+	p.InitBase("subtree-backoff-cancel-test")
+	p.Logger = logger
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	msg := &kafka.SubtreeMessage{Hash: "subtree-backoff-cancel"}
+	begin := time.Now()
+	err := p.handleTransientFailure(ctx, msg, "storing subtree", errors.New("blip"), time.Now())
+	if err == nil {
+		t.Fatal("expected an error when the backoff is interrupted by context cancellation")
+	}
+	if elapsed := time.Since(begin); elapsed > 5*time.Second {
+		t.Fatalf("backoff did not abort on cancel (took %v)", elapsed)
+	}
+	if got := len(retryMock.getMessages()); got != 0 {
+		t.Errorf("expected no retry publish after interrupted backoff, got %d", got)
+	}
+}
+
+// TestHandleTransientFailure_DiskFullNeverDLQs is the regression test for the
+// ENOSPC data loss: a full disk is an operational condition, not bad data, so
+// it must never consume the retry budget nor route to subtree-dlq (from which
+// there is no replay — every registered tx in the subtree loses its callbacks
+// permanently). Instead the handler surfaces an error, the consumer parks the
+// message by not advancing past it, and Kafka retention keeps it safe until
+// the disk recovers.
+func TestHandleTransientFailure_DiskFullNeverDLQs(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	retryMock := &mockSyncProducer{}
+	dlqMock := &mockSyncProducer{}
+	p := &Processor{
+		cfg: &config.Config{
+			Subtree: config.SubtreeConfig{MaxAttempts: 3, RetryBackoffBaseMs: 1},
+		},
+		retryProducer: kafka.NewTestProducer(retryMock, "subtree-test", logger),
+		dlqProducer:   kafka.NewTestProducer(dlqMock, "subtree-dlq-test", logger),
+	}
+	p.InitBase("subtree-diskfull-test")
+	p.Logger = logger
+
+	// AttemptCount 2 with MaxAttempts 3: an ordinary transient failure would
+	// DLQ right here. Disk-full must not.
+	msg := &kafka.SubtreeMessage{Hash: "subtree-diskfull", AttemptCount: 2}
+	beforeParked := subtreeCount(metrics.OutcomeParkedDiskFull)
+	err := p.handleTransientFailure(context.Background(), msg, "storing subtree", enospcErr(), time.Now())
+	if err == nil {
+		t.Fatal("expected an error so the consumer parks the message (no ack, no advance)")
+	}
+	if !errors.Is(err, syscall.ENOSPC) {
+		t.Errorf("returned error should wrap the ENOSPC cause, got: %v", err)
+	}
+	if got := len(dlqMock.getMessages()); got != 0 {
+		t.Errorf("disk-full must never DLQ, got %d DLQ publishes", got)
+	}
+	if got := len(retryMock.getMessages()); got != 0 {
+		t.Errorf("disk-full must not burn the retry budget, got %d retry publishes", got)
+	}
+	if msg.AttemptCount != 2 {
+		t.Errorf("AttemptCount mutated to %d, want unchanged 2 (parked, not retried)", msg.AttemptCount)
+	}
+	if got := subtreeCount(metrics.OutcomeParkedDiskFull) - beforeParked; got != 1 {
+		t.Errorf("parked_disk_full outcome delta = %d, want 1", got)
+	}
+}
+
+// TestHandleTransientFailure_DiskQuotaMessageNeverDLQs covers quota-style
+// full-filesystem errors that arrive as text (e.g. from a store layer that
+// did not preserve the errno chain).
+func TestHandleTransientFailure_DiskQuotaMessageNeverDLQs(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	retryMock := &mockSyncProducer{}
+	dlqMock := &mockSyncProducer{}
+	p := &Processor{
+		cfg: &config.Config{
+			Subtree: config.SubtreeConfig{MaxAttempts: 3, RetryBackoffBaseMs: 1},
+		},
+		retryProducer: kafka.NewTestProducer(retryMock, "subtree-test", logger),
+		dlqProducer:   kafka.NewTestProducer(dlqMock, "subtree-dlq-test", logger),
+	}
+	p.InitBase("subtree-quota-test")
+	p.Logger = logger
+
+	for _, cause := range []error{
+		errors.New("mkdir /data/subtrees/ab: disk quota exceeded"),
+		errors.New("write /data/subtrees/ab/cd.subtree: no space left on device"),
+	} {
+		msg := &kafka.SubtreeMessage{Hash: "subtree-quota", AttemptCount: 2}
+		if err := p.handleTransientFailure(context.Background(), msg, "storing subtree", cause, time.Now()); err == nil {
+			t.Errorf("cause %q: expected parking error, got nil", cause)
+		}
+	}
+	if got := len(dlqMock.getMessages()); got != 0 {
+		t.Errorf("quota-style disk-full must never DLQ, got %d", got)
+	}
+	if got := len(retryMock.getMessages()); got != 0 {
+		t.Errorf("quota-style disk-full must not retry-publish, got %d", got)
+	}
+}
+
+// TestHandleMessage_DiskFullOnStore_ParksMessage drives the incident path end
+// to end: DataHub fetch succeeds, the blob-store write fails with ENOSPC, and
+// handleMessage must surface an error (parking the message) without touching
+// the DLQ, the retry topic, or the dedup cache.
+func TestHandleMessage_DiskFullOnStore_ParksMessage(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	registeredTxid := "9602604163d73e2ab424bad28b1363694c397512dfa883ec1ee90cc92f847359"
+	dataHubServer := startRawSubtreeServer(hashFromHex(t, registeredTxid))
+	defer dataHubServer.Close()
+
+	retryMock := &mockSyncProducer{}
+	dlqMock := &mockSyncProducer{}
+	blobStore := &failingSubtreeStore{storeErr: enospcErr()}
+	p := &Processor{
+		cfg: &config.Config{
+			Subtree: config.SubtreeConfig{
+				MaxAttempts:        3,
+				StorageMode:        "realtime",
+				RetryBackoffBaseMs: 1,
+			},
+		},
+		registrationStore: &mockRegStore{registrations: map[string][]string{}},
+		seenCounterStore:  &mockSeenCounter{},
+		subtreeStore:      blobStore,
+		dedupCache:        cache.NewDedupCache(16),
+		retryProducer:     kafka.NewTestProducer(retryMock, "subtree-test", logger),
+		dlqProducer:       kafka.NewTestProducer(dlqMock, "subtree-dlq-test", logger),
+		dataHubClient:     datahub.NewClient(5, 0, logger),
+	}
+	p.InitBase("subtree-diskfull-e2e-test")
+	p.Logger = logger
+
+	msg := &kafka.SubtreeMessage{Hash: "subtree-diskfull-e2e", DataHubURL: dataHubServer.URL}
+	value, err := msg.Encode()
+	if err != nil {
+		t.Fatalf("encode subtree msg: %v", err)
+	}
+
+	if err := p.handleMessage(t.Context(), &kafka.Message{Value: value}); err == nil {
+		t.Fatal("expected handleMessage to return an error so the consumer does not advance past the message")
+	}
+	if blobStore.calls == 0 {
+		t.Fatal("blob store was never written — test did not reach the storing-subtree stage")
+	}
+	if got := len(dlqMock.getMessages()); got != 0 {
+		t.Errorf("expected 0 DLQ publishes on disk-full, got %d", got)
+	}
+	if got := len(retryMock.getMessages()); got != 0 {
+		t.Errorf("expected 0 retry publishes on disk-full, got %d", got)
+	}
+	if p.dedupCache.Contains(msg.Hash) {
+		t.Error("dedup cache must not mark a parked subtree as processed — redelivery would be skipped")
+	}
+}

--- a/test/scale/production_test.go
+++ b/test/scale/production_test.go
@@ -235,7 +235,7 @@ func runProductionScaleTest(t *testing.T, fixtureDir string, timeout time.Durati
 	}
 
 	// ---- Phase A: SEEN (network observation) ----
-	subtreeProducer, err := kafka.NewProducer([]string{kafkaBroker}, subtreeTopic, logger)
+	subtreeProducer, err := kafka.NewProducer([]string{kafkaBroker}, subtreeTopic, nil, logger)
 	if err != nil {
 		t.Fatalf("failed to create subtree producer: %v", err)
 	}
@@ -281,7 +281,7 @@ func runProductionScaleTest(t *testing.T, fixtureDir string, timeout time.Durati
 	_, seenTxids := waitSeen()
 
 	// ---- Phase B: MINED (block processing) ----
-	blockProducer, err := kafka.NewProducer([]string{kafkaBroker}, blockTopic, logger)
+	blockProducer, err := kafka.NewProducer([]string{kafkaBroker}, blockTopic, nil, logger)
 	if err != nil {
 		t.Fatalf("failed to create block producer: %v", err)
 	}

--- a/test/scale/scale_test.go
+++ b/test/scale/scale_test.go
@@ -31,7 +31,7 @@ func testLogger() *slog.Logger {
 // TestMain performs environment checks before running scale tests.
 func TestMain(m *testing.M) {
 	// Check Kafka reachability.
-	p, err := kafka.NewProducer([]string{kafkaBroker}, "probe-topic", slog.Default())
+	p, err := kafka.NewProducer([]string{kafkaBroker}, "probe-topic", nil, slog.Default())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "SKIP: Kafka not reachable at %s: %v\n", kafkaBroker, err)
 		os.Exit(0)
@@ -219,7 +219,7 @@ func runScaleTest(t *testing.T, fixtureDir string, instanceCount int, timeout ti
 	stumpsDLQTopic := stumpsTopic + "-dlq"
 	subtreeWorkTopic := fmt.Sprintf("scale-subtree-work-%d", time.Now().UnixNano())
 
-	blockProducer, err := kafka.NewProducer([]string{kafkaBroker}, blockTopic, logger)
+	blockProducer, err := kafka.NewProducer([]string{kafkaBroker}, blockTopic, nil, logger)
 	if err != nil {
 		t.Fatalf("failed to create block producer: %v", err)
 	}


### PR DESCRIPTION
## Incident

On the dev-ovh-1 scale cluster (v0.4.5, very high tx volume), the shared blob-store volume filled to 100% and exposed five resilience gaps. All were observed live; details in each commit message.

## Fixes (one commit each)

1. **Mid-batch commit progress** (`internal/kafka/consumer.go`) — partition workers commit the successful prefix every 50 records instead of once per fetched batch, and per-poll fetches are bounded (256 KiB/partition, 8 MiB total). Under the incident's 50k-message backlog a single batch took hours, committed offsets froze for 40+ minutes across restarts, and every restart reprocessed from scratch. F-030 prefix-commit/rewind/DLQ semantics unchanged and pinned by tests. Commit failures now log at WARN with the offset range.

2. **Fencing recovery** — SessionTimeout 10s→30s, RebalanceTimeout 60s→5m; `partitionsLost` cancels the per-partition worker context so a fenced pod stops working partitions it no longer owns (we observed fenced pods burning 13–40 cores each on stolen partitions while group membership sat at 1 of 5). Graceful revoke still drains and commits. The #180 rewind machinery is untouched.

3. **Fetcher ENOSPC backpressure** (`internal/subtree/processor.go`) — real exponential backoff between retry attempts (new `subtree.retryBackoffBaseMs`, default 1s; the incident burned all 3 attempts in ~300ms), and disk-full errors (ENOSPC / "disk quota exceeded") park the message under Kafka retention instead of dead-lettering: 1,406 subtrees went to the write-only `subtree-dlq` in one 15-minute window — permanent callback loss for every registered tx in them.

4. **Startup registry retry** (`internal/store/factory.go`, all six binaries) — 5 attempts / ~2 min backoff instead of `exit(1)` on an Aerospike blip; api-server pods had crash-looped 5–7× each.

5. **Explicit retention at topic creation** (`internal/kafka/admin.go`) — new `kafka.topicRetentionMs` / `kafka.dlqRetentionMs` (6h / 7d defaults) passed at CREATE time only; never alters existing topics (GitOps Topic CRDs own those — see teranode-argocd-deployments#177). dev-ovh-1's broker default was **15 minutes**, which silently deleted unconsumed work items and dead letters during the incident.

## Verification

- `go build ./...`, `go test ./... -count=1`: 20/20 packages pass; race detector clean on `internal/kafka`; `golangci-lint` 0 issues.
- New tests: `commit_progress_test.go`, `fencing_test.go`, `processor_backpressure_test.go`, `factory_retry_test.go`, `admin_test.go` retention cases (incl. a kfake test pinning that existing topics are never altered).

## Follow-ups (not in this PR)

- Disk-full parking for the subtree-worker stump-write path (this PR scopes ENOSPC parking to the fetcher).
- arcade: BLOCK_PROCESSED with zero STUMPs on a block with no tracked txs leaves the row eternally stale, so the watchdog re-drives empty blocks until its attempt cap — consider marking such rows complete-empty.