### PR TITLE
fix(block): back off between subtree-work retries; park on disk-full; bound the 404 budget

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -347,6 +347,24 @@ block:
   # Env: BLOCK_MAX_ATTEMPTS
   maxAttempts: 10
 
+  # Base delay (ms) before a transiently-failed subtree work item is
+  # re-published for retry; doubles per attempt, capped at 5s (deliberately
+  # below the fetcher's 30s cap — see subtree.retryBackoffBaseMs — so a
+  # failing 50-record consumer chunk cannot sleep past the group's 5m
+  # rebalance timeout). Without it the whole maxAttempts budget burns in
+  # milliseconds per item, amplifying dependency outages with immediate
+  # republish storms. 0 disables the backoff (not recommended in production).
+  # Env: BLOCK_RETRY_BACKOFF_BASE_MS
+  retryBackoffBaseMs: 1000
+
+  # Reduced retry budget for work items failing with a DataHub 404. Worker
+  # subtrees existed at announcement time, but teranode's asset cache prunes
+  # subtree data after ~2h, so a late 404 is effectively permanent — it DLQs
+  # after this many attempts instead of burning the full maxAttempts budget.
+  # maxAttempts remains a hard ceiling regardless.
+  # Env: BLOCK_NOT_FOUND_MAX_ATTEMPTS
+  notFoundMaxAttempts: 3
+
   # Memory (MB) for the block-time registration deduplication cache. Same
   # shape as subtree.cacheMaxMB but independent so all-in-one and microservice
   # topologies behave identically. 0 disables.

--- a/internal/block/subtree_worker.go
+++ b/internal/block/subtree_worker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bsv-blockchain/merkle-service/internal/datahub"
 	"github.com/bsv-blockchain/merkle-service/internal/kafka"
 	"github.com/bsv-blockchain/merkle-service/internal/logfields"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
 	"github.com/bsv-blockchain/merkle-service/internal/ssrfguard"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
@@ -452,6 +453,7 @@ func (s *SubtreeWorkerService) handleTransientFailure(ctx context.Context, workM
 		if pubErr := s.dlqProducer.PublishWithHashKey(context.WithoutCancel(ctx), workMsg.SubtreeHash, data); pubErr != nil {
 			return fmt.Errorf("publishing subtree work message to DLQ: %w", pubErr)
 		}
+		metrics.IncSubtreeWork(metrics.OutcomeDLQ)
 		return nil
 	}
 
@@ -480,6 +482,7 @@ func (s *SubtreeWorkerService) handleTransientFailure(ctx context.Context, workM
 	if pubErr := s.retryProducer.PublishWithHashKey(context.WithoutCancel(ctx), workMsg.SubtreeHash, data); pubErr != nil {
 		return fmt.Errorf("re-publishing subtree work message for retry: %w", pubErr)
 	}
+	metrics.IncSubtreeWork(metrics.OutcomeRetried)
 	// Intentionally do NOT decrement on retry — only success or DLQ counts.
 	return nil
 }

--- a/internal/block/subtree_worker.go
+++ b/internal/block/subtree_worker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bsv-blockchain/merkle-service/internal/kafka"
 	"github.com/bsv-blockchain/merkle-service/internal/logfields"
 	"github.com/bsv-blockchain/merkle-service/internal/metrics"
+	"github.com/bsv-blockchain/merkle-service/internal/retryutil"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
 	"github.com/bsv-blockchain/merkle-service/internal/ssrfguard"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
@@ -187,6 +188,8 @@ func (s *SubtreeWorkerService) Init(_ interface{}) error {
 		"subtreeWorkTopic", s.kafkaCfg.SubtreeWorkTopic,
 		"subtreeWorkDLQTopic", dlqTopic,
 		"maxAttempts", s.maxAttempts(),
+		"retryBackoffBaseMs", s.blockCfg.RetryBackoffBaseMs,
+		"notFoundMaxAttempts", s.notFoundMaxAttempts(),
 		"regCacheEnabled", s.regCache != nil,
 		"regCacheMaxMB", s.blockCfg.RegCacheMaxMB,
 		"batchGetConcurrency", s.blockCfg.BatchGetConcurrency,
@@ -243,6 +246,42 @@ func (s *SubtreeWorkerService) maxAttempts() int {
 		return s.blockCfg.MaxAttempts
 	}
 	return 10
+}
+
+// notFoundMaxAttempts is the reduced retry budget for DataHub 404s (see
+// BlockConfig.NotFoundMaxAttempts): teranode's asset cache prunes subtree
+// data after ~2h, so a late 404 is effectively permanent and burning the full
+// maxAttempts budget on it only amplifies the outage. Mirrors maxAttempts'
+// zero-value handling so struct-literal test configs get the default.
+func (s *SubtreeWorkerService) notFoundMaxAttempts() int {
+	if s.blockCfg.NotFoundMaxAttempts > 0 {
+		return s.blockCfg.NotFoundMaxAttempts
+	}
+	return 3
+}
+
+// workerRetryBackoffCap bounds the worker's exponential retry backoff at 5s —
+// deliberately below the fetcher's 30s cap (internal/subtree). Two reasons:
+// the fetcher's default 3-attempt budget never reaches its cap (schedule tops
+// out at 4s) while the worker's 10-attempt budget would LIVE at one; and the
+// consumer's processBatch runs 50-record chunks with no intra-chunk quit
+// check, draining the whole in-flight chunk on graceful revoke without ctx
+// cancellation — at 30s/record a chunk of failing records sleeps ~25 minutes
+// against rebalanceTimeout=5m and the member is fenced, unobservably so,
+// because partitionsLost runs on the poll goroutine, which is blocked
+// dispatching into the sleeping partition's depth-5 channel. At 5s the
+// worst-case chunk is ~4.2 minutes, under the rebalance window.
+const workerRetryBackoffCap = 5 * time.Second
+
+// retryBackoff returns how long to wait before retry attempt `attempt`
+// (1-based): Block.RetryBackoffBaseMs doubling per attempt, capped at
+// workerRetryBackoffCap. 0 when the backoff is disabled (base <= 0, or a
+// struct-literal test cfg). At the default base the 10-attempt budget spans
+// ~37s of deliberate wait (1s/2s/4s/5s/5s…) plus one backlog traversal per
+// republish — during the 2026-07-15 scale-ovh incident the same budget
+// burned in milliseconds, amplifying the DataHub-404 storm ~10x.
+func (s *SubtreeWorkerService) retryBackoff(attempt int) time.Duration {
+	return retryutil.Backoff(s.blockCfg.RetryBackoffBaseMs, attempt, workerRetryBackoffCap)
 }
 
 // handleMessage consumes a single SubtreeWorkMessage.
@@ -395,11 +434,25 @@ func isPermanentFetchErr(err error) bool {
 	return errors.Is(err, ssrfguard.ErrInvalidURL) || errors.Is(err, ssrfguard.ErrBlockedAddress)
 }
 
-// handleTransientFailure either re-publishes the work item to subtree-work for
-// retry or, once max attempts is reached OR the failure is permanent for the
-// work item's DataHub URL (isPermanentFetchErr), parks it on subtree-work-dlq
-// and decrements the counter so BLOCK_PROCESSED can still fire (with a missing
+// handleTransientFailure either re-publishes the work item to subtree-work
+// for retry (after an exponential backoff — see retryBackoff) or, once max
+// attempts is reached OR the DataHub-404 budget is exhausted
+// (notFoundMaxAttempts) OR the failure is permanent for the work item's
+// DataHub URL (isPermanentFetchErr), parks it on subtree-work-dlq and
+// decrements the counter so BLOCK_PROCESSED can still fire (with a missing
 // STUMP that arcade will surface as a BUMP build error rather than silent loss).
+//
+// Full-disk failures are the exception to all of the above: they are an
+// operational condition, not bad data, so they never consume the retry
+// budget, never decrement the counter, and never route to the DLQ (which has
+// no replay — the fetcher learned this on dev-ovh-1, where a 15-minute
+// ENOSPC window dead-lettered 1,406 subtrees). Instead the work item is
+// PARKED: an error is returned, the consumer doesn't advance past the
+// record, and topic retention keeps it safe in Kafka until the disk
+// recovers. Caveat: an outage longer than aerospike.subtreeCounterTTLSec
+// expires the per-block counter, and recovery then hits the
+// ErrCounterNotFound ACK+ALERT path — those blocks need a /reprocess (see
+// the openspec design doc).
 //
 // On the DLQ branch the counter is decremented BEFORE the DLQ publish. If the
 // decrement fails (counter-store transient hiccup), we return the error so the
@@ -411,19 +464,57 @@ func isPermanentFetchErr(err error) bool {
 // which is deduplicated by the receiver, while the DLQ publish either
 // eventually succeeds or surfaces as a sustained loud-error log.
 func (s *SubtreeWorkerService) handleTransientFailure(ctx context.Context, workMsg *kafka.SubtreeWorkMessage, cause error) error {
+	if retryutil.IsDiskFull(cause) {
+		s.Logger.Warn(
+			"blob store full; parking subtree work item in Kafka until space recovers (never DLQ)",
+			logfields.SubtreeHash(workMsg.SubtreeHash),
+			logfields.BlockHash(workMsg.BlockHash),
+			logfields.SubtreeIndex(workMsg.SubtreeIndex),
+			"attemptCount", workMsg.AttemptCount,
+			"error", cause,
+		)
+		metrics.IncSubtreeWork(metrics.OutcomeParkedDiskFull)
+		// Throttle the redelivery loop; AttemptCount is not bumped (the
+		// message is never re-published), so this stays near the base delay
+		// per redelivery on top of the consumer's own rewind backoff.
+		_ = retryutil.Wait(ctx, s.retryBackoff(workMsg.AttemptCount+1))
+		return fmt.Errorf("blob store full, parking subtree work item for redelivery: %w", cause)
+	}
+
 	nextAttempt := workMsg.AttemptCount + 1
 	maxAttempts := s.maxAttempts()
+	// DataHub 404s get a REDUCED budget rather than the fetcher's immediate
+	// DLQ: worker subtrees provably existed at announcement time (the block
+	// referenced them), so a short retry can outlive a single peer's cache
+	// prune — but teranode's asset cache drops subtree data after ~2h, so a
+	// persistent 404 is permanent and must not burn the full budget.
+	// maxAttempts below stays an independent clause: a misconfigured
+	// notFoundMaxAttempts > maxAttempts can never EXTEND the budget.
+	notFoundExhausted := errors.Is(cause, datahub.ErrNotFound) && nextAttempt >= s.notFoundMaxAttempts()
 
-	if nextAttempt >= maxAttempts || isPermanentFetchErr(cause) {
+	if nextAttempt >= maxAttempts || notFoundExhausted || isPermanentFetchErr(cause) {
+		var reason string
+		switch {
+		case isPermanentFetchErr(cause):
+			reason = "permanent_fetch_error"
+		case notFoundExhausted:
+			reason = "not_found_attempts_exhausted"
+		default:
+			reason = "max_attempts"
+		}
 		s.Logger.Error(
-			"subtree work item exceeded max attempts, routing to DLQ",
+			"subtree work item retries exhausted, routing to DLQ",
 			logfields.SubtreeHash(workMsg.SubtreeHash),
 			logfields.BlockHash(workMsg.BlockHash),
 			logfields.SubtreeIndex(workMsg.SubtreeIndex),
 			"attemptCount", workMsg.AttemptCount,
 			"maxAttempts", maxAttempts,
+			"reason", reason,
 			"error", cause,
 		)
+		// This branch is terminal and deliberately sleep-free: backing off
+		// before a DLQ hand-off would only delay BLOCK_PROCESSED.
+		//
 		// Decrement FIRST so a counter-store hiccup aborts before we publish to
 		// the DLQ — otherwise every redelivery while the counter store is
 		// degraded would publish another DLQ duplicate.
@@ -457,6 +548,7 @@ func (s *SubtreeWorkerService) handleTransientFailure(ctx context.Context, workM
 		return nil
 	}
 
+	backoff := s.retryBackoff(nextAttempt)
 	s.Logger.Warn(
 		"subtree work item transient failure, re-publishing for retry",
 		logfields.SubtreeHash(workMsg.SubtreeHash),
@@ -464,8 +556,17 @@ func (s *SubtreeWorkerService) handleTransientFailure(ctx context.Context, workM
 		logfields.SubtreeIndex(workMsg.SubtreeIndex),
 		"attemptCount", workMsg.AttemptCount,
 		"nextAttempt", nextAttempt,
+		"backoffMs", backoff.Milliseconds(),
 		"error", cause,
 	)
+	// Wait BEFORE the hand-off so the retry budget spans real time (1s/2s/4s/
+	// 5s… rather than back-to-back republish→refetch cycles). An interrupted
+	// wait (shutdown, lost partition) returns an error without publishing: the
+	// unacked original is redelivered, so nothing is lost, duplicated, or
+	// double-counted by aborting here.
+	if waitErr := retryutil.Wait(ctx, backoff); waitErr != nil {
+		return fmt.Errorf("interrupted while backing off before subtree work retry: %w", waitErr)
+	}
 	workMsg.AttemptCount = nextAttempt
 	data, encErr := workMsg.Encode()
 	if encErr != nil {

--- a/internal/block/subtree_worker_backpressure_test.go
+++ b/internal/block/subtree_worker_backpressure_test.go
@@ -3,16 +3,35 @@ package block
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 
 	"github.com/bsv-blockchain/merkle-service/internal/config"
+	"github.com/bsv-blockchain/merkle-service/internal/datahub"
 	"github.com/bsv-blockchain/merkle-service/internal/kafka"
 	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 )
+
+// enospcErr is what a full filesystem actually returns from a blob write: an
+// *fs.PathError wrapping syscall.ENOSPC, further wrapped by the store layer.
+// Mirrors internal/subtree/processor_backpressure_test.go.
+func enospcErr() error {
+	return fmt.Errorf("writing blob: %w", &fs.PathError{Op: "write", Path: "/data/stumps/ab/cd.stump", Err: syscall.ENOSPC})
+}
+
+// notFoundErr mimics the worker's real 404 chain: datahub wraps ErrNotFound
+// with %w at the 404 site, and intermediate stages wrap again.
+func notFoundErr() error {
+	return fmt.Errorf("fetching subtree from datahub: %w",
+		fmt.Errorf("%w: http://peer.example.test/subtree/aa (HTTP 404)", datahub.ErrNotFound))
+}
 
 // subtreeWorkCount returns the current value of the named outcome counter on
 // merkle_subtree_work_messages_total. Tests assert on deltas against a
@@ -100,5 +119,312 @@ func TestWorkerHandleTransientFailure_CountsDLQOutcome(t *testing.T) {
 	}
 	if got := counter.decrementCount(); got != 1 {
 		t.Errorf("expected exactly 1 counter decrement on DLQ, got %d", got)
+	}
+}
+
+// --- retry backoff schedule ---
+
+// TestWorkerRetryBackoff_ExponentialWithCap pins the worker's backoff
+// schedule: base doubling per attempt, capped at workerRetryBackoffCap (5s,
+// NOT the fetcher's 30s — the worker's 10-attempt budget would live at a
+// bigger cap and a failing 50-record consumer chunk would sleep past the
+// group's 5m rebalance timeout and get the member fenced).
+func TestWorkerRetryBackoff_ExponentialWithCap(t *testing.T) {
+	s := &SubtreeWorkerService{blockCfg: config.BlockConfig{RetryBackoffBaseMs: 1000}}
+
+	cases := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{1, 1 * time.Second},
+		{2, 2 * time.Second},
+		{3, 4 * time.Second},
+		{4, 5 * time.Second},  // 8s capped at 5s
+		{10, 5 * time.Second}, // deep in the budget, still 5s
+		{50, 5 * time.Second}, // shift overflow guard
+	}
+	for _, tc := range cases {
+		if got := s.retryBackoff(tc.attempt); got != tc.want {
+			t.Errorf("retryBackoff(%d) = %v, want %v", tc.attempt, got, tc.want)
+		}
+	}
+
+	// 0 disables (struct-literal test configs keep existing tests sleep-free).
+	s.blockCfg.RetryBackoffBaseMs = 0
+	if got := s.retryBackoff(3); got != 0 {
+		t.Errorf("retryBackoff with base 0 = %v, want 0 (disabled)", got)
+	}
+}
+
+// --- backoff-before-retry ---
+
+// TestWorkerHandleTransientFailure_BacksOffBeforeRetry verifies a transient
+// failure waits its backoff before re-publishing, so the bounded retry budget
+// spans real time instead of burning out in milliseconds (the 2026-07-15
+// scale-ovh amplification).
+func TestWorkerHandleTransientFailure_BacksOffBeforeRetry(t *testing.T) {
+	retryMock := &callbackFailingProducer{}
+	dlqMock := &callbackFailingProducer{}
+	counter := newCountingSubtreeCounter()
+	svc := newWorkerForTransientFailure(t, retryMock, dlqMock, counter,
+		config.BlockConfig{MaxAttempts: 5, RetryBackoffBaseMs: 60})
+
+	// AttemptCount 1 -> next attempt 2 -> base*2 = 120ms.
+	msg := &kafka.SubtreeWorkMessage{BlockHash: "blk-backoff", SubtreeHash: "aa33", AttemptCount: 1}
+	begin := time.Now()
+	if err := svc.handleTransientFailure(context.Background(), msg, errors.New("blip")); err != nil {
+		t.Fatalf("handleTransientFailure: %v", err)
+	}
+	if elapsed := time.Since(begin); elapsed < 120*time.Millisecond {
+		t.Errorf("retry republished after %v, want >= 120ms backoff (attempt 2, base 60ms)", elapsed)
+	}
+	if got := retryMock.sentCount(); got != 1 {
+		t.Errorf("expected 1 retry publish after backoff, got %d", got)
+	}
+	if got := dlqMock.sentCount(); got != 0 {
+		t.Errorf("expected 0 DLQ publishes, got %d", got)
+	}
+	if got := counter.decrementCount(); got != 0 {
+		t.Errorf("expected 0 counter decrements on retry, got %d", got)
+	}
+}
+
+// TestWorkerHandleTransientFailure_BackoffAbortsOnContextCancel verifies a
+// canceled consumer context (shutdown, lost partition) interrupts the backoff
+// and surfaces an error WITHOUT re-publishing — the unacked original is
+// redelivered instead, so nothing is lost or duplicated by the abort.
+func TestWorkerHandleTransientFailure_BackoffAbortsOnContextCancel(t *testing.T) {
+	retryMock := &callbackFailingProducer{}
+	dlqMock := &callbackFailingProducer{}
+	counter := newCountingSubtreeCounter()
+	svc := newWorkerForTransientFailure(t, retryMock, dlqMock, counter,
+		config.BlockConfig{MaxAttempts: 5, RetryBackoffBaseMs: 60_000})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	msg := &kafka.SubtreeWorkMessage{BlockHash: "blk-backoff-cancel", SubtreeHash: "aa44"}
+	begin := time.Now()
+	err := svc.handleTransientFailure(ctx, msg, errors.New("blip"))
+	if err == nil {
+		t.Fatal("expected an error when the backoff is interrupted by context cancellation")
+	}
+	if elapsed := time.Since(begin); elapsed > 5*time.Second {
+		t.Fatalf("backoff did not abort on cancel (took %v)", elapsed)
+	}
+	if got := retryMock.sentCount(); got != 0 {
+		t.Errorf("expected no retry publish after interrupted backoff, got %d", got)
+	}
+	if got := dlqMock.sentCount(); got != 0 {
+		t.Errorf("expected no DLQ publish after interrupted backoff, got %d", got)
+	}
+}
+
+// --- disk-full parking ---
+
+// TestWorkerHandleTransientFailure_DiskFullNeverDLQs is the worker-side
+// regression test for the ENOSPC data loss the fetcher fixed in v0.4.6: a
+// full disk is an operational condition, not bad data, so it must never
+// consume the retry budget, never decrement the per-block counter, and never
+// route to subtree-work-dlq (from which there is no replay). The handler
+// surfaces an error, the consumer parks the message by not advancing past it,
+// and Kafka retention keeps it safe until the disk recovers.
+func TestWorkerHandleTransientFailure_DiskFullNeverDLQs(t *testing.T) {
+	retryMock := &callbackFailingProducer{}
+	dlqMock := &callbackFailingProducer{}
+	counter := newCountingSubtreeCounter()
+	svc := newWorkerForTransientFailure(t, retryMock, dlqMock, counter,
+		config.BlockConfig{MaxAttempts: 3, RetryBackoffBaseMs: 1})
+
+	// AttemptCount 2 with MaxAttempts 3: an ordinary transient failure would
+	// DLQ right here. Disk-full must not.
+	msg := &kafka.SubtreeWorkMessage{BlockHash: "blk-diskfull", SubtreeHash: "aa55", AttemptCount: 2}
+	beforeParked := subtreeWorkCount(metrics.OutcomeParkedDiskFull)
+	err := svc.handleTransientFailure(context.Background(), msg, enospcErr())
+	if err == nil {
+		t.Fatal("expected an error so the consumer parks the message (no ack, no advance)")
+	}
+	if !errors.Is(err, syscall.ENOSPC) {
+		t.Errorf("returned error should wrap the ENOSPC cause, got: %v", err)
+	}
+	if got := dlqMock.sentCount(); got != 0 {
+		t.Errorf("disk-full must never DLQ, got %d DLQ publishes", got)
+	}
+	if got := retryMock.sentCount(); got != 0 {
+		t.Errorf("disk-full must not burn the retry budget, got %d retry publishes", got)
+	}
+	if got := counter.decrementCount(); got != 0 {
+		t.Errorf("disk-full must not decrement the per-block counter, got %d decrements", got)
+	}
+	if msg.AttemptCount != 2 {
+		t.Errorf("AttemptCount mutated to %d, want unchanged 2 (parked, not retried)", msg.AttemptCount)
+	}
+	if got := subtreeWorkCount(metrics.OutcomeParkedDiskFull) - beforeParked; got != 1 {
+		t.Errorf("parked_disk_full outcome delta = %d, want 1", got)
+	}
+}
+
+// TestWorkerHandleTransientFailure_DiskQuotaMessageNeverDLQs covers
+// quota-style full-filesystem errors that arrive as text (e.g. from a store
+// layer that did not preserve the errno chain).
+func TestWorkerHandleTransientFailure_DiskQuotaMessageNeverDLQs(t *testing.T) {
+	retryMock := &callbackFailingProducer{}
+	dlqMock := &callbackFailingProducer{}
+	counter := newCountingSubtreeCounter()
+	svc := newWorkerForTransientFailure(t, retryMock, dlqMock, counter,
+		config.BlockConfig{MaxAttempts: 3, RetryBackoffBaseMs: 1})
+
+	for _, cause := range []error{
+		errors.New("mkdir /data/stumps/ab: disk quota exceeded"),
+		errors.New("write /data/stumps/ab/cd.stump: no space left on device"),
+	} {
+		msg := &kafka.SubtreeWorkMessage{BlockHash: "blk-quota", SubtreeHash: "aa66", AttemptCount: 2}
+		if err := svc.handleTransientFailure(context.Background(), msg, cause); err == nil {
+			t.Errorf("cause %q: expected parking error, got nil", cause)
+		}
+	}
+	if got := dlqMock.sentCount(); got != 0 {
+		t.Errorf("quota-style disk-full must never DLQ, got %d", got)
+	}
+	if got := retryMock.sentCount(); got != 0 {
+		t.Errorf("quota-style disk-full must not retry-publish, got %d", got)
+	}
+	if got := counter.decrementCount(); got != 0 {
+		t.Errorf("quota-style disk-full must not decrement, got %d", got)
+	}
+}
+
+// TestHandleMessage_DiskFullOnStumpPut_ParksMessage drives the incident path
+// end to end: subtree processing succeeds, the STUMP blob write fails with
+// ENOSPC, and handleMessage must surface an error (parking the message)
+// without touching the DLQ, the retry topic, or the counter. This pins that
+// ENOSPC survives the publishSubtreeCallbacks error wrap.
+func TestHandleMessage_DiskFullOnStumpPut_ParksMessage(t *testing.T) {
+	cbMock := &callbackFailingProducer{}
+	retryMock := &callbackFailingProducer{}
+	dlqMock := &callbackFailingProducer{}
+
+	counter := newCountingSubtreeCounter()
+	stumpStore := &stubStumpStore{putErr: enospcErr()}
+
+	subtreePayload := buildRawSubtreeBytes(t, 2)
+	server := rawSubtreeServer(subtreePayload)
+	defer server.Close()
+
+	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, 3)
+
+	// AttemptCount = maxAttempts-1: an ordinary transient failure would DLQ
+	// right here; disk-full must park instead.
+	value := makeWorkMessageBytes(t, "block-diskfull-e2e", contentAddressOf(t, subtreePayload), server.URL, 2)
+	if err := svc.handleMessage(context.Background(), &kafka.Message{Value: value}); err == nil {
+		t.Fatal("expected handleMessage to return an error so the consumer does not advance past the message")
+	}
+	if stumpStore.puts == 0 {
+		t.Fatal("stump store was never written — test did not reach the STUMP Put stage")
+	}
+	if got := dlqMock.sentCount(); got != 0 {
+		t.Errorf("expected 0 DLQ publishes on disk-full, got %d", got)
+	}
+	if got := retryMock.sentCount(); got != 0 {
+		t.Errorf("expected 0 retry publishes on disk-full, got %d", got)
+	}
+	if got := counter.decrementCount(); got != 0 {
+		t.Errorf("expected 0 counter decrements on disk-full, got %d", got)
+	}
+}
+
+// --- DataHub 404 reduced budget ---
+
+// TestWorkerHandleTransientFailure_NotFound_ReducedBudgetDLQs verifies a
+// datahub.ErrNotFound failure DLQs once AttemptCount+1 reaches
+// notFoundMaxAttempts — well before block.maxAttempts. Teranode's asset cache
+// prunes subtree data after ~2h, so a late 404 is effectively permanent;
+// burning the full 10-attempt budget on it amplified the scale-ovh 404 storm.
+func TestWorkerHandleTransientFailure_NotFound_ReducedBudgetDLQs(t *testing.T) {
+	retryMock := &callbackFailingProducer{}
+	dlqMock := &callbackFailingProducer{}
+	counter := newCountingSubtreeCounter()
+	_ = counter.Init("blk-nf-dlq", 2, nil)
+	svc := newWorkerForTransientFailure(t, retryMock, dlqMock, counter,
+		config.BlockConfig{MaxAttempts: 10, NotFoundMaxAttempts: 3, RetryBackoffBaseMs: 1})
+
+	// AttemptCount 2 -> next attempt 3 >= notFoundMaxAttempts 3 -> DLQ,
+	// even though maxAttempts (10) is nowhere near exhausted.
+	msg := &kafka.SubtreeWorkMessage{BlockHash: "blk-nf-dlq", SubtreeHash: "aa77", AttemptCount: 2}
+	if err := svc.handleTransientFailure(context.Background(), msg, notFoundErr()); err != nil {
+		t.Fatalf("handleTransientFailure: expected nil after DLQ hand-off, got: %v", err)
+	}
+	if got := dlqMock.sentCount(); got != 1 {
+		t.Errorf("expected exactly 1 DLQ publish at not-found budget, got %d", got)
+	}
+	if got := retryMock.sentCount(); got != 0 {
+		t.Errorf("expected 0 retry publishes at not-found budget, got %d", got)
+	}
+	// Terminal: BLOCK_PROCESSED must still be able to fire — counter MUST be
+	// decremented exactly once.
+	if got := counter.decrementCount(); got != 1 {
+		t.Errorf("expected exactly 1 counter decrement on not-found DLQ, got %d", got)
+	}
+}
+
+// TestWorkerHandleTransientFailure_NotFound_BelowBudgetRetriesWithBackoff
+// verifies a 404 below the reduced budget still retries (with its backoff):
+// worker subtrees provably existed at announcement time, so a short retry can
+// win — unlike the fetcher, which DLQs announcement-time 404s immediately.
+func TestWorkerHandleTransientFailure_NotFound_BelowBudgetRetriesWithBackoff(t *testing.T) {
+	retryMock := &callbackFailingProducer{}
+	dlqMock := &callbackFailingProducer{}
+	counter := newCountingSubtreeCounter()
+	svc := newWorkerForTransientFailure(t, retryMock, dlqMock, counter,
+		config.BlockConfig{MaxAttempts: 10, NotFoundMaxAttempts: 3, RetryBackoffBaseMs: 60})
+
+	// AttemptCount 0 -> next attempt 1 < notFoundMaxAttempts 3 -> retry after
+	// base*1 = 60ms.
+	msg := &kafka.SubtreeWorkMessage{BlockHash: "blk-nf-retry", SubtreeHash: "aa88", AttemptCount: 0}
+	begin := time.Now()
+	if err := svc.handleTransientFailure(context.Background(), msg, notFoundErr()); err != nil {
+		t.Fatalf("handleTransientFailure: %v", err)
+	}
+	if elapsed := time.Since(begin); elapsed < 60*time.Millisecond {
+		t.Errorf("not-found retry republished after %v, want >= 60ms backoff (attempt 1, base 60ms)", elapsed)
+	}
+	if got := retryMock.sentCount(); got != 1 {
+		t.Errorf("expected 1 retry publish below not-found budget, got %d", got)
+	}
+	if got := dlqMock.sentCount(); got != 0 {
+		t.Errorf("expected 0 DLQ publishes below not-found budget, got %d", got)
+	}
+	if got := counter.decrementCount(); got != 0 {
+		t.Errorf("expected 0 counter decrements on retry, got %d", got)
+	}
+}
+
+// TestWorkerHandleTransientFailure_NotFoundBudgetCappedByMaxAttempts pins the
+// hard ceiling: maxAttempts stays an independent DLQ clause, so a
+// misconfigured notFoundMaxAttempts > maxAttempts cannot extend the budget.
+func TestWorkerHandleTransientFailure_NotFoundBudgetCappedByMaxAttempts(t *testing.T) {
+	retryMock := &callbackFailingProducer{}
+	dlqMock := &callbackFailingProducer{}
+	counter := newCountingSubtreeCounter()
+	_ = counter.Init("blk-nf-cap", 2, nil)
+	svc := newWorkerForTransientFailure(t, retryMock, dlqMock, counter,
+		config.BlockConfig{MaxAttempts: 3, NotFoundMaxAttempts: 20, RetryBackoffBaseMs: 1})
+
+	// AttemptCount 2 -> next attempt 3 >= maxAttempts 3 -> DLQ under the
+	// maxAttempts clause despite the (misconfigured) not-found budget of 20.
+	msg := &kafka.SubtreeWorkMessage{BlockHash: "blk-nf-cap", SubtreeHash: "aa99", AttemptCount: 2}
+	if err := svc.handleTransientFailure(context.Background(), msg, notFoundErr()); err != nil {
+		t.Fatalf("handleTransientFailure: expected nil after DLQ hand-off, got: %v", err)
+	}
+	if got := dlqMock.sentCount(); got != 1 {
+		t.Errorf("expected exactly 1 DLQ publish at the maxAttempts ceiling, got %d", got)
+	}
+	if got := retryMock.sentCount(); got != 0 {
+		t.Errorf("expected 0 retry publishes at the maxAttempts ceiling, got %d", got)
+	}
+	if got := counter.decrementCount(); got != 1 {
+		t.Errorf("expected exactly 1 counter decrement, got %d", got)
 	}
 }

--- a/internal/block/subtree_worker_backpressure_test.go
+++ b/internal/block/subtree_worker_backpressure_test.go
@@ -1,0 +1,104 @@
+package block
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/bsv-blockchain/merkle-service/internal/config"
+	"github.com/bsv-blockchain/merkle-service/internal/kafka"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
+)
+
+// subtreeWorkCount returns the current value of the named outcome counter on
+// merkle_subtree_work_messages_total. Tests assert on deltas against a
+// pre-call snapshot since the underlying Prometheus counter is process-global
+// and accumulates across tests.
+func subtreeWorkCount(outcome string) int64 {
+	return int64(testutil.ToFloat64(metrics.SubtreeWorkMessagesTotal.WithLabelValues(outcome)))
+}
+
+// newWorkerForTransientFailure builds the minimal SubtreeWorkerService needed
+// to drive handleTransientFailure directly: block config, counter, and the
+// (retry, dlq) producers. The callback producer stays nil — the DLQ branch's
+// decrement can still run because countingSubtreeCounter is pre-seeded above
+// zero, so no BLOCK_PROCESSED emission is triggered.
+func newWorkerForTransientFailure(
+	t *testing.T,
+	retry, dlq kafka.Publisher,
+	counter *countingSubtreeCounter,
+	blockCfg config.BlockConfig,
+) *SubtreeWorkerService {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	s := &SubtreeWorkerService{
+		blockCfg:       blockCfg,
+		subtreeCounter: counter,
+	}
+	s.InitBase("subtree-worker-backpressure-test")
+	s.Logger = logger
+	s.retryProducer = kafka.NewTestProducer(retry, "subtree-work-test", logger)
+	s.dlqProducer = kafka.NewTestProducer(dlq, "subtree-work-dlq-test", logger)
+	return s
+}
+
+// TestWorkerHandleTransientFailure_CountsRetriedOutcome pins the visibility
+// the 2026-07-15 incident lacked: every retry republish increments
+// merkle_subtree_work_messages_total{outcome="retried"}.
+func TestWorkerHandleTransientFailure_CountsRetriedOutcome(t *testing.T) {
+	retryMock := &callbackFailingProducer{}
+	dlqMock := &callbackFailingProducer{}
+	counter := newCountingSubtreeCounter()
+	svc := newWorkerForTransientFailure(t, retryMock, dlqMock, counter,
+		config.BlockConfig{MaxAttempts: 5})
+
+	msg := &kafka.SubtreeWorkMessage{BlockHash: "blk-metric-retry", SubtreeHash: "aa11", AttemptCount: 0}
+	before := subtreeWorkCount(metrics.OutcomeRetried)
+	if err := svc.handleTransientFailure(context.Background(), msg, errors.New("blip")); err != nil {
+		t.Fatalf("handleTransientFailure: %v", err)
+	}
+	if got := subtreeWorkCount(metrics.OutcomeRetried) - before; got != 1 {
+		t.Errorf("retried outcome delta = %d, want 1", got)
+	}
+	if got := retryMock.sentCount(); got != 1 {
+		t.Errorf("expected 1 retry publish, got %d", got)
+	}
+	if got := dlqMock.sentCount(); got != 0 {
+		t.Errorf("expected 0 DLQ publishes, got %d", got)
+	}
+}
+
+// TestWorkerHandleTransientFailure_CountsDLQOutcome pins the terminal branch:
+// a max-attempts DLQ hand-off increments outcome="dlq".
+func TestWorkerHandleTransientFailure_CountsDLQOutcome(t *testing.T) {
+	retryMock := &callbackFailingProducer{}
+	dlqMock := &callbackFailingProducer{}
+	counter := newCountingSubtreeCounter()
+	// Pre-seed above zero so the DLQ-branch decrement does not reach the
+	// BLOCK_PROCESSED emit path (callback producer is nil in this harness).
+	_ = counter.Init("blk-metric-dlq", 2, nil)
+	svc := newWorkerForTransientFailure(t, retryMock, dlqMock, counter,
+		config.BlockConfig{MaxAttempts: 3})
+
+	msg := &kafka.SubtreeWorkMessage{BlockHash: "blk-metric-dlq", SubtreeHash: "aa22", AttemptCount: 2}
+	before := subtreeWorkCount(metrics.OutcomeDLQ)
+	if err := svc.handleTransientFailure(context.Background(), msg, errors.New("blip")); err != nil {
+		t.Fatalf("handleTransientFailure: %v", err)
+	}
+	if got := subtreeWorkCount(metrics.OutcomeDLQ) - before; got != 1 {
+		t.Errorf("dlq outcome delta = %d, want 1", got)
+	}
+	if got := dlqMock.sentCount(); got != 1 {
+		t.Errorf("expected 1 DLQ publish, got %d", got)
+	}
+	if got := retryMock.sentCount(); got != 0 {
+		t.Errorf("expected 0 retry publishes, got %d", got)
+	}
+	if got := counter.decrementCount(); got != 1 {
+		t.Errorf("expected exactly 1 counter decrement on DLQ, got %d", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -440,6 +440,24 @@ type BlockConfig struct {
 	// can fire — at that point arcade will see a missing STUMP for that subtree
 	// and surface it as a BUMP build error rather than silently going stale.
 	MaxAttempts int `yaml:"maxAttempts" mapstructure:"maxattempts"`
+	// RetryBackoffBaseMs is the base delay before a transiently-failed subtree
+	// work item is re-published to subtree-work; it doubles per attempt and is
+	// capped at 5s (deliberately below the fetcher's 30s — the worker's
+	// 10-attempt budget would live at a higher cap and a failing 50-record
+	// consumer chunk would sleep past the group's 5m rebalance timeout).
+	// Without it the whole MaxAttempts budget burned in milliseconds per item,
+	// which is how the 2026-07-15 scale-ovh DataHub-404 storm was amplified
+	// ~10x by immediate republishes. Default 1000. 0 disables the backoff
+	// (unit tests; not recommended in production).
+	RetryBackoffBaseMs int `yaml:"retryBackoffBaseMs" mapstructure:"retrybackoffbasems"`
+	// NotFoundMaxAttempts caps the retry budget for work items whose failure
+	// is a DataHub 404 (datahub.ErrNotFound). Worker subtrees provably existed
+	// at announcement time, but teranode's asset cache prunes subtree data
+	// after ~2h — a late 404 is effectively permanent, and burning the full
+	// MaxAttempts budget on it only amplified the scale-ovh 404 storm.
+	// MaxAttempts remains a hard ceiling regardless of this value. Default 3.
+	// <= 0 selects the default.
+	NotFoundMaxAttempts int `yaml:"notFoundMaxAttempts" mapstructure:"notfoundmaxattempts"`
 	// RegCacheMaxMB sizes the in-process registration deduplication cache used
 	// by block-time subtree processing. Same shape as Subtree.CacheMaxMB but
 	// independent so all-in-one and microservice topologies behave identically.
@@ -649,6 +667,12 @@ func registerDefaults(v *viper.Viper) {
 	v.SetDefault("block.postminettlsec", 1800)
 	v.SetDefault("block.dedupcachesize", 10000)
 	v.SetDefault("block.maxattempts", 10)
+	// 1s base, doubling per attempt (cap 5s): a 10-attempt budget spans ~37s
+	// of deliberate wait (plus per-republish backlog traversal) instead of
+	// milliseconds — see BlockConfig.RetryBackoffBaseMs.
+	v.SetDefault("block.retrybackoffbasems", 1000)
+	// Reduced budget for DataHub 404s (see BlockConfig.NotFoundMaxAttempts).
+	v.SetDefault("block.notfoundmaxattempts", 3)
 	v.SetDefault("block.regcachemaxmb", 64)
 	v.SetDefault("block.batchgetconcurrency", 4)
 
@@ -808,6 +832,8 @@ func bindEnvVars(v *viper.Viper) {
 		"block.postminettlsec":      "BLOCK_POST_MINE_TTL_SEC",
 		"block.dedupcachesize":      "BLOCK_DEDUP_CACHE_SIZE",
 		"block.maxattempts":         "BLOCK_MAX_ATTEMPTS",
+		"block.retrybackoffbasems":  "BLOCK_RETRY_BACKOFF_BASE_MS",
+		"block.notfoundmaxattempts": "BLOCK_NOT_FOUND_MAX_ATTEMPTS",
 		"block.regcachemaxmb":       "BLOCK_REG_CACHE_MAX_MB",
 		"block.batchgetconcurrency": "BLOCK_BATCH_GET_CONCURRENCY",
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -39,6 +39,7 @@ func clearConfigEnv(t *testing.T) {
 		"SUBTREE_STORAGE_MODE", "SUBTREE_DAH_OFFSET", "SUBTREE_CACHE_MAX_MB",
 		"SUBTREE_MAX_ATTEMPTS",
 		"BLOCK_WORKER_POOL_SIZE", "BLOCK_POST_MINE_TTL_SEC",
+		"BLOCK_RETRY_BACKOFF_BASE_MS", "BLOCK_NOT_FOUND_MAX_ATTEMPTS",
 		"CALLBACK_MAX_RETRIES", "CALLBACK_BACKOFF_BASE_SEC",
 		"CALLBACK_TIMEOUT_SEC", "CALLBACK_SEEN_THRESHOLD",
 		"BLOB_STORE_URL",
@@ -141,6 +142,12 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.Block.PostMineTTLSec != 1800 {
 		t.Errorf("Block.PostMineTTLSec: expected 1800, got %d", cfg.Block.PostMineTTLSec)
 	}
+	if cfg.Block.RetryBackoffBaseMs != 1000 {
+		t.Errorf("Block.RetryBackoffBaseMs: expected 1000, got %d", cfg.Block.RetryBackoffBaseMs)
+	}
+	if cfg.Block.NotFoundMaxAttempts != 3 {
+		t.Errorf("Block.NotFoundMaxAttempts: expected 3, got %d", cfg.Block.NotFoundMaxAttempts)
+	}
 
 	// Callback defaults
 	if cfg.Callback.MaxRetries != 5 {
@@ -194,6 +201,8 @@ func TestLoad_EnvOverrides(t *testing.T) {
 	_ = os.Setenv("SUBTREE_MAX_ATTEMPTS", "7")
 	_ = os.Setenv("BLOCK_WORKER_POOL_SIZE", "32")
 	_ = os.Setenv("BLOCK_POST_MINE_TTL_SEC", "3600")
+	_ = os.Setenv("BLOCK_RETRY_BACKOFF_BASE_MS", "250")
+	_ = os.Setenv("BLOCK_NOT_FOUND_MAX_ATTEMPTS", "5")
 	_ = os.Setenv("CALLBACK_MAX_RETRIES", "10")
 	_ = os.Setenv("CALLBACK_BACKOFF_BASE_SEC", "60")
 	_ = os.Setenv("CALLBACK_TIMEOUT_SEC", "20")
@@ -251,6 +260,12 @@ func TestLoad_EnvOverrides(t *testing.T) {
 	}
 	if cfg.Block.WorkerPoolSize != 32 {
 		t.Errorf("Block.WorkerPoolSize: expected 32, got %d", cfg.Block.WorkerPoolSize)
+	}
+	if cfg.Block.RetryBackoffBaseMs != 250 {
+		t.Errorf("Block.RetryBackoffBaseMs: expected 250, got %d", cfg.Block.RetryBackoffBaseMs)
+	}
+	if cfg.Block.NotFoundMaxAttempts != 5 {
+		t.Errorf("Block.NotFoundMaxAttempts: expected 5, got %d", cfg.Block.NotFoundMaxAttempts)
 	}
 	if cfg.Callback.MaxRetries != 10 {
 		t.Errorf("Callback.MaxRetries: expected 10, got %d", cfg.Callback.MaxRetries)

--- a/internal/metrics/block.go
+++ b/internal/metrics/block.go
@@ -1,0 +1,30 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// SubtreeWorkMessagesTotal counts subtree work items flowing through the
+// subtree-worker's retry pipeline, classified by outcome (OutcomeRetried,
+// OutcomeDLQ, OutcomeParkedDiskFull). This is the per-outcome visibility the
+// 2026-07-15 scale-ovh incident lacked: an immediate-republish storm was only
+// diagnosable from raw consumer lag, because retries, DLQ hand-offs, and
+// their causes were invisible in metrics.
+var SubtreeWorkMessagesTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "merkle_subtree_work_messages_total",
+		Help: "Subtree work items handled by the subtree-worker retry pipeline, classified by outcome.",
+	},
+	[]string{labelOutcome},
+)
+
+func init() {
+	Registry.MustRegister(
+		SubtreeWorkMessagesTotal,
+	)
+}
+
+// IncSubtreeWork records one subtree-work retry-pipeline outcome.
+func IncSubtreeWork(outcome string) {
+	SubtreeWorkMessagesTotal.WithLabelValues(outcome).Inc()
+}

--- a/internal/retryutil/retryutil.go
+++ b/internal/retryutil/retryutil.go
@@ -1,0 +1,83 @@
+// Package retryutil holds the retry-backpressure primitives shared by the
+// subtree-fetcher (internal/subtree) and the subtree-worker (internal/block):
+// an exponential backoff schedule, a context-aware wait, and full-filesystem
+// error classification.
+//
+// Extracted (rather than copied) chiefly for IsDiskFull: its errno-plus-text
+// matching is exactly the kind of list that silently forks when duplicated —
+// one site learns a new quota spelling, the other keeps dead-lettering. The
+// backoff cap is a parameter, not a constant, because the two call sites
+// deliberately differ: the fetcher's 3-attempt budget rides a 30s cap, while
+// the worker's 10-attempt budget must stay at 5s so a failing 50-record
+// consumer chunk (drained without a quit check on graceful revoke) cannot
+// sleep past the group's 5m rebalance timeout and get the member fenced.
+//
+// This package intentionally imports nothing from internal/ so any retry
+// path can use it without cycle risk.
+package retryutil
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// Backoff returns how long to wait before retry attempt `attempt` (1-based):
+// baseMs doubling per attempt, capped at maxBackoff. Returns 0 when the
+// backoff is disabled (baseMs <= 0, e.g. a struct-literal test config).
+// Attempts < 1 are treated as 1; attempts past the shift-overflow horizon
+// (> 30) saturate at maxBackoff, as does any doubled value that exceeds it.
+func Backoff(baseMs, attempt int, maxBackoff time.Duration) time.Duration {
+	if baseMs <= 0 {
+		return 0
+	}
+	base := time.Duration(baseMs) * time.Millisecond
+	if attempt < 1 {
+		attempt = 1
+	}
+	// Doubling past attempt ~32 overflows the shift; anything that far in is
+	// at the cap regardless.
+	if attempt > 30 {
+		return maxBackoff
+	}
+	d := base << uint(attempt-1)
+	if d > maxBackoff || d <= 0 {
+		return maxBackoff
+	}
+	return d
+}
+
+// Wait sleeps for d, returning early with ctx.Err() when the context dies
+// first (shutdown, lost partition — see the kafka consumer's partitions-lost
+// cancellation). d <= 0 returns immediately with nil.
+func Wait(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// IsDiskFull reports whether err is a full-filesystem condition: ENOSPC (via
+// the wrapped errno chain) or a quota/space error that only survived as text.
+// Callers treat these as operational conditions — park the message under
+// Kafka retention, never burn the retry budget, never DLQ.
+func IsDiskFull(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.ENOSPC) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "no space left on device") ||
+		strings.Contains(msg, "disk quota exceeded")
+}

--- a/internal/retryutil/retryutil_test.go
+++ b/internal/retryutil/retryutil_test.go
@@ -1,0 +1,120 @@
+package retryutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestBackoff_ExponentialWithCap pins the schedule shape shared by the
+// subtree-fetcher (30s cap) and the subtree-worker (5s cap): base doubling
+// per 1-based attempt, saturating at the caller's cap.
+func TestBackoff_ExponentialWithCap(t *testing.T) {
+	cases := []struct {
+		name       string
+		baseMs     int
+		attempt    int
+		maxBackoff time.Duration
+		want       time.Duration
+	}{
+		{"attempt 1", 1000, 1, 30 * time.Second, 1 * time.Second},
+		{"attempt 2", 1000, 2, 30 * time.Second, 2 * time.Second},
+		{"attempt 3", 1000, 3, 30 * time.Second, 4 * time.Second},
+		{"attempt 6 capped", 1000, 6, 30 * time.Second, 30 * time.Second}, // 32s capped
+		{"shift overflow guard", 1000, 50, 30 * time.Second, 30 * time.Second},
+		{"worker cap 5s at attempt 4", 1000, 4, 5 * time.Second, 5 * time.Second}, // 8s capped
+		{"worker cap 5s below cap", 1000, 3, 5 * time.Second, 4 * time.Second},
+		{"attempt < 1 treated as 1", 1000, 0, 30 * time.Second, 1 * time.Second},
+	}
+	for _, tc := range cases {
+		if got := Backoff(tc.baseMs, tc.attempt, tc.maxBackoff); got != tc.want {
+			t.Errorf("%s: Backoff(%d, %d, %v) = %v, want %v",
+				tc.name, tc.baseMs, tc.attempt, tc.maxBackoff, got, tc.want)
+		}
+	}
+}
+
+// TestBackoff_NonPositiveBaseDisables pins the contract every struct-literal
+// test config relies on: base <= 0 disables the backoff entirely.
+func TestBackoff_NonPositiveBaseDisables(t *testing.T) {
+	if got := Backoff(0, 3, 30*time.Second); got != 0 {
+		t.Errorf("Backoff with base 0 = %v, want 0 (disabled)", got)
+	}
+	if got := Backoff(-1, 3, 30*time.Second); got != 0 {
+		t.Errorf("Backoff with base -1 = %v, want 0 (disabled)", got)
+	}
+}
+
+func TestWait_NonPositiveReturnsImmediately(t *testing.T) {
+	begin := time.Now()
+	if err := Wait(context.Background(), 0); err != nil {
+		t.Fatalf("Wait(ctx, 0): %v", err)
+	}
+	if err := Wait(context.Background(), -time.Second); err != nil {
+		t.Fatalf("Wait(ctx, -1s): %v", err)
+	}
+	if elapsed := time.Since(begin); elapsed > time.Second {
+		t.Errorf("non-positive Wait took %v, want immediate return", elapsed)
+	}
+}
+
+func TestWait_CompletesAfterDuration(t *testing.T) {
+	begin := time.Now()
+	if err := Wait(context.Background(), 30*time.Millisecond); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if elapsed := time.Since(begin); elapsed < 30*time.Millisecond {
+		t.Errorf("Wait returned after %v, want >= 30ms", elapsed)
+	}
+}
+
+func TestWait_AbortsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	begin := time.Now()
+	err := Wait(ctx, time.Minute)
+	if err == nil {
+		t.Fatal("expected ctx error when the wait is interrupted by cancellation")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Wait returned %v, want context.Canceled", err)
+	}
+	if elapsed := time.Since(begin); elapsed > 5*time.Second {
+		t.Fatalf("Wait did not abort on cancel (took %v)", elapsed)
+	}
+}
+
+// TestIsDiskFull covers the full-filesystem matrix: the errno chain a blob
+// store preserves, the text-only variants one that doesn't, and the negative
+// cases that must keep flowing through the ordinary retry budget.
+func TestIsDiskFull(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"bare ENOSPC", syscall.ENOSPC, true},
+		{
+			"wrapped fs.PathError ENOSPC",
+			fmt.Errorf("writing blob: %w", &fs.PathError{Op: "write", Path: "/data/x", Err: syscall.ENOSPC}),
+			true,
+		},
+		{"no-space text", errors.New("write /data/x: no space left on device"), true},
+		{"quota text", errors.New("mkdir /data/y: disk quota exceeded"), true},
+		{"unrelated error", errors.New("aerospike timeout"), false},
+		{"unrelated errno", &fs.PathError{Op: "write", Path: "/data/x", Err: syscall.EACCES}, false},
+	}
+	for _, tc := range cases {
+		if got := IsDiskFull(tc.err); got != tc.want {
+			t.Errorf("%s: IsDiskFull(%v) = %v, want %v", tc.name, tc.err, got, tc.want)
+		}
+	}
+}

--- a/internal/subtree/processor.go
+++ b/internal/subtree/processor.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
-	"syscall"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -17,6 +15,7 @@ import (
 	"github.com/bsv-blockchain/merkle-service/internal/kafka"
 	"github.com/bsv-blockchain/merkle-service/internal/logfields"
 	"github.com/bsv-blockchain/merkle-service/internal/metrics"
+	"github.com/bsv-blockchain/merkle-service/internal/retryutil"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
 	"github.com/bsv-blockchain/merkle-service/internal/ssrfguard"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
@@ -443,54 +442,23 @@ const subtreeRetryBackoffCap = 30 * time.Second
 // ~300ms against a disk that stayed full for 15 minutes — retries must span
 // real time to have any chance of outliving the condition they're retrying.
 func (p *Processor) retryBackoff(attempt int) time.Duration {
-	if p.cfg == nil || p.cfg.Subtree.RetryBackoffBaseMs <= 0 {
+	if p.cfg == nil {
 		return 0
 	}
-	base := time.Duration(p.cfg.Subtree.RetryBackoffBaseMs) * time.Millisecond
-	if attempt < 1 {
-		attempt = 1
-	}
-	// Doubling past attempt ~32 overflows the shift; anything that far in is
-	// at the cap regardless.
-	if attempt > 30 {
-		return subtreeRetryBackoffCap
-	}
-	d := base << uint(attempt-1)
-	if d > subtreeRetryBackoffCap || d <= 0 {
-		return subtreeRetryBackoffCap
-	}
-	return d
+	return retryutil.Backoff(p.cfg.Subtree.RetryBackoffBaseMs, attempt, subtreeRetryBackoffCap)
 }
 
 // waitBackoff sleeps for d, returning early with ctx.Err() when the context
 // dies first (shutdown, lost partition — see the kafka consumer's
 // partitions-lost cancellation). d <= 0 returns immediately.
 func waitBackoff(ctx context.Context, d time.Duration) error {
-	if d <= 0 {
-		return nil
-	}
-	t := time.NewTimer(d)
-	defer t.Stop()
-	select {
-	case <-t.C:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+	return retryutil.Wait(ctx, d)
 }
 
 // isDiskFull reports whether err is a full-filesystem condition: ENOSPC (via
 // the wrapped errno chain) or a quota/space error that only survived as text.
 func isDiskFull(err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, syscall.ENOSPC) {
-		return true
-	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "no space left on device") ||
-		strings.Contains(msg, "disk quota exceeded")
+	return retryutil.IsDiskFull(err)
 }
 
 // handleTransientFailure bumps AttemptCount and either re-publishes the

--- a/openspec/changes/subtree-worker-retry-backpressure/.openspec.yaml
+++ b/openspec/changes/subtree-worker-retry-backpressure/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/subtree-worker-retry-backpressure/design.md
+++ b/openspec/changes/subtree-worker-retry-backpressure/design.md
@@ -1,0 +1,123 @@
+# Design: subtree-worker retry backpressure
+
+## Context
+
+`internal/block/subtree_worker.go` consumes `subtree-work` (one message per subtree per
+block) on a per-partition serial worker (`internal/kafka/consumer.go`). On transient
+failure, `handleTransientFailure` either re-publishes the item with `AttemptCount+1`
+(retry) or, at `block.maxAttempts` / on a permanent SSRF-classified URL, decrements the
+per-block subtree counter and publishes to `subtree-work-dlq` (terminal). The counter is
+decremented exactly once per work item — success or DLQ, never retry — which is what
+lets BLOCK_PROCESSED still fire when a subtree's retries exhaust.
+
+The fetcher (`internal/subtree/processor.go`) already solved the same three problems for
+the `subtree` topic in v0.4.6: exponential backoff (`retryBackoff`/`waitBackoff`),
+ENOSPC parking (`isDiskFull`), and permanent-failure classification. This change ports
+that shape to the worker without disturbing the counter contract.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Retry republishes span real time instead of burning the budget in milliseconds.
+- A full disk never dead-letters work items (the DLQ has no replay).
+- Deterministically-stale 404s stop consuming the full 10-attempt budget.
+- Per-outcome counter metric for the worker retry path.
+- Zero behavior change for the fetcher; zero-value config keeps existing worker tests
+  (and any struct-literal construction) backoff-free.
+
+**Non-Goals:**
+
+- Changing consumer semantics (chunked commits, rewind, rebalance handling).
+- DLQ replay tooling.
+- Raising `aerospike.subtreeCounterTTLSec` (flagged as an owner decision, out of scope).
+
+## Decisions
+
+### 1. Worker backoff cap = 5s, NOT the fetcher's 30s
+
+The fetcher's default budget (`subtree.maxAttempts=3`) never reaches its 30s cap — its
+schedule tops out at 4s. The worker's (`block.maxAttempts=10`) would *live* at a 30s
+cap. That interacts badly with the consumer's chunked dispatch:
+
+- `processBatch` runs 50-record chunks with no intra-chunk quit check, and a graceful
+  revoke drains the whole in-flight chunk without context cancellation.
+- At 30s/record, a chunk of failing records sleeps ~25 minutes against
+  `rebalanceTimeout = 5m` → the member is fenced. Worse, a fenced member cannot even
+  observe the fencing promptly: `partitionsLost` runs on the poll goroutine, which is
+  blocked dispatching into the sleeping partition's depth-5 channel.
+- A **5s cap** bounds the worst-case chunk at ~4.2 minutes — under the 5m rebalance
+  window.
+
+Schedule at the default base (1000ms): 1s, 2s, 4s, 5s, 5s, … ≈ 37s of deliberate wait
+across a 10-attempt life. Each republish also re-traverses the partition backlog before
+its next attempt, so the real spread during an incident is minutes — enough for a
+dependency blip to clear, and it removes the ~10× immediate-republish amplification.
+
+The cap is a *parameter* of `retryutil.Backoff` (not a package constant), so the fetcher
+keeps `subtreeRetryBackoffCap = 30s` locally and the worker declares
+`workerRetryBackoffCap = 5s` next to the consumer-semantics comment that justifies it.
+
+### 2. Extract `internal/retryutil` instead of copying
+
+The strongest argument is `IsDiskFull`: ENOSPC via `errors.Is` **plus** a string match
+list ("no space left on device", "disk quota exceeded") for store layers that drop the
+errno chain. A copied list silently forks the moment one site learns a new spelling.
+`retryutil` imports nothing internal (stdlib only), so there is no cycle risk from
+either `internal/subtree` or `internal/block`. The fetcher keeps one-line wrapper
+methods (`retryBackoff`, `waitBackoff`, `isDiskFull`) so its existing tests — including
+`processor_backpressure_test.go` — pass unmodified, which is the zero-behavior-change
+gate for the refactor.
+
+### 3. Disk-full parks BEFORE attempt accounting, and never touches the counter
+
+The park branch sits at the top of `handleTransientFailure`, before `nextAttempt` is
+computed: WARN + `merkle_subtree_work_messages_total{outcome="parked_disk_full"}` + a
+context-aware throttle sleep (`retryBackoff(AttemptCount+1)`) + **return the error**.
+No AttemptCount bump (the message is never re-published), no counter decrement, no DLQ.
+The consumer does not advance past the record; its rewind/redeliver cycle (~1.5–2s per
+partition on top of the throttle) retries under topic retention until the disk recovers.
+
+**Counter-TTL caveat (runbook item):** parking relies on the per-block subtree counter
+still existing when the disk recovers. An ENOSPC outage that leaves a block's counter
+untouched for longer than `aerospike.subtreeCounterTTLSec` (7200 on dev-ovh-1) expires
+it; on recovery the parked items' decrements hit the existing `ErrCounterNotFound`
+ACK+ALERT path, and those blocks need a manual `POST /api/v1/blocks/{hash}/reprocess`
+to rebuild the counter and re-emit BLOCK_PROCESSED. This is strictly better than
+today's behavior (the same outage currently dead-letters the items un-replayably AND
+still loses BLOCK_PROCESSED coordination), but operators must know the recovery step.
+Widening the TTL is a separate owner decision.
+
+### 4. 404s get a reduced budget with a hard ceiling — not the fetcher's immediate DLQ
+
+The fetcher DLQs a DataHub 404 immediately (`handlePermanentFailure`): at announcement
+time, a peer 404ing a subtree it just announced is lying. The worker deliberately
+diverges: its subtrees **provably existed** at announcement time (the block referenced
+them), so a 404 here is usually cache pruning on one peer — a short retry can win via
+another attempt window, but retrying 10 times cannot. `block.notFoundMaxAttempts`
+(default 3) bounds the budget for `errors.Is(cause, datahub.ErrNotFound)`.
+
+`nextAttempt >= maxAttempts` stays an **independent** clause of the DLQ condition, so a
+misconfigured `notFoundMaxAttempts > maxAttempts` can never extend the overall budget.
+
+### 5. Backoff waits before the republish, and an interrupted wait publishes nothing
+
+`retryutil.Wait(ctx, backoff)` runs BEFORE the AttemptCount bump/encode/publish. The
+ctx is the per-partition worker context, canceled on partitions-lost — a sleeping
+handler aborts promptly instead of finishing a hand-off for a partition another member
+owns. An interrupted wait returns an error without publishing: the unacked original is
+redelivered, so nothing is lost or double-counted. The DLQ branch stays sleep-free
+(it's terminal; delaying it only delays BLOCK_PROCESSED).
+
+## Risks / Trade-offs
+
+- **Wider fetch→commit window** slightly raises the pre-existing odds of a
+  duplicate republish around a rebalance (at-least-once). Absorbed by receiver-side
+  dedup; tests must not assume exactly-once.
+- **Consumer lag during outages is now expected.** `subtree-work` lag alerts fire
+  during a long dependency outage where previously items would have burned to the DLQ
+  quickly. This is the intended trade: lag is recoverable, the DLQ is not.
+- **Parked messages hold their partition.** One disk-full worker parks all partitions
+  it owns; that is exactly the fetcher's accepted semantics (a full disk is
+  process-wide anyway).
+- **Counter TTL vs long outages** — see decision 3; documented runbook step, not code.

--- a/openspec/changes/subtree-worker-retry-backpressure/proposal.md
+++ b/openspec/changes/subtree-worker-retry-backpressure/proposal.md
@@ -1,0 +1,65 @@
+# Harden the subtree-worker retry path
+
+## Why
+
+During the 2026-07-15 scale-ovh incident the subtree-worker's retry path amplified a
+DataHub-404 storm roughly 10×: `handleTransientFailure` re-publishes failed work items to
+`subtree-work` **immediately** — no backoff — so the full `block.maxAttempts` budget (10)
+burns in milliseconds per item, each attempt re-fanning load onto the already-failing
+dependency. The subtree-fetcher gained an exponential retry backoff for exactly this
+failure shape (`subtree.retryBackoffBaseMs`, dev-ovh-1 ENOSPC incident); the worker never
+did.
+
+Two sibling gaps live in the same function:
+
+1. **Disk-full dead-letters.** A full blob store (STUMP `Put` returning ENOSPC) is
+   treated as an ordinary transient failure, so after the retry budget it lands on
+   `subtree-work-dlq` — which has no replay. The fetcher got ENOSPC "parking" (ride out
+   the outage under Kafka retention, never DLQ) in v0.4.6; the worker was deferred.
+2. **Late 404s are permanent but retried forever.** Teranode's asset cache prunes
+   subtree data after ~2h, so a DataHub 404 on an old work item can never succeed —
+   yet it burns the full 10-attempt budget like any other blip.
+
+## What Changes
+
+- Extract the fetcher's backoff/wait/disk-full helpers into a new `internal/retryutil`
+  package (zero behavior change for the fetcher) so the two retry paths cannot silently
+  fork — especially `IsDiskFull`'s errno-plus-text matching.
+- `handleTransientFailure` in the subtree-worker:
+  - waits an exponential, context-aware backoff before every retry republish
+    (`block.retryBackoffBaseMs`, default 1000ms, capped at **5s** — see design.md for
+    why not the fetcher's 30s);
+  - **parks** work items on disk-full: WARN + metric + throttle, no AttemptCount bump,
+    no counter decrement, no DLQ — the unacked message rides out the outage under
+    Kafka retention;
+  - routes DataHub 404s to the DLQ after a reduced budget
+    (`block.notFoundMaxAttempts`, default 3), hard-ceilinged by `block.maxAttempts`.
+- New counter `merkle_subtree_work_messages_total{outcome}` (retried / dlq /
+  parked_disk_full) — the per-outcome visibility the incident lacked.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `block-processing`: subtree-work retry hand-offs gain backoff, disk-full parking, and
+  a bounded not-found budget.
+
+## Impact
+
+- **`internal/retryutil`** (new): `Backoff`, `Wait`, `IsDiskFull` lifted from
+  `internal/subtree/processor.go`; the fetcher keeps thin wrappers so its behavior and
+  tests are byte-for-byte unchanged.
+- **`internal/config/config.go` / `config.yaml`**: `block.retryBackoffBaseMs`
+  (`BLOCK_RETRY_BACKOFF_BASE_MS`), `block.notFoundMaxAttempts`
+  (`BLOCK_NOT_FOUND_MAX_ATTEMPTS`).
+- **`internal/metrics/block.go`** (new): `merkle_subtree_work_messages_total`.
+- **`internal/block/subtree_worker.go`**: `handleTransientFailure` gains the park
+  branch, the not-found DLQ clause, and the pre-publish backoff wait.
+- **Operational**: retries for a failing item now span real time (≈37s across a
+  10-attempt life at defaults, plus per-republish backlog traversal), so
+  `subtree-work` consumer lag during dependency outages is expected and healthy —
+  see design.md for the counter-TTL runbook caveat.

--- a/openspec/changes/subtree-worker-retry-backpressure/specs/block-processing/spec.md
+++ b/openspec/changes/subtree-worker-retry-backpressure/specs/block-processing/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Subtree-work retries back off exponentially
+The subtree-worker SHALL wait an exponential, context-aware backoff before re-publishing
+a transiently-failed work item to `subtree-work`: `block.retryBackoffBaseMs` doubling
+per attempt, capped at 5 seconds. A backoff of 0 (base <= 0) disables the wait. The
+backoff MUST run before the AttemptCount bump and the republish, and an interrupted
+wait (canceled consumer context) MUST surface an error without publishing so the
+unacked original is redelivered.
+
+#### Scenario: Transient failure retries after backoff
+- **WHEN** a work item fails transiently below the retry budget with retryBackoffBaseMs 1000
+- **THEN** the worker waits 1s, 2s, 4s, 5s, 5s… (per attempt) before each republish, and the retry publish carries AttemptCount+1
+
+#### Scenario: Backoff aborts on context cancellation
+- **WHEN** the consumer context is canceled while a retry backoff is in progress
+- **THEN** the worker returns an error without re-publishing, and the original message is redelivered
+
+#### Scenario: Zero base disables backoff
+- **WHEN** block.retryBackoffBaseMs is 0 or unset (struct-literal test configs)
+- **THEN** retries republish immediately, preserving pre-existing behavior
+
+### Requirement: Disk-full work items are parked, never dead-lettered
+The subtree-worker SHALL treat a full-filesystem failure (ENOSPC or quota/space text) as
+an operational condition: log a warning, count `parked_disk_full`, throttle, and return
+an error WITHOUT bumping AttemptCount, decrementing the per-block subtree counter, or
+publishing to `subtree-work-dlq`. The unacked message stays in Kafka under topic
+retention until the disk recovers.
+
+#### Scenario: ENOSPC on STUMP blob write parks the work item
+- **WHEN** the STUMP store Put fails with an error chain containing syscall.ENOSPC, even at maxAttempts-1
+- **THEN** the worker publishes nothing to any topic, leaves AttemptCount and the subtree counter untouched, and returns an error so the consumer redelivers
+
+#### Scenario: Quota-style text errors park too
+- **WHEN** a failure arrives as text ("no space left on device", "disk quota exceeded") without an errno chain
+- **THEN** the work item is parked exactly as for ENOSPC
+
+### Requirement: DataHub 404s consume a reduced retry budget
+The subtree-worker SHALL route a work item whose failure chain matches
+`datahub.ErrNotFound` to the DLQ once `AttemptCount+1 >= block.notFoundMaxAttempts`
+(default 3), decrementing the per-block subtree counter exactly once as on any DLQ
+hand-off. The overall `block.maxAttempts` ceiling SHALL remain an independent DLQ
+condition so a misconfigured notFoundMaxAttempts cannot extend the budget.
+
+#### Scenario: Not-found exhausts its reduced budget
+- **WHEN** a work item at AttemptCount 2 fails with a DataHub 404 and notFoundMaxAttempts is 3
+- **THEN** the item is published to subtree-work-dlq and the counter is decremented exactly once
+
+#### Scenario: Not-found below budget retries with backoff
+- **WHEN** a work item at AttemptCount 0 fails with a DataHub 404
+- **THEN** it is re-published for retry after its backoff, with no DLQ publish and no counter decrement
+
+#### Scenario: maxAttempts remains a hard ceiling
+- **WHEN** notFoundMaxAttempts is misconfigured above maxAttempts and a 404 item reaches AttemptCount maxAttempts-1
+- **THEN** the item routes to the DLQ under the maxAttempts clause
+
+### Requirement: Subtree-work retry outcomes are observable
+The worker SHALL expose `merkle_subtree_work_messages_total` with an `outcome` label
+(`retried`, `dlq`, `parked_disk_full`) incremented on each corresponding
+`handleTransientFailure` branch.
+
+#### Scenario: Outcomes counted per branch
+- **WHEN** a work item is re-published for retry, routed to the DLQ, or parked on disk-full
+- **THEN** the counter increments with outcome retried, dlq, or parked_disk_full respectively

--- a/openspec/changes/subtree-worker-retry-backpressure/tasks.md
+++ b/openspec/changes/subtree-worker-retry-backpressure/tasks.md
@@ -15,12 +15,12 @@
 
 ## 4. Worker retry path
 
-- [ ] 4.1 `workerRetryBackoffCap = 5s` const + `retryBackoff(attempt)` / `notFoundMaxAttempts()` helpers on `SubtreeWorkerService`; log both new settings from `Init`
-- [ ] 4.2 Park branch at the top of `handleTransientFailure`: `retryutil.IsDiskFull(cause)` → WARN + `parked_disk_full` + throttle wait + return error (no AttemptCount bump, no decrement, no DLQ)
-- [ ] 4.3 DLQ condition gains `notFoundExhausted` (`errors.Is(cause, datahub.ErrNotFound) && nextAttempt >= notFoundMaxAttempts()`) as an independent clause alongside `maxAttempts` and `isPermanentFetchErr`; add a `reason` field to the DLQ log; branch body (decrement-before-DLQ) unchanged and sleep-free
-- [ ] 4.4 Retry branch waits `retryutil.Wait(ctx, retryBackoff(nextAttempt))` BEFORE the AttemptCount bump/encode/publish; interrupted wait returns an error without publishing; add `backoffMs` to the retry WARN log
+- [x] 4.1 `workerRetryBackoffCap = 5s` const + `retryBackoff(attempt)` / `notFoundMaxAttempts()` helpers on `SubtreeWorkerService`; log both new settings from `Init`
+- [x] 4.2 Park branch at the top of `handleTransientFailure`: `retryutil.IsDiskFull(cause)` → WARN + `parked_disk_full` + throttle wait + return error (no AttemptCount bump, no decrement, no DLQ)
+- [x] 4.3 DLQ condition gains `notFoundExhausted` (`errors.Is(cause, datahub.ErrNotFound) && nextAttempt >= notFoundMaxAttempts()`) as an independent clause alongside `maxAttempts` and `isPermanentFetchErr`; add a `reason` field to the DLQ log; branch body (decrement-before-DLQ) unchanged and sleep-free
+- [x] 4.4 Retry branch waits `retryutil.Wait(ctx, retryBackoff(nextAttempt))` BEFORE the AttemptCount bump/encode/publish; interrupted wait returns an error without publishing; add `backoffMs` to the retry WARN log
 
 ## 5. Tests
 
-- [ ] 5.1 `internal/block/subtree_worker_backpressure_test.go`: backoff schedule pins the 5s cap; wall-clock backoff-before-retry; ctx-cancel abort; ENOSPC + quota-text parking (no DLQ, no decrement, AttemptCount unchanged, metric delta); e2e disk-full park via `stubStumpStore{putErr: enospcErr()}`; not-found reduced-budget DLQ + below-budget retry + budget capped by maxAttempts
-- [ ] 5.2 Existing worker tests pass unmodified (zero-value config disables backoff); `go build ./...`, `go test ./... -count=1`, `-race` on internal/kafka + internal/block + internal/subtree, `golangci-lint run` all green
+- [x] 5.1 `internal/block/subtree_worker_backpressure_test.go`: backoff schedule pins the 5s cap; wall-clock backoff-before-retry; ctx-cancel abort; ENOSPC + quota-text parking (no DLQ, no decrement, AttemptCount unchanged, metric delta); e2e disk-full park via `stubStumpStore{putErr: enospcErr()}`; not-found reduced-budget DLQ + below-budget retry + budget capped by maxAttempts
+- [x] 5.2 Existing worker tests pass unmodified (zero-value config disables backoff); `go build ./...`, `go test ./... -count=1`, `-race` on internal/kafka + internal/block + internal/subtree, `golangci-lint run` all green

--- a/openspec/changes/subtree-worker-retry-backpressure/tasks.md
+++ b/openspec/changes/subtree-worker-retry-backpressure/tasks.md
@@ -1,7 +1,7 @@
 ## 1. retryutil extraction (zero behavior change)
 
-- [ ] 1.1 Create `internal/retryutil` with `Backoff(baseMs, attempt int, maxBackoff time.Duration) time.Duration` (exponential, 1-based attempt, 0 when baseMs<=0, shift-overflow guard → maxBackoff), `Wait(ctx, d) error` (ctx-aware timer, d<=0 → nil), and `IsDiskFull(err) bool` (ENOSPC via errors.Is + "no space left on device"/"disk quota exceeded" text match); unit tests for schedule/cap/overflow/disable, Wait cancellation, and the IsDiskFull matrix
-- [ ] 1.2 Refactor `internal/subtree/processor.go` `retryBackoff`/`waitBackoff`/`isDiskFull` into one-line wrappers over retryutil, keeping `subtreeRetryBackoffCap = 30s` local; `processor_backpressure_test.go` passes UNMODIFIED
+- [x] 1.1 Create `internal/retryutil` with `Backoff(baseMs, attempt int, maxBackoff time.Duration) time.Duration` (exponential, 1-based attempt, 0 when baseMs<=0, shift-overflow guard → maxBackoff), `Wait(ctx, d) error` (ctx-aware timer, d<=0 → nil), and `IsDiskFull(err) bool` (ENOSPC via errors.Is + "no space left on device"/"disk quota exceeded" text match); unit tests for schedule/cap/overflow/disable, Wait cancellation, and the IsDiskFull matrix
+- [x] 1.2 Refactor `internal/subtree/processor.go` `retryBackoff`/`waitBackoff`/`isDiskFull` into one-line wrappers over retryutil, keeping `subtreeRetryBackoffCap = 30s` local; `processor_backpressure_test.go` passes UNMODIFIED
 
 ## 2. Configuration
 

--- a/openspec/changes/subtree-worker-retry-backpressure/tasks.md
+++ b/openspec/changes/subtree-worker-retry-backpressure/tasks.md
@@ -10,8 +10,8 @@
 
 ## 3. Metrics
 
-- [ ] 3.1 New `internal/metrics/block.go`: `SubtreeWorkMessagesTotal` CounterVec (`merkle_subtree_work_messages_total`, label `outcome`) + `IncSubtreeWork(outcome)`, reusing the existing outcome label constants
-- [ ] 3.2 Increment `retried` / `dlq` on the worker's two existing `handleTransientFailure` branches, with tests pinning the deltas
+- [x] 3.1 New `internal/metrics/block.go`: `SubtreeWorkMessagesTotal` CounterVec (`merkle_subtree_work_messages_total`, label `outcome`) + `IncSubtreeWork(outcome)`, reusing the existing outcome label constants
+- [x] 3.2 Increment `retried` / `dlq` on the worker's two existing `handleTransientFailure` branches, with tests pinning the deltas
 
 ## 4. Worker retry path
 

--- a/openspec/changes/subtree-worker-retry-backpressure/tasks.md
+++ b/openspec/changes/subtree-worker-retry-backpressure/tasks.md
@@ -1,0 +1,26 @@
+## 1. retryutil extraction (zero behavior change)
+
+- [ ] 1.1 Create `internal/retryutil` with `Backoff(baseMs, attempt int, maxBackoff time.Duration) time.Duration` (exponential, 1-based attempt, 0 when baseMs<=0, shift-overflow guard → maxBackoff), `Wait(ctx, d) error` (ctx-aware timer, d<=0 → nil), and `IsDiskFull(err) bool` (ENOSPC via errors.Is + "no space left on device"/"disk quota exceeded" text match); unit tests for schedule/cap/overflow/disable, Wait cancellation, and the IsDiskFull matrix
+- [ ] 1.2 Refactor `internal/subtree/processor.go` `retryBackoff`/`waitBackoff`/`isDiskFull` into one-line wrappers over retryutil, keeping `subtreeRetryBackoffCap = 30s` local; `processor_backpressure_test.go` passes UNMODIFIED
+
+## 2. Configuration
+
+- [ ] 2.1 Add `RetryBackoffBaseMs` (mapstructure `retrybackoffbasems`) and `NotFoundMaxAttempts` (`notfoundmaxattempts`) to `config.BlockConfig` with incident-referencing doc comments
+- [ ] 2.2 Defaults `block.retrybackoffbasems=1000`, `block.notfoundmaxattempts=3`; env bindings `BLOCK_RETRY_BACKOFF_BASE_MS`, `BLOCK_NOT_FOUND_MAX_ATTEMPTS`; document both in `config.yaml`
+
+## 3. Metrics
+
+- [ ] 3.1 New `internal/metrics/block.go`: `SubtreeWorkMessagesTotal` CounterVec (`merkle_subtree_work_messages_total`, label `outcome`) + `IncSubtreeWork(outcome)`, reusing the existing outcome label constants
+- [ ] 3.2 Increment `retried` / `dlq` on the worker's two existing `handleTransientFailure` branches, with tests pinning the deltas
+
+## 4. Worker retry path
+
+- [ ] 4.1 `workerRetryBackoffCap = 5s` const + `retryBackoff(attempt)` / `notFoundMaxAttempts()` helpers on `SubtreeWorkerService`; log both new settings from `Init`
+- [ ] 4.2 Park branch at the top of `handleTransientFailure`: `retryutil.IsDiskFull(cause)` → WARN + `parked_disk_full` + throttle wait + return error (no AttemptCount bump, no decrement, no DLQ)
+- [ ] 4.3 DLQ condition gains `notFoundExhausted` (`errors.Is(cause, datahub.ErrNotFound) && nextAttempt >= notFoundMaxAttempts()`) as an independent clause alongside `maxAttempts` and `isPermanentFetchErr`; add a `reason` field to the DLQ log; branch body (decrement-before-DLQ) unchanged and sleep-free
+- [ ] 4.4 Retry branch waits `retryutil.Wait(ctx, retryBackoff(nextAttempt))` BEFORE the AttemptCount bump/encode/publish; interrupted wait returns an error without publishing; add `backoffMs` to the retry WARN log
+
+## 5. Tests
+
+- [ ] 5.1 `internal/block/subtree_worker_backpressure_test.go`: backoff schedule pins the 5s cap; wall-clock backoff-before-retry; ctx-cancel abort; ENOSPC + quota-text parking (no DLQ, no decrement, AttemptCount unchanged, metric delta); e2e disk-full park via `stubStumpStore{putErr: enospcErr()}`; not-found reduced-budget DLQ + below-budget retry + budget capped by maxAttempts
+- [ ] 5.2 Existing worker tests pass unmodified (zero-value config disables backoff); `go build ./...`, `go test ./... -count=1`, `-race` on internal/kafka + internal/block + internal/subtree, `golangci-lint run` all green

--- a/openspec/changes/subtree-worker-retry-backpressure/tasks.md
+++ b/openspec/changes/subtree-worker-retry-backpressure/tasks.md
@@ -5,8 +5,8 @@
 
 ## 2. Configuration
 
-- [ ] 2.1 Add `RetryBackoffBaseMs` (mapstructure `retrybackoffbasems`) and `NotFoundMaxAttempts` (`notfoundmaxattempts`) to `config.BlockConfig` with incident-referencing doc comments
-- [ ] 2.2 Defaults `block.retrybackoffbasems=1000`, `block.notfoundmaxattempts=3`; env bindings `BLOCK_RETRY_BACKOFF_BASE_MS`, `BLOCK_NOT_FOUND_MAX_ATTEMPTS`; document both in `config.yaml`
+- [x] 2.1 Add `RetryBackoffBaseMs` (mapstructure `retrybackoffbasems`) and `NotFoundMaxAttempts` (`notfoundmaxattempts`) to `config.BlockConfig` with incident-referencing doc comments
+- [x] 2.2 Defaults `block.retrybackoffbasems=1000`, `block.notfoundmaxattempts=3`; env bindings `BLOCK_RETRY_BACKOFF_BASE_MS`, `BLOCK_NOT_FOUND_MAX_ATTEMPTS`; document both in `config.yaml`
 
 ## 3. Metrics
 


### PR DESCRIPTION
## Incident follow-up

Closes out the worker-retry weaknesses from the 2026-07-15 dev-ovh-1 incident (follow-up flagged in #186). The subtree-worker re-published failed work items with no delay, so `block.maxAttempts` (10) burned in milliseconds per item — during the DataHub-404 storm this amplified queue load ~10×. Two sibling gaps in the same path: a disk-full STUMP/blob write dead-lettered items to the un-replayable `subtree-work-dlq`, and 404s consumed the full 10-attempt budget even though teranode's asset cache prunes subtree data after ~2h (making persistent 404s permanent).

## Changes (one commit each)

1. **`internal/retryutil` (new)** — `Backoff`/`Wait`/`IsDiskFull` extracted from the subtree fetcher; the fetcher keeps thin wrappers and its 30s cap. Zero behavior change: `processor_backpressure_test.go` passes unmodified. Extraction motivated by `IsDiskFull`'s string list being the code most likely to silently fork.
2. **Config** — `block.retryBackoffBaseMs` (default 1000, 0 disables) and `block.notFoundMaxAttempts` (default 3), with env overrides.
3. **Metrics** — `merkle_subtree_work_messages_total{outcome}` (retried / dlq / parked_disk_full): the per-outcome visibility the incident lacked.
4. **Worker** (`internal/block/subtree_worker.go`):
   - **Backoff before republish** — exponential 1s/2s/4s/5s… with a **5s cap** (deliberately smaller than the fetcher's 30s: the worker's 10-attempt budget lives at its cap, and a 50-record chunk sleeping 30s/record would blow past the 5m rebalance timeout and fence the member; ≤5s keeps the worst-case chunk under it). Interrupted wait aborts without publishing — the unacked original redelivers with no double-count.
   - **Disk-full parking** — ENOSPC/quota errors never consume the retry budget, never decrement the counter, never DLQ; the item parks in Kafka under topic retention until the disk recovers. Caveat documented: an outage longer than `subtreeCounterTTLSec` expires per-block counters and those blocks need `/reprocess` (openspec design doc + runbook note).
   - **Reduced 404 budget** — `datahub.ErrNotFound` DLQs after 3 spaced attempts instead of 10 (a deliberate middle ground vs the fetcher's immediate-DLQ-on-404: worker subtrees provably existed at announcement time, so a brief propagation gap deserves a retry — but a pruned block must not churn). `maxAttempts` stays a hard ceiling; DLQ log gains a `reason` field.
   - Decrement-before-DLQ ordering (F-013) and counter exactly-once semantics untouched.

## Verification

- `go build ./...`; `go test ./... -count=1` — 21 packages ok; `-race` clean on internal/kafka, internal/block, internal/subtree; `make lint` 0 issues; tag-gated `go vet` clean.
- 11 new tests in `internal/block/subtree_worker_backpressure_test.go` + retryutil suite: backoff schedule/5s-cap pin, wait-before-retry wall-clock, ctx-cancel abort-without-publish, ENOSPC/quota parking (no DLQ, no decrement, metric), e2e park via STUMP-store ENOSPC, 404 reduced-budget DLQ + hard-ceiling, existing tests unmodified.

Composes with #185 (poll-loop fetch-error handling) — this change is entirely on the handler side.