### PR TITLE
fix(store): age-sweep orphaned subtree blobs — bounded store regardless of DAH state

### DIFF
--- a/cmd/block-processor/main.go
+++ b/cmd/block-processor/main.go
@@ -35,6 +35,16 @@ func main() {
 	}
 	defer func() { _ = registry.Close() }()
 
+	// Blob-store age sweeper: backstop GC for subtree blobs whose
+	// delete-at-height never fires (subtree-work item trimmed, parked, or
+	// crashed — dev-ovh-1, 2026-07-15). Runs here ONLY: the block-processor
+	// is the single replica that already executes DAH prunes on the shared
+	// volume, so one sweeper covers every service without a per-replica
+	// stampede. Sweeps once at startup, then every interval; no-op for
+	// memory stores or when disabled via config.
+	stopSweeper := store.StartAgeSweeperFromConfig(registry.Blob, cfg.BlobStore, logger)
+	defer stopSweeper()
+
 	processor := block.NewProcessor(
 		cfg.Kafka, cfg.Block, cfg.DataHub,
 		registry.Registration, registry.Subtree, registry.CallbackURLRegistry, registry.DataHubRegistry, registry.SubtreeCounter,

--- a/config.yaml
+++ b/config.yaml
@@ -442,14 +442,31 @@ blobStore:
   # Env: BLOB_STORE_URL
   url: file:///mnt/nvme/merkle-subtreestore
 
-  # Orphan sweeper (file:// stores only). Blobs whose block height becomes
-  # known are pruned by delete-at-height schedules; blobs that are announced
-  # but never mined have no height and would otherwise live forever. The
-  # sweeper deletes blob files older than orphanMaxAgeSec — set it well above
-  # the longest plausible announcement-to-mine gap. 0 disables the sweeper.
-  orphanMaxAgeSec: 86400
-  # How often the sweeper walks the store.
-  sweepIntervalSec: 3600
+  # Age sweeper (file:// stores only; runs in the block-processor ONLY — the
+  # single replica that already executes delete-at-height prunes on the
+  # shared volume, so one sweeper covers every service without a per-replica
+  # stampede). A subtree blob only gets a delete-at-height schedule when its
+  # subtree-work item completes; items that never complete (queue trimmed
+  # during incident recovery, long-term parking, crash between store and
+  # schedule) orphan their blobs FOREVER. On dev-ovh-1 (2026-07-15) those
+  # orphans plus zero-byte ENOSPC litter filled a 1TiB volume in ~3h while
+  # steady state holds ~2 blocks ≈ 26GB. Subtree blobs are a re-fetchable
+  # cache (DataHub re-serves them; the miss path carried a whole block at
+  # 100% miss rate), so aggressive age GC is safe — the sweeper removes ONLY
+  # top-level 64-lowercase-hex subtree blobs plus zero-byte litter older
+  # than ~5min. STUMP blobs (under stump/) are never age-swept: callback
+  # delivery reads them at delivery time with retry windows up to ~1h.
+  # .dah/ bookkeeping is never touched.
+  #
+  # How often the sweeper walks the store. 0 disables the sweeper.
+  # Env: BLOB_STORE_SWEEP_INTERVAL_SEC
+  sweepIntervalSec: 300
+  # Age after which an orphaned subtree blob is removed. Default 1800 ≈ 3
+  # blocks at ~10min cadence. Nonzero values below 600 are rejected at
+  # startup — a sweep age under one block interval could delete the
+  # in-flight block's blobs mid-processing. 0 disables age sweeping.
+  # Env: BLOB_STORE_SWEEP_MAX_AGE_SEC
+  sweepMaxAgeSec: 1800
 
 # ---------------------------------------------------------------------------
 # DataHub — HTTP client for fetching subtree/block data from Teranode

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -495,16 +495,24 @@ type CallbackConfig struct {
 // BlobStoreConfig holds blob store configuration.
 type BlobStoreConfig struct {
 	URL string `yaml:"url" mapstructure:"url"`
-	// OrphanMaxAgeSec is the age after which a blob file with no fired
-	// delete-at-height schedule is removed by the background sweeper — the
-	// backstop for subtrees announced but never mined (their height is never
-	// learned, so height-based pruning cannot reach them) and for files
-	// orphaned by a crash between write and schedule. Must comfortably
-	// exceed the longest plausible announcement-to-mine gap. 0 disables the
-	// sweeper.
-	OrphanMaxAgeSec int `yaml:"orphanMaxAgeSec" mapstructure:"orphanmaxagesec"`
-	// SweepIntervalSec is how often the orphan sweeper walks the store.
+	// SweepIntervalSec is how often the age sweeper walks a file:// store.
+	// The sweep runs in the block-processor only (single replica — a
+	// per-replica sweep would stampede the shared volume). 0 disables the
+	// sweeper. Default 300.
 	SweepIntervalSec int `yaml:"sweepIntervalSec" mapstructure:"sweepintervalsec"`
+	// SweepMaxAgeSec is the age after which a top-level subtree blob (a
+	// 64-lowercase-hex file at the store root) is removed by the sweeper —
+	// the backstop for blobs whose subtree-work item never completes
+	// (trimmed queues, long parking, crashes), which the delete-at-height
+	// path can never reach. Subtree blobs are a re-fetchable cache (DataHub
+	// re-serves them), so an aggressive age is safe; STUMP blobs (under
+	// stump/) and .dah/ bookkeeping are never age-swept. Default 1800
+	// (~3 blocks at ~10min cadence). Nonzero values below 600 are rejected
+	// at startup: a sweep age under one block interval could delete the
+	// in-flight block's blobs mid-processing. 0 disables age sweeping.
+	// Rationale: 2026-07-15 dev-ovh-1 incident — orphaned subtree blobs
+	// filled a 1TiB volume in ~3h while steady state is ~2 blocks ≈ 26GB.
+	SweepMaxAgeSec int `yaml:"sweepMaxAgeSec" mapstructure:"sweepmaxagesec"`
 }
 
 // DataHubConfig holds DataHub HTTP client configuration.
@@ -689,8 +697,12 @@ func registerDefaults(v *viper.Viper) {
 
 	// BlobStore
 	v.SetDefault("blobstore.url", "file:///tmp/merkle-subtrees")
-	v.SetDefault("blobstore.orphanmaxagesec", 86400)
-	v.SetDefault("blobstore.sweepintervalsec", 3600)
+	// Age sweeper: aggressive by design. Subtree blobs are a re-fetchable
+	// cache, and the 2026-07-15 dev-ovh-1 incident filled a 1TiB volume in
+	// ~3h with orphans the DAH path could never reach. 1800s ≈ 3 blocks at
+	// ~10min cadence; a 300s interval bounds orphan buildup between sweeps.
+	v.SetDefault("blobstore.sweepintervalsec", 300)
+	v.SetDefault("blobstore.sweepmaxagesec", 1800)
 
 	// DataHub
 	// Defaults tuned so a known-bad peer is dropped in seconds, not minutes.
@@ -848,7 +860,9 @@ func bindEnvVars(v *viper.Viper) {
 		"callback.allowprivateips":     "CALLBACK_ALLOW_PRIVATE_IPS",
 
 		// BlobStore
-		"blobstore.url": "BLOB_STORE_URL",
+		"blobstore.url":              "BLOB_STORE_URL",
+		"blobstore.sweepintervalsec": "BLOB_STORE_SWEEP_INTERVAL_SEC",
+		"blobstore.sweepmaxagesec":   "BLOB_STORE_SWEEP_MAX_AGE_SEC",
 
 		// DataHub
 		"datahub.timeoutsec":                  "DATAHUB_TIMEOUT_SEC",
@@ -943,6 +957,18 @@ func Load() (*Config, error) {
 	// becomes a permanent record that the sweeper never reclaims.
 	if cfg.Aerospike.SubtreeCounterTTLSec <= 0 {
 		return nil, fmt.Errorf("invalid aerospike.subtreeCounterTTLSec %d: must be > 0", cfg.Aerospike.SubtreeCounterTTLSec)
+	}
+
+	// Blob-store sweeper validation. The age floor is the safety property:
+	// the sweeper deletes by mtime, and a nonzero max age below one block
+	// interval (~600s) could remove the in-flight block's subtree blobs
+	// while the block-processor is still assembling STUMPs from them. 0 is
+	// legal for both keys — it disables the sweeper outright.
+	if cfg.BlobStore.SweepIntervalSec < 0 {
+		return nil, fmt.Errorf("invalid blobStore.sweepIntervalSec %d: must be >= 0 (0 disables the sweeper)", cfg.BlobStore.SweepIntervalSec)
+	}
+	if cfg.BlobStore.SweepMaxAgeSec != 0 && cfg.BlobStore.SweepMaxAgeSec < 600 {
+		return nil, fmt.Errorf("invalid blobStore.sweepMaxAgeSec %d: must be 0 (disabled) or >= 600 — a sweep age below one block interval could delete the in-flight block's subtree blobs", cfg.BlobStore.SweepMaxAgeSec)
 	}
 
 	// Telemetry validation. telemetry.endpoint is intentionally NOT required

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -42,7 +42,7 @@ func clearConfigEnv(t *testing.T) {
 		"BLOCK_RETRY_BACKOFF_BASE_MS", "BLOCK_NOT_FOUND_MAX_ATTEMPTS",
 		"CALLBACK_MAX_RETRIES", "CALLBACK_BACKOFF_BASE_SEC",
 		"CALLBACK_TIMEOUT_SEC", "CALLBACK_SEEN_THRESHOLD",
-		"BLOB_STORE_URL",
+		"BLOB_STORE_URL", "BLOB_STORE_SWEEP_INTERVAL_SEC", "BLOB_STORE_SWEEP_MAX_AGE_SEC",
 		envTelemetryEnabled, "TELEMETRY_ENDPOINT", envTelemetryProtocol,
 		"TELEMETRY_INSECURE", "TELEMETRY_SERVICE_NAME", "TELEMETRY_NAMESPACE",
 		"TELEMETRY_TRACES", "TELEMETRY_METRICS", "TELEMETRY_SAMPLE_RATIO",
@@ -161,14 +161,16 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.BlobStore.URL != "file:///tmp/merkle-subtrees" {
 		t.Errorf("BlobStore.URL: expected %q, got %q", "file:///tmp/merkle-subtrees", cfg.BlobStore.URL)
 	}
-	// Orphan sweeper: on by default with a generous window — it is the
-	// backstop for blobs whose height is never learned (announced but never
-	// mined), which delete-at-height pruning cannot reach.
-	if cfg.BlobStore.OrphanMaxAgeSec != 86400 {
-		t.Errorf("BlobStore.OrphanMaxAgeSec: expected 86400, got %d", cfg.BlobStore.OrphanMaxAgeSec)
+	// Age sweeper: on by default and aggressive — subtree blobs are a
+	// re-fetchable cache (DataHub re-serves them), and the 2026-07-15
+	// dev-ovh-1 incident showed orphans filling a 1TiB volume in ~3h.
+	// 1800s ≈ 3 blocks at ~10min cadence; 300s interval bounds orphan
+	// buildup to a small fraction of steady state.
+	if cfg.BlobStore.SweepIntervalSec != 300 {
+		t.Errorf("BlobStore.SweepIntervalSec: expected 300, got %d", cfg.BlobStore.SweepIntervalSec)
 	}
-	if cfg.BlobStore.SweepIntervalSec != 3600 {
-		t.Errorf("BlobStore.SweepIntervalSec: expected 3600, got %d", cfg.BlobStore.SweepIntervalSec)
+	if cfg.BlobStore.SweepMaxAgeSec != 1800 {
+		t.Errorf("BlobStore.SweepMaxAgeSec: expected 1800, got %d", cfg.BlobStore.SweepMaxAgeSec)
 	}
 }
 
@@ -208,6 +210,8 @@ func TestLoad_EnvOverrides(t *testing.T) {
 	_ = os.Setenv("CALLBACK_TIMEOUT_SEC", "20")
 	_ = os.Setenv("CALLBACK_SEEN_THRESHOLD", "5")
 	_ = os.Setenv("BLOB_STORE_URL", "s3://my-bucket")
+	_ = os.Setenv("BLOB_STORE_SWEEP_INTERVAL_SEC", "120")
+	_ = os.Setenv("BLOB_STORE_SWEEP_MAX_AGE_SEC", "900")
 
 	defer clearConfigEnv(t)
 
@@ -272,6 +276,78 @@ func TestLoad_EnvOverrides(t *testing.T) {
 	}
 	if cfg.BlobStore.URL != "s3://my-bucket" {
 		t.Errorf("BlobStore.URL: expected %q, got %q", "s3://my-bucket", cfg.BlobStore.URL)
+	}
+	if cfg.BlobStore.SweepIntervalSec != 120 {
+		t.Errorf("BlobStore.SweepIntervalSec: expected 120, got %d", cfg.BlobStore.SweepIntervalSec)
+	}
+	if cfg.BlobStore.SweepMaxAgeSec != 900 {
+		t.Errorf("BlobStore.SweepMaxAgeSec: expected 900, got %d", cfg.BlobStore.SweepMaxAgeSec)
+	}
+}
+
+// TestLoad_BlobStoreSweepValidation pins the sweep-age floor: a nonzero
+// blobStore.sweepMaxAgeSec below 600s (~1 block interval) could delete the
+// in-flight block's subtree blobs mid-processing, so Load must reject it.
+// 0 stays legal — it disables age-based sweeping entirely.
+func TestLoad_BlobStoreSweepValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		env       map[string]string
+		wantError bool
+	}{
+		{
+			name:      "defaults are valid",
+			env:       nil,
+			wantError: false,
+		},
+		{
+			name:      "max age at the 600s floor is accepted",
+			env:       map[string]string{"BLOB_STORE_SWEEP_MAX_AGE_SEC": "600"},
+			wantError: false,
+		},
+		{
+			name:      "max age below the floor is rejected",
+			env:       map[string]string{"BLOB_STORE_SWEEP_MAX_AGE_SEC": "599"},
+			wantError: true,
+		},
+		{
+			name:      "max age 0 disables the sweeper and is accepted",
+			env:       map[string]string{"BLOB_STORE_SWEEP_MAX_AGE_SEC": "0"},
+			wantError: false,
+		},
+		{
+			name:      "negative max age is rejected",
+			env:       map[string]string{"BLOB_STORE_SWEEP_MAX_AGE_SEC": "-1"},
+			wantError: true,
+		},
+		{
+			name:      "interval 0 disables the sweeper and is accepted",
+			env:       map[string]string{"BLOB_STORE_SWEEP_INTERVAL_SEC": "0"},
+			wantError: false,
+		},
+		{
+			name:      "negative interval is rejected",
+			env:       map[string]string{"BLOB_STORE_SWEEP_INTERVAL_SEC": "-1"},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearConfigEnv(t)
+			t.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			_, err := Load()
+			if tt.wantError && err == nil {
+				t.Fatal("expected Load() to return an error, got nil")
+			}
+			if !tt.wantError && err != nil {
+				t.Fatalf("expected Load() to succeed, got error: %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/metrics/blobstore.go
+++ b/internal/metrics/blobstore.go
@@ -1,0 +1,40 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// BlobStoreSweptFilesTotal counts blob files removed by the age sweeper —
+// orphaned subtree blobs (no delete-at-height ever fired because their
+// subtree-work item never completed) plus zero-byte ENOSPC litter. This is
+// the visibility the 2026-07-15 dev-ovh-1 incident lacked: the store filled
+// a 1TiB volume in ~3h and the growth was only diagnosable by walking the
+// volume by hand.
+var BlobStoreSweptFilesTotal = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Name: "merkle_blobstore_swept_files_total",
+		Help: "Blob files removed by the blob-store age sweeper (orphaned subtree blobs and zero-byte litter).",
+	},
+)
+
+// BlobStoreSweptBytesTotal counts the bytes reclaimed by the age sweeper.
+var BlobStoreSweptBytesTotal = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Name: "merkle_blobstore_swept_bytes_total",
+		Help: "Bytes reclaimed by the blob-store age sweeper.",
+	},
+)
+
+func init() {
+	Registry.MustRegister(
+		BlobStoreSweptFilesTotal,
+		BlobStoreSweptBytesTotal,
+	)
+}
+
+// AddBlobSweep records one age-sweep pass. Zero deltas are recorded too so
+// the series exists (and stays flat) on healthy stores.
+func AddBlobSweep(files int, bytes int64) {
+	BlobStoreSweptFilesTotal.Add(float64(files))
+	BlobStoreSweptBytesTotal.Add(float64(bytes))
+}

--- a/internal/store/factory.go
+++ b/internal/store/factory.go
@@ -127,6 +127,7 @@ func newAerospikeRegistry(_ context.Context, cfg *config.Config, logger *slog.Lo
 		),
 		Subtree: NewSubtreeStore(blob, uint64(cfg.Subtree.DAHOffset), logger),    //nolint:gosec // config-validated int
 		Stump:   NewStumpStore(blob, uint64(cfg.Subtree.StumpDAHOffset), logger), //nolint:gosec // config-validated int
+		Blob:    blob,
 		CallbackDedup: NewCallbackDedupStore(
 			asClient, cfg.Aerospike.CallbackDedupSet,
 			cfg.Aerospike.MaxRetries, cfg.Aerospike.RetryBaseMs, logger,
@@ -160,11 +161,6 @@ func newAerospikeRegistry(_ context.Context, cfg *config.Config, logger *slog.Lo
 		Health: asClient,
 	}
 	r.AddCloser(func() error { asClient.Close(); return nil })
-
-	// Backstop for blobs whose height is never learned (announced but never
-	// mined) — see StartBlobSweeperFromConfig. No-op for memory stores.
-	stopSweeper := StartBlobSweeperFromConfig(blob, cfg.BlobStore, logger)
-	r.AddCloser(func() error { stopSweeper(); return nil })
 
 	return r, nil
 }

--- a/internal/store/file_blob_sweep.go
+++ b/internal/store/file_blob_sweep.go
@@ -10,32 +10,76 @@ import (
 	"time"
 
 	"github.com/bsv-blockchain/merkle-service/internal/config"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 )
 
-// SweepOrphans deletes blob files whose modification time is older than
-// maxAge and returns how many it removed. It is the backstop for blobs the
-// delete-at-height path can never reach:
+// zeroByteMaxAge is how long a zero-byte file may exist before the sweeper
+// treats it as failed-write litter. os.WriteFile creates-then-writes, so a
+// blob is legitimately zero-byte for the instant a write is in flight; a file
+// that has stayed empty for minutes is an ENOSPC artifact (the 2026-07-15
+// dev-ovh-1 incident left 13,433 of them). Empty blobs are never valid data —
+// subtree payloads and STUMPs are non-empty by construction — so this reaps
+// them everywhere outside .dah/, regardless of namespace or the caller's age
+// threshold.
+const zeroByteMaxAge = 5 * time.Minute
+
+// isSubtreeBlobName reports whether name has the shape of a subtree blob key:
+// exactly 64 lowercase hex characters, the content-addressed sha256 form every
+// subtree is stored under. STUMP blobs share the same hex shape but live under
+// the "stump/" prefix (see stumpKeyPrefix), so name shape plus top-level
+// placement discriminates the two with certainty.
+func isSubtreeBlobName(name string) bool {
+	if len(name) != 64 {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// SweepOlderThan deletes qualifying blob files and returns how many files and
+// bytes it removed. It is the backstop for subtree blobs the delete-at-height
+// path can never reach: a blob only gets a DAH schedule when its subtree-work
+// item completes, so trimmed queues, long-term parking, and crashes between
+// store and schedule orphan blobs forever (dev-ovh-1, 2026-07-15: 39,477 such
+// orphans filled a 1TiB volume in ~3h).
 //
-//   - subtrees announced but never mined — no block ever supplies their
-//     height, so no schedule is ever recorded for them;
-//   - blobs orphaned by a crash between the file write and the schedule
-//     append;
-//   - files that predate schedule manifests entirely.
+// Two rules, deliberately narrow:
 //
-// Every blob with a knowable height is pruned by the (earlier, event-driven)
-// DAH path, so with a generous maxAge the sweeper only ever touches data the
-// chain abandoned. The .dah bookkeeping is skipped: manifests must survive
-// until their height fires, and a schedule outliving its blob is a no-op.
+//   - top-level 64-lowercase-hex files (subtree blobs — see isSubtreeBlobName)
+//     with mtime older than maxAge are removed. Subtree blobs are a cache:
+//     DataHub re-serves them and the worker's miss path re-fetches, so the
+//     worst case for a swept blob is one re-fetch.
+//   - zero-byte files older than zeroByteMaxAge are removed anywhere outside
+//     .dah/ — failed-write (ENOSPC) litter is never valid data.
 //
-// Errors on individual files are skipped (another replica sweeping the same
-// shared volume concurrently makes ENOENT ordinary); only a failure to walk
-// the root is returned.
-func (f *FileBlobStore) SweepOrphans(maxAge time.Duration) (int, error) {
-	cutoff := time.Now().Add(-maxAge)
+// Everything else is never touched: STUMP blobs (under stump/) are read by
+// callback-delivery at delivery time with retry windows up to ~1h, and .dah/
+// manifests must survive until their height fires (a schedule outliving its
+// blob is a no-op). Keys that match neither rule leak to operators rather
+// than risk deleting live data.
+//
+// The sweep takes no lock and is safe to run concurrently with Set/Get/Del
+// and the DAH pruner: blob files are content-addressed (a concurrent
+// re-store simply recreates the key), POSIX keeps a deleted file readable
+// through any already-open descriptor, and the .dah/ bookkeeping — the only
+// state the store mutates under its mutex — is skipped entirely. FileBlobStore
+// keeps no per-key in-memory state, so there is nothing else to reconcile.
+//
+// Errors on individual files are skipped (a file vanishing mid-walk is
+// ordinary next to the DAH pruner); only a failure to walk the root is
+// returned.
+func (f *FileBlobStore) SweepOlderThan(maxAge time.Duration) (files int, bytes int64, err error) {
+	now := time.Now()
+	cutoff := now.Add(-maxAge)
+	zeroByteCutoff := now.Add(-zeroByteMaxAge)
 	dahRoot := filepath.Join(f.rootAbs, dahDirName)
 
-	removed := 0
-	err := filepath.WalkDir(f.rootAbs, func(path string, d fs.DirEntry, err error) error {
+	walkErr := filepath.WalkDir(f.rootAbs, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			// Entry vanished mid-walk (concurrent prune/sweep) or unreadable:
 			// skip it rather than aborting the whole sweep.
@@ -54,46 +98,65 @@ func (f *FileBlobStore) SweepOrphans(maxAge time.Duration) (int, error) {
 		if err != nil {
 			return nil //nolint:nilerr // entry vanished; nothing to sweep
 		}
-		if info.ModTime().After(cutoff) {
+
+		size := info.Size()
+		switch {
+		case size == 0 && info.ModTime().Before(zeroByteCutoff):
+			// Failed-write litter: reap early regardless of maxAge.
+		case isSubtreeBlobName(d.Name()) && filepath.Dir(path) == f.rootAbs && info.ModTime().Before(cutoff):
+			// Orphaned subtree blob: top-level, content-addressed, stale.
+		default:
 			return nil
 		}
+
 		// The walk is rooted at the store's own data directory and blob
 		// writes never create symlinks, so the TOCTOU window G122 warns
 		// about cannot escape the root; worst case a concurrently-replaced
 		// file is removed, which for content-addressed blobs means a
 		// harmless refetch.
 		if os.Remove(path) == nil { //nolint:gosec // see comment above
-			removed++
+			files++
+			bytes += size
 		}
 		return nil
 	})
-	if err != nil {
-		return removed, fmt.Errorf("sweeping blob store %s: %w", f.dir, err)
+	if walkErr != nil {
+		return files, bytes, fmt.Errorf("sweeping blob store %s: %w", f.dir, walkErr)
 	}
-	return removed, nil
+	return files, bytes, nil
 }
 
-// StartOrphanSweeper runs SweepOrphans immediately and then every interval,
-// until the returned stop function is called. The stop function is
-// idempotent and safe to call concurrently. logger may be nil. A
-// non-positive interval is clamped to one hour: time.NewTicker panics on
-// values <= 0, and this method is exported (StartBlobSweeperFromConfig
-// clamps too, but direct callers deserve the same protection).
-func (f *FileBlobStore) StartOrphanSweeper(interval, maxAge time.Duration, logger *slog.Logger) (stop func()) {
+// StartAgeSweeper runs SweepOlderThan immediately and then every interval,
+// until the returned stop function is called. The stop function is idempotent
+// and safe to call concurrently. logger may be nil. Metrics are updated on
+// every pass; the INFO log fires only when something was removed so a healthy
+// store stays quiet. A non-positive interval is clamped to one hour:
+// time.NewTicker panics on values <= 0, and this method is exported
+// (StartAgeSweeperFromConfig refuses to start in that case, but direct
+// callers deserve the same protection).
+func (f *FileBlobStore) StartAgeSweeper(interval, maxAge time.Duration, logger *slog.Logger) (stop func()) {
 	if interval <= 0 {
 		interval = time.Hour
 	}
 	sweep := func() {
-		removed, err := f.SweepOrphans(maxAge)
+		start := time.Now()
+		files, bytes, err := f.SweepOlderThan(maxAge)
+		metrics.AddBlobSweep(files, bytes)
 		if logger == nil {
 			return
 		}
 		if err != nil {
-			logger.Warn("blob orphan sweep failed", "dir", f.dir, "error", err)
+			logger.Warn("blob age sweep failed", "dir", f.dir, "error", err)
 			return
 		}
-		if removed > 0 {
-			logger.Info("blob orphan sweep removed stale blobs", "dir", f.dir, "removed", removed, "maxAge", maxAge.String())
+		if files > 0 {
+			logger.Info("blob age sweep removed stale blobs",
+				"dir", f.dir,
+				"files", files,
+				"bytes", bytes,
+				"maxAge", maxAge.String(),
+				"duration", time.Since(start).String(),
+			)
 		}
 	}
 	sweep()
@@ -116,20 +179,21 @@ func (f *FileBlobStore) StartOrphanSweeper(interval, maxAge time.Duration, logge
 	return func() { once.Do(func() { close(done) }) }
 }
 
-// StartBlobSweeperFromConfig starts the orphan sweeper for file-backed blob
-// stores when cfg enables it (OrphanMaxAgeSec > 0) and returns a stop
-// function; for memory stores or disabled config it returns a no-op. The
-// store factories call this so every process that mounts the shared blob
-// volume participates in sweeping — the sweep is idempotent across replicas
-// (a file already removed by another sweeper is simply skipped).
-func StartBlobSweeperFromConfig(blob BlobStore, cfg config.BlobStoreConfig, logger *slog.Logger) (stop func()) {
+// StartAgeSweeperFromConfig starts the age sweeper for file-backed blob
+// stores when cfg enables it (both SweepIntervalSec and SweepMaxAgeSec > 0)
+// and returns a stop function; for memory stores or disabled config it
+// returns a no-op. Called from the block-processor ONLY — it is the single
+// replica that already executes DAH prunes on the shared volume, and one
+// sweeper avoids every replica of every service walking the same CephFS tree
+// each interval.
+func StartAgeSweeperFromConfig(blob BlobStore, cfg config.BlobStoreConfig, logger *slog.Logger) (stop func()) {
 	fbs, ok := blob.(*FileBlobStore)
-	if !ok || cfg.OrphanMaxAgeSec <= 0 {
+	if !ok || cfg.SweepIntervalSec <= 0 || cfg.SweepMaxAgeSec <= 0 {
 		return func() {}
 	}
-	interval := time.Duration(cfg.SweepIntervalSec) * time.Second
-	if interval <= 0 {
-		interval = time.Hour
-	}
-	return fbs.StartOrphanSweeper(interval, time.Duration(cfg.OrphanMaxAgeSec)*time.Second, logger)
+	return fbs.StartAgeSweeper(
+		time.Duration(cfg.SweepIntervalSec)*time.Second,
+		time.Duration(cfg.SweepMaxAgeSec)*time.Second,
+		logger,
+	)
 }

--- a/internal/store/file_blob_sweep_test.go
+++ b/internal/store/file_blob_sweep_test.go
@@ -4,43 +4,68 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
 	"github.com/bsv-blockchain/merkle-service/internal/config"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 )
 
-// The age sweeper is the backstop for blobs that delete-at-height can never
-// reach: subtrees announced but never mined (no block ever supplies their
-// height), plus anything orphaned by a crash between a blob write and its
-// schedule append, and pre-existing files from before manifests shipped.
-// Age is the only signal available for these — every blob with a knowable
-// height is already covered by the (event-driven) DAH path, so the sweeper
-// only ever fires on data the chain abandoned.
+// The age sweeper is the backstop for subtree blobs that delete-at-height can
+// never reach: a subtree blob only gets a DAH schedule when its subtree-work
+// item completes, so trimmed queues, long parking, and crashes orphan blobs
+// FOREVER (2026-07-15 dev-ovh-1: 39,477 orphans filled a 1TiB volume in ~3h).
+// Subtree blobs are re-fetchable from DataHub, so age-based GC is safe — but
+// ONLY for subtree blobs. STUMP blobs (namespaced under "stump/") are read by
+// callback-delivery at delivery time with retry windows up to ~1h and must
+// never be age-swept; ".dah/" manifests are bookkeeping that must survive
+// until their height fires. The sweeper therefore discriminates by key
+// namespace: only top-level 64-lowercase-hex files qualify, plus zero-byte
+// ENOSPC litter (13,433 such files in the incident) anywhere outside .dah/.
 
-// TestFileBlobStore_SweepOrphansDeletesOnlyOldFiles pins the core contract:
-// files older than maxAge are removed, fresh files and DAH manifests are not.
-func TestFileBlobStore_SweepOrphansDeletesOnlyOldFiles(t *testing.T) {
+// subtreeKey returns a valid top-level subtree blob key: 64 lowercase hex
+// characters, the shape produced by content addressing (sha256 hex).
+func subtreeKey(b string) string {
+	return strings.Repeat(b, 32)
+}
+
+// TestFileBlobStore_SweepOlderThanDeletesOnlyOldSubtreeBlobs pins the core
+// contract: top-level 64-lowercase-hex files older than maxAge are removed
+// (with their byte size accounted), while fresh subtree blobs, STUMP blobs of
+// any age, non-subtree-shaped names, and .dah manifests are never touched.
+func TestFileBlobStore_SweepOlderThanDeletesOnlyOldSubtreeBlobs(t *testing.T) {
 	dir := t.TempDir()
 	bs, err := NewFileBlobStore(dir)
 	if err != nil {
 		t.Fatalf("NewFileBlobStore: %v", err)
 	}
 
-	for _, key := range []string{"old-blob", "fresh-blob", "stump/oldref"} {
-		if setErr := bs.Set(key, []byte("payload")); setErr != nil {
+	oldSubtree := subtreeKey("0a")
+	freshSubtree := subtreeKey("0b")
+	oldStump := "stump/" + subtreeKey("0c")
+	oldUppercase := strings.Repeat("0A", 32) // 64 chars but not lowercase hex
+	oldShortHex := strings.Repeat("d", 63)   // hex but not 64 chars
+	oldNonHex := "not-a-subtree.bin"
+
+	payload := []byte("subtree-payload")
+	for _, key := range []string{oldSubtree, freshSubtree, oldStump, oldUppercase, oldShortHex, oldNonHex} {
+		if setErr := bs.Set(key, payload); setErr != nil {
 			t.Fatalf("Set(%s): %v", key, setErr)
 		}
 	}
 	// A schedule for a future height — its manifest must survive sweeping
 	// even when the manifest file itself is old.
-	if schedErr := bs.ScheduleDelete("fresh-blob", 99); schedErr != nil {
+	if schedErr := bs.ScheduleDelete(freshSubtree, 99); schedErr != nil {
 		t.Fatalf("ScheduleDelete: %v", schedErr)
 	}
 
-	// Age the old files (and the manifest) well past maxAge.
+	// Age everything except freshSubtree well past maxAge — including the
+	// manifest, the stump, and the non-subtree-shaped names.
 	past := time.Now().Add(-2 * time.Hour)
-	for _, rel := range []string{"old-blob", "stump/oldref"} {
+	for _, rel := range []string{oldSubtree, oldStump, oldUppercase, oldShortHex, oldNonHex} {
 		if chErr := os.Chtimes(filepath.Join(dir, rel), past, past); chErr != nil {
 			t.Fatalf("Chtimes(%s): %v", rel, chErr)
 		}
@@ -55,55 +80,135 @@ func TestFileBlobStore_SweepOrphansDeletesOnlyOldFiles(t *testing.T) {
 		}
 	}
 
-	removed, err := bs.SweepOrphans(time.Hour)
+	files, bytes, err := bs.SweepOlderThan(time.Hour)
 	if err != nil {
-		t.Fatalf("SweepOrphans: %v", err)
+		t.Fatalf("SweepOlderThan: %v", err)
 	}
-	if removed != 2 {
-		t.Errorf("SweepOrphans removed = %d, want 2", removed)
+	if files != 1 {
+		t.Errorf("SweepOlderThan files = %d, want 1", files)
+	}
+	if bytes != int64(len(payload)) {
+		t.Errorf("SweepOlderThan bytes = %d, want %d", bytes, len(payload))
 	}
 
-	if _, err := bs.Get("old-blob"); !errors.Is(err, ErrBlobNotFound) {
-		t.Errorf("old-blob should be swept; Get err = %v", err)
+	if _, err := bs.Get(oldSubtree); !errors.Is(err, ErrBlobNotFound) {
+		t.Errorf("old subtree blob should be swept; Get err = %v", err)
 	}
-	if _, err := bs.Get("stump/oldref"); !errors.Is(err, ErrBlobNotFound) {
-		t.Errorf("stump/oldref should be swept; Get err = %v", err)
-	}
-	if _, err := bs.Get("fresh-blob"); err != nil {
-		t.Errorf("fresh-blob must survive the sweep; Get err = %v", err)
+	for _, key := range []string{freshSubtree, oldStump, oldUppercase, oldShortHex, oldNonHex} {
+		if _, err := bs.Get(key); err != nil {
+			t.Errorf("%s must survive the sweep; Get err = %v", key, err)
+		}
 	}
 
 	// The aged manifest must still fire later — sweeping must not have
 	// touched the bookkeeping.
 	bs.SetCurrentBlockHeight(99)
-	if _, err := bs.Get("fresh-blob"); !errors.Is(err, ErrBlobNotFound) {
+	if _, err := bs.Get(freshSubtree); !errors.Is(err, ErrBlobNotFound) {
 		t.Errorf("schedule must survive sweeping and fire at its height; Get err = %v", err)
 	}
 }
 
-// TestFileBlobStore_StartOrphanSweeper pins the runner: an immediate sweep on
-// start (deterministic for operators and tests alike), and a stop function
-// that halts the loop.
-func TestFileBlobStore_StartOrphanSweeper(t *testing.T) {
+// TestFileBlobStore_SweepOlderThanReapsZeroByteLitter pins the ENOSPC-litter
+// rule: zero-byte files older than ~5 minutes are reaped regardless of the
+// age threshold and regardless of namespace (a zero-byte STUMP is unreadable
+// litter, not a deliverable blob) — but never inside .dah/, and never while
+// fresh (a write in progress is briefly zero-byte).
+func TestFileBlobStore_SweepOlderThanReapsZeroByteLitter(t *testing.T) {
 	dir := t.TempDir()
 	bs, err := NewFileBlobStore(dir)
 	if err != nil {
 		t.Fatalf("NewFileBlobStore: %v", err)
 	}
 
-	if err := bs.Set("ancient", []byte("x")); err != nil {
+	emptySubtree := subtreeKey("0e")
+	emptyStump := "stump/" + subtreeKey("0f")
+	emptyFresh := subtreeKey("1a")
+	for _, key := range []string{emptySubtree, emptyStump, emptyFresh} {
+		if setErr := bs.Set(key, nil); setErr != nil {
+			t.Fatalf("Set(%s): %v", key, setErr)
+		}
+	}
+	// A zero-byte file inside .dah/ (torn manifest create) must be left for
+	// the DAH machinery — the sweeper never reaches into bookkeeping space.
+	dahHeightDir := filepath.Join(dir, dahDirName, "42")
+	if mkErr := os.MkdirAll(dahHeightDir, 0o750); mkErr != nil {
+		t.Fatalf("MkdirAll(.dah/42): %v", mkErr)
+	}
+	emptyManifest := filepath.Join(dahHeightDir, "torn.list")
+	if wErr := os.WriteFile(emptyManifest, nil, 0o600); wErr != nil {
+		t.Fatalf("WriteFile(torn.list): %v", wErr)
+	}
+
+	// 10 minutes old: past the zero-byte grace, well inside the 30m maxAge.
+	past := time.Now().Add(-10 * time.Minute)
+	for _, p := range []string{
+		filepath.Join(dir, emptySubtree),
+		filepath.Join(dir, emptyStump),
+		emptyManifest,
+	} {
+		if chErr := os.Chtimes(p, past, past); chErr != nil {
+			t.Fatalf("Chtimes(%s): %v", p, chErr)
+		}
+	}
+
+	files, bytes, err := bs.SweepOlderThan(30 * time.Minute)
+	if err != nil {
+		t.Fatalf("SweepOlderThan: %v", err)
+	}
+	if files != 2 {
+		t.Errorf("SweepOlderThan files = %d, want 2 (the two aged zero-byte blobs)", files)
+	}
+	if bytes != 0 {
+		t.Errorf("SweepOlderThan bytes = %d, want 0", bytes)
+	}
+
+	for _, key := range []string{emptySubtree, emptyStump} {
+		if _, err := bs.Get(key); !errors.Is(err, ErrBlobNotFound) {
+			t.Errorf("aged zero-byte %s should be reaped; Get err = %v", key, err)
+		}
+	}
+	if _, err := bs.Get(emptyFresh); err != nil {
+		t.Errorf("fresh zero-byte file must survive (write may be in flight); Get err = %v", err)
+	}
+	if _, err := os.Stat(emptyManifest); err != nil {
+		t.Errorf("zero-byte file under .dah/ must never be touched; Stat err = %v", err)
+	}
+}
+
+// TestFileBlobStore_StartAgeSweeper pins the runner: an immediate sweep on
+// start (deterministic for operators and tests alike), metrics counters
+// updated with the sweep's files/bytes, and an idempotent stop function.
+func TestFileBlobStore_StartAgeSweeper(t *testing.T) {
+	dir := t.TempDir()
+	bs, err := NewFileBlobStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileBlobStore: %v", err)
+	}
+
+	ancient := subtreeKey("2b")
+	payload := []byte("x")
+	if err := bs.Set(ancient, payload); err != nil {
 		t.Fatalf("Set: %v", err)
 	}
 	past := time.Now().Add(-3 * time.Hour)
-	if err := os.Chtimes(filepath.Join(dir, "ancient"), past, past); err != nil {
+	if err := os.Chtimes(filepath.Join(dir, ancient), past, past); err != nil {
 		t.Fatalf("Chtimes: %v", err)
 	}
 
-	stop := bs.StartOrphanSweeper(time.Minute, time.Hour, nil)
+	filesBefore := testutil.ToFloat64(metrics.BlobStoreSweptFilesTotal)
+	bytesBefore := testutil.ToFloat64(metrics.BlobStoreSweptBytesTotal)
+
+	stop := bs.StartAgeSweeper(time.Minute, time.Hour, nil)
 	defer stop()
 
-	if _, err := bs.Get("ancient"); !errors.Is(err, ErrBlobNotFound) {
-		t.Errorf("StartOrphanSweeper must run an immediate sweep; Get err = %v", err)
+	if _, err := bs.Get(ancient); !errors.Is(err, ErrBlobNotFound) {
+		t.Errorf("StartAgeSweeper must run an immediate sweep; Get err = %v", err)
+	}
+	if got := testutil.ToFloat64(metrics.BlobStoreSweptFilesTotal) - filesBefore; got != 1 {
+		t.Errorf("swept-files counter delta = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.BlobStoreSweptBytesTotal) - bytesBefore; got != float64(len(payload)) {
+		t.Errorf("swept-bytes counter delta = %v, want %d", got, len(payload))
 	}
 
 	// stop must be idempotent and not hang.
@@ -111,67 +216,61 @@ func TestFileBlobStore_StartOrphanSweeper(t *testing.T) {
 	stop()
 }
 
-// TestStartBlobSweeperFromConfig pins the wiring helper the store factories
-// use: file-backed store + positive max age starts a sweeper (immediate first
-// sweep proves it); memory store or disabled config yields a no-op stop.
-func TestStartBlobSweeperFromConfig(t *testing.T) {
-	t.Run("file store with sweeper enabled sweeps immediately", func(t *testing.T) {
+// TestStartAgeSweeperFromConfig pins the wiring helper the block-processor
+// uses: file-backed store + positive interval + positive max age starts a
+// sweeper (immediate first sweep proves it); interval 0, max age 0, or a
+// memory store yields a safe no-op stop.
+func TestStartAgeSweeperFromConfig(t *testing.T) {
+	newAgedStore := func(t *testing.T) (*FileBlobStore, string) {
+		t.Helper()
 		dir := t.TempDir()
 		bs, err := NewFileBlobStore(dir)
 		if err != nil {
 			t.Fatalf("NewFileBlobStore: %v", err)
 		}
-		if err := bs.Set("ancient", []byte("x")); err != nil {
+		ancient := subtreeKey("3c")
+		if err := bs.Set(ancient, []byte("x")); err != nil {
 			t.Fatalf("Set: %v", err)
 		}
 		past := time.Now().Add(-3 * time.Hour)
-		if err := os.Chtimes(filepath.Join(dir, "ancient"), past, past); err != nil {
+		if err := os.Chtimes(filepath.Join(dir, ancient), past, past); err != nil {
 			t.Fatalf("Chtimes: %v", err)
 		}
+		return bs, ancient
+	}
 
-		stop := StartBlobSweeperFromConfig(bs, config.BlobStoreConfig{OrphanMaxAgeSec: 3600, SweepIntervalSec: 60}, nil)
+	t.Run("enabled config sweeps immediately", func(t *testing.T) {
+		bs, ancient := newAgedStore(t)
+		stop := StartAgeSweeperFromConfig(bs, config.BlobStoreConfig{SweepIntervalSec: 60, SweepMaxAgeSec: 3600}, nil)
 		defer stop()
 
-		if _, err := bs.Get("ancient"); !errors.Is(err, ErrBlobNotFound) {
+		if _, err := bs.Get(ancient); !errors.Is(err, ErrBlobNotFound) {
 			t.Errorf("enabled sweeper must sweep on start; Get err = %v", err)
 		}
 	})
 
-	t.Run("disabled and non-file stores return safe no-op", func(t *testing.T) {
-		bs, err := NewFileBlobStore(t.TempDir())
-		if err != nil {
-			t.Fatalf("NewFileBlobStore: %v", err)
-		}
-		stop := StartBlobSweeperFromConfig(bs, config.BlobStoreConfig{OrphanMaxAgeSec: 0}, nil)
+	t.Run("interval 0 disables the sweeper", func(t *testing.T) {
+		bs, ancient := newAgedStore(t)
+		stop := StartAgeSweeperFromConfig(bs, config.BlobStoreConfig{SweepIntervalSec: 0, SweepMaxAgeSec: 3600}, nil)
 		stop() // must not panic
 
-		stop = StartBlobSweeperFromConfig(NewMemoryBlobStore(), config.BlobStoreConfig{OrphanMaxAgeSec: 3600}, nil)
+		if _, err := bs.Get(ancient); err != nil {
+			t.Errorf("disabled sweeper must not remove anything; Get err = %v", err)
+		}
+	})
+
+	t.Run("max age 0 disables the sweeper", func(t *testing.T) {
+		bs, ancient := newAgedStore(t)
+		stop := StartAgeSweeperFromConfig(bs, config.BlobStoreConfig{SweepIntervalSec: 60, SweepMaxAgeSec: 0}, nil)
+		stop() // must not panic
+
+		if _, err := bs.Get(ancient); err != nil {
+			t.Errorf("disabled sweeper must not remove anything; Get err = %v", err)
+		}
+	})
+
+	t.Run("memory store returns safe no-op", func(t *testing.T) {
+		stop := StartAgeSweeperFromConfig(NewMemoryBlobStore(), config.BlobStoreConfig{SweepIntervalSec: 60, SweepMaxAgeSec: 3600}, nil)
 		stop() // must not panic
 	})
-}
-
-// TestFileBlobStore_StartOrphanSweeperGuardsInterval pins that a non-positive
-// interval cannot panic time.NewTicker: the runner clamps it to a sane
-// default. (StartBlobSweeperFromConfig already clamps, but this method is
-// exported and callable directly.)
-func TestFileBlobStore_StartOrphanSweeperGuardsInterval(t *testing.T) {
-	dir := t.TempDir()
-	bs, err := NewFileBlobStore(dir)
-	if err != nil {
-		t.Fatalf("NewFileBlobStore: %v", err)
-	}
-	if err := bs.Set("ancient", []byte("x")); err != nil {
-		t.Fatalf("Set: %v", err)
-	}
-	past := time.Now().Add(-3 * time.Hour)
-	if err := os.Chtimes(filepath.Join(dir, "ancient"), past, past); err != nil {
-		t.Fatalf("Chtimes: %v", err)
-	}
-
-	stop := bs.StartOrphanSweeper(0, time.Hour, nil) // must not panic
-	defer stop()
-
-	if _, err := bs.Get("ancient"); !errors.Is(err, ErrBlobNotFound) {
-		t.Errorf("immediate sweep must still run with clamped interval; Get err = %v", err)
-	}
 }

--- a/internal/store/registry.go
+++ b/internal/store/registry.go
@@ -16,6 +16,13 @@ type Registry struct {
 	SubtreeCounter      SubtreeCounterStore
 	ExpectedStump       ExpectedStumpStore
 
+	// Blob is the raw blob store backing Stump and Subtree. Exposed so the
+	// block-processor — the single replica that already executes DAH prunes
+	// on the shared volume — can run the age sweeper on it (see
+	// StartAgeSweeperFromConfig); services should otherwise use the typed
+	// Stump/Subtree stores.
+	Blob BlobStore
+
 	// Health reports backend reachability for the API health endpoint. May be
 	// nil for backends that don't need a liveness probe (e.g., an in-memory
 	// test backend).

--- a/internal/store/sql/sql.go
+++ b/internal/store/sql/sql.go
@@ -88,14 +88,10 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger) (*storepk
 		SeenCounter:         newSeenCounter(db, d, cfg.Callback.SeenThreshold),
 		SubtreeCounter:      newSubtreeCounter(db, d, cfg.Aerospike.SubtreeCounterTTLSec),
 		ExpectedStump:       newExpectedStump(db, d, cfg.Aerospike.SubtreeCounterTTLSec),
+		Blob:                blob,
 		Health:              &pingHealth{db: db},
 	}
-	// Backstop for blobs whose height is never learned (announced but never
-	// mined) — see StartBlobSweeperFromConfig. No-op for memory stores.
-	stopBlobSweeper := storepkg.StartBlobSweeperFromConfig(blob, cfg.BlobStore, logger)
-
 	r.AddCloser(func() error {
-		stopBlobSweeper()
 		cancelSweeper()
 		sw.waitStopped()
 		return db.Close()

--- a/openspec/changes/blobstore-age-sweeper/design.md
+++ b/openspec/changes/blobstore-age-sweeper/design.md
@@ -1,0 +1,121 @@
+# Design: blob-store age sweeper
+
+## Context
+
+`FileBlobStore` (internal/store/file_blob.go) is the durable backend for two blob
+families sharing one volume, plus its own bookkeeping:
+
+- **Subtree blobs** — `StoreSubtree(id, ...)` writes the raw key, and every producer
+  passes a content-addressed sha256 hex hash (`verifySubtreeContentAddress` parses it
+  via `chainhash.NewHashFromStr`). On disk: **top-level files named with 64 lowercase
+  hex characters**.
+- **STUMP blobs** — `stumpStore.Put` prefixes every key with `stumpKeyPrefix = "stump/"`
+  (internal/store/stump_store.go), explicitly "so they cannot collide with subtree keys
+  when the same BlobStore backs both". On disk: files under the **`stump/`
+  subdirectory**.
+- **DAH manifests** — `<root>/.dah/<height>/<owner>.list`; `resolvePath` rejects any
+  blob key that would land inside `.dah/`, so it is bookkeeping-only space.
+
+Deletion is event-driven (delete-at-height manifests, pruned by
+`SetCurrentBlockHeight`), but a subtree blob only gets a schedule when its subtree-work
+item completes. Incomplete items (trimmed queues, long parking, crashes) orphan blobs
+forever — dev-ovh-1 filled 1TiB in ~3h (issue #188).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The subtree blob store is bounded in size regardless of what the DAH path missed.
+- STUMP blobs are never age-swept: callback-delivery fetches them at delivery time with
+  retry windows up to ~1h (`stumpDahOffset=6` exists for that window).
+- Zero-byte ENOSPC litter (13,433 files in the incident) is reaped quickly.
+- Exactly one sweeper per shared volume (no CephFS walk herd).
+- Sweep visibility: counters for files/bytes reclaimed.
+
+**Non-Goals:**
+
+- Sweeping `.dah/` manifests: a schedule outliving its blob is a no-op fire, and
+  manifests are tiny; deleting them risks unscheduling live blobs. (Issue #188 floated
+  reaping stale manifests; deliberately dropped here — wrong risk/reward.)
+- A general TTL/GC framework for the blob store; DAH remains the precise prompt path.
+- Sweeping memory stores (single-process, lost on restart anyway).
+
+## Decisions
+
+### 1. Discriminator: key namespace, not DAH-schedule lookup
+
+The sweeper deletes a file only when it is **directly at the store root AND named with
+exactly 64 lowercase hex characters** — the shape every subtree key has by construction
+(content addressing) and no other on-disk artifact can have: STUMPs are namespaced under
+`stump/` (enforced at the only STUMP write site), and `.dah/` is rejected key space.
+Anything else (uppercase hex, wrong length, other names) is left alone: an unknown file
+leaks to operators rather than risking live data.
+
+The alternative — "delete only keys with no pending DAH schedule" — was rejected:
+manifests are per-writer append-only files keyed by height, so answering "is key K
+scheduled?" means parsing every manifest on every sweep, and a torn append (already
+tolerated by the DAH design) would make the answer wrong exactly when it matters.
+Age (mtime) plus the namespace split is sufficient: every *completed* subtree gets a DAH
+schedule that fires well before the sweep age, so the sweeper only ever fires on data
+the pipeline abandoned.
+
+### 2. Zero-byte litter: reaped everywhere outside `.dah/`, after 5 minutes
+
+A zero-byte blob is never valid data — subtree payloads and STUMPs are non-empty by
+construction — but `os.WriteFile` creates-then-writes, so a file is legitimately empty
+for the instant a write is in flight. A fixed `zeroByteMaxAge = 5min` grace (orders of
+magnitude above any write latency, orders of magnitude below the incident's litter age)
+separates the two. This applies under `stump/` too: a zero-byte STUMP would otherwise
+be *served* as empty bytes by `Get` (which only maps ENOENT to not-found), poisoning
+callback delivery; deleting it converts that to the well-handled `ErrStumpNotFound`.
+`.dah/` stays untouched even for empty manifests — torn-manifest handling belongs to
+the DAH machinery.
+
+### 3. Block-processor is the only sweeper
+
+The previous sweeper ran wherever the store was constructed — every replica of every
+service walking the same shared CephFS tree each interval. The block-processor is a
+single replica, already executes the DAH prunes on this volume (it is where
+`SetCurrentBlockHeight` fires), and mounts the same blob store through the registry. The
+registry now exposes `Blob BlobStore`, and `cmd/block-processor` starts
+`StartAgeSweeperFromConfig` right after registry construction: one sweep immediately
+(deterministic recovery after a restart mid-incident), then every `sweepIntervalSec`.
+Store factories no longer start sweepers.
+
+Concurrency posture is unchanged from the old sweeper: no lock taken. Blob files are
+content-addressed (concurrent re-store recreates the key), POSIX keeps deleted files
+readable through open descriptors, `GetSubtree`'s miss path re-fetches, and the only
+mutex-guarded state (`.dah/`) is skipped entirely. `FileBlobStore` keeps no per-key
+in-memory state, so there is nothing to reconcile after a delete.
+
+### 4. Config: rename to `sweepMaxAgeSec`, tighten defaults, floor at 600s
+
+`orphanMaxAgeSec` (86400) becomes `sweepMaxAgeSec` (1800 ≈ 3 blocks at ~10min cadence)
+— the rename is deliberate: the semantics changed from "sweep everything" to "sweep
+subtree blobs only", and a silently-inherited 24h value would defeat the fix.
+`sweepIntervalSec` drops 3600 → 300 so orphan buildup between sweeps stays a small
+fraction of steady state. Load() rejects nonzero `sweepMaxAgeSec < 600`: mtime-based
+deletion below one block interval could remove the in-flight block's blobs while STUMPs
+are still being assembled from them. 0 disables (either key), preserving an operator
+escape hatch. Old configs carrying `orphanMaxAgeSec` are ignored by viper and fall back
+to the new defaults — safe in the conservative direction for STUMPs (never swept) and
+the aggressive direction for orphans (which is the point).
+
+### 5. Metrics: two counters, no duration gauge
+
+`merkle_blobstore_swept_files_total` / `merkle_blobstore_swept_bytes_total`, updated on
+every pass (zero deltas keep the series alive on healthy stores). Per-sweep duration is
+logged, not gauged — internal/metrics has no last-run-duration gauge pattern, and the
+INFO log (emitted only when files > 0, to keep healthy stores quiet) carries it.
+
+## Risks / Trade-offs
+
+- **A never-mined subtree announced >30min before its block**: its blob is swept and
+  the worker re-fetches from DataHub once at block time. Accepted — that miss path
+  carried a full block at 100% miss rate during the incident.
+- **Non-lowercase or non-standard subtree keys would never be swept.** No such producer
+  exists (`chainhash` hex is lowercase); if one appears, blobs leak visibly (the
+  incident dashboards now watch the volume) rather than being wrongly deleted.
+- **Sweeper down = block-processor down.** Then no blocks are processed either, so the
+  dominant blob producer (block-path re-stores) is also down; announcement-time writes
+  continue but at a rate the volume tolerates until the single replica reschedules.

--- a/openspec/changes/blobstore-age-sweeper/proposal.md
+++ b/openspec/changes/blobstore-age-sweeper/proposal.md
@@ -1,0 +1,76 @@
+# Blob-store age sweeper for orphaned subtree blobs
+
+## Why
+
+A subtree blob only receives a delete-at-height schedule when its subtree-work item
+completes (the worker re-stores/schedules at `blockHeight + dahOffset`). Any blob whose
+work item never completes — queue trimmed during incident recovery, item parked
+long-term, service crash between store and schedule — has **no DAH entry and is never
+deleted**. Failed writes on a full disk additionally leave zero-byte litter.
+
+Observed on dev-ovh-1 (15 Jul 2026): the subtree store grew from ~2% to **100% of a
+1TiB volume in ~3 hours** under reprocess-storm conditions — 46,197 files, of which
+39,477 were older than 2h (orphans; steady state should hold ~2 blocks ≈ 26GB) and
+13,433 were zero-byte ENOSPC artifacts. A full store then cascades: fetcher stores park,
+prune scheduling itself needs disk, and the fetcher's peer-health tracker gets poisoned
+by local write failures.
+
+The existing orphan sweeper (v0.4.x, issue #177) could not contain this: its 24h default
+age is 8× slower than the observed fill rate, it swept **every** file older than the
+threshold — including STUMP blobs, which callback-delivery reads at delivery time with
+retry windows up to ~1h (`subtree.stumpDahOffset=6` exists for exactly that window) —
+and it ran in every process that mounts the volume, a sweep herd on shared CephFS.
+
+Aggressive GC is safe **for subtree blobs only**: they are a cache. DataHub re-serves
+subtree data (~2h window), and the worker's miss path ("subtree not in blob store,
+fetching from DataHub") is battle-tested — it carried an entire block at 100% miss rate.
+Worst case for a swept blob is one re-fetch.
+
+## What Changes
+
+- Replace `SweepOrphans` with `SweepOlderThan(maxAge) (files, bytes, err)` on
+  `FileBlobStore`: removes **only** top-level 64-lowercase-hex files (subtree blobs)
+  older than maxAge, plus zero-byte files older than ~5min anywhere outside `.dah/`
+  (ENOSPC litter). STUMP blobs (`stump/` namespace) and `.dah/` bookkeeping are never
+  touched. Keys matching neither rule are left alone — leak, don't risk live data.
+- Rewire the sweeper to run in the **block-processor only** (single replica; it already
+  executes DAH prunes on the shared volume), started from `cmd/block-processor` via
+  `store.StartAgeSweeperFromConfig(registry.Blob, ...)`: one sweep at startup, then
+  every interval; INFO log per sweep only when something was removed. The store
+  factories no longer start a per-process sweeper.
+- Config: `blobStore.sweepMaxAgeSec` (default **1800** ≈ 3 blocks, replaces
+  `blobStore.orphanMaxAgeSec`; nonzero values below 600 rejected at startup) and
+  `blobStore.sweepIntervalSec` (default **300**, was 3600; 0 disables). New env
+  bindings `BLOB_STORE_SWEEP_MAX_AGE_SEC` / `BLOB_STORE_SWEEP_INTERVAL_SEC`.
+- New counters `merkle_blobstore_swept_files_total` and
+  `merkle_blobstore_swept_bytes_total`, updated on every sweep pass.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `subtree-processing`: the subtree blob store gains a bounded-size guarantee — an age
+  sweeper that reclaims orphaned subtree blobs and zero-byte litter without ever
+  touching STUMP blobs or DAH bookkeeping.
+
+## Impact
+
+- **`internal/store/file_blob_sweep.go`**: `SweepOlderThan`, `StartAgeSweeper`,
+  `StartAgeSweeperFromConfig` (replacing `SweepOrphans`, `StartOrphanSweeper`,
+  `StartBlobSweeperFromConfig`).
+- **`internal/store/registry.go` / `factory.go` / `sql/sql.go`**: `Registry.Blob`
+  exposes the raw blob store for the block-processor's sweeper wiring; per-process
+  sweeper start removed from both backends.
+- **`cmd/block-processor/main.go`**: starts the sweeper after registry construction,
+  stops it on shutdown.
+- **`internal/config/config.go` / `config.yaml`**: `blobStore.sweepMaxAgeSec` replaces
+  `blobStore.orphanMaxAgeSec`; new defaults, env bindings, and the ≥600s age floor.
+- **`internal/metrics/blobstore.go`** (new): the two sweep counters.
+- **Operational**: deployments that pinned `blobStore.orphanMaxAgeSec` must move to
+  `blobStore.sweepMaxAgeSec` (unknown YAML keys are ignored, so stale configs silently
+  fall back to the new, safer defaults). DAH remains the precise prompt-delete path;
+  the sweeper guarantees a bounded store regardless of what DAH missed.

--- a/openspec/changes/blobstore-age-sweeper/specs/subtree-processing/spec.md
+++ b/openspec/changes/blobstore-age-sweeper/specs/subtree-processing/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Subtree blob store is bounded by an age sweeper
+The service SHALL run a periodic age sweeper against file-backed blob stores, in the
+block-processor only, that deletes top-level 64-lowercase-hex blob files (subtree
+blobs) whose modification time is older than `blobStore.sweepMaxAgeSec` (default 1800),
+and zero-byte files older than ~5 minutes anywhere outside `.dah/`. The sweeper MUST
+NOT touch STUMP blobs (the `stump/` namespace) at any age, MUST NOT touch `.dah/`
+bookkeeping, and MUST NOT delete files whose names do not match the subtree key shape.
+The sweep runs once at startup and then every `blobStore.sweepIntervalSec` (default
+300); either key set to 0 disables the sweeper. A nonzero `blobStore.sweepMaxAgeSec`
+below 600 MUST be rejected at startup. Files and bytes reclaimed SHALL be exposed via
+`merkle_blobstore_swept_files_total` and `merkle_blobstore_swept_bytes_total`.
+
+#### Scenario: Orphaned subtree blob is reclaimed
+- **WHEN** a top-level 64-lowercase-hex blob file's mtime is older than sweepMaxAgeSec because its subtree-work item never completed (no delete-at-height was ever scheduled)
+- **THEN** the sweeper removes it and accounts its size in the swept files/bytes counters, and a later request for that subtree falls through to the DataHub re-fetch path
+
+#### Scenario: STUMP blobs survive any age
+- **WHEN** a blob under the stump/ namespace is older than sweepMaxAgeSec
+- **THEN** the sweeper leaves it in place, because callback-delivery reads STUMPs at delivery time with retry windows up to ~1h
+
+#### Scenario: DAH bookkeeping survives sweeping
+- **WHEN** a .dah/ manifest file is older than sweepMaxAgeSec
+- **THEN** the sweeper leaves it in place and the schedule still fires when its height is reached
+
+#### Scenario: Zero-byte litter is reaped early
+- **WHEN** a zero-byte blob file outside .dah/ is older than ~5 minutes but younger than sweepMaxAgeSec
+- **THEN** the sweeper removes it, because failed writes (ENOSPC) leave empty files that are never valid data
+
+#### Scenario: Sweeper disabled by configuration
+- **WHEN** blobStore.sweepIntervalSec or blobStore.sweepMaxAgeSec is 0
+- **THEN** no sweeper runs and no blob files are age-deleted
+
+#### Scenario: Unsafe sweep age is rejected at startup
+- **WHEN** blobStore.sweepMaxAgeSec is nonzero and below 600
+- **THEN** configuration loading fails, because a sweep age under one block interval could delete the in-flight block's subtree blobs

--- a/openspec/changes/blobstore-age-sweeper/tasks.md
+++ b/openspec/changes/blobstore-age-sweeper/tasks.md
@@ -1,0 +1,48 @@
+## 1. Configuration
+
+- [x] 1.1 Replace `OrphanMaxAgeSec` with `SweepMaxAgeSec` (mapstructure `sweepmaxagesec`)
+  in `config.BlobStoreConfig`; re-document `SweepIntervalSec` (0 disables) with
+  incident-referencing doc comments
+- [x] 1.2 Defaults `blobstore.sweepintervalsec=300`, `blobstore.sweepmaxagesec=1800`;
+  env bindings `BLOB_STORE_SWEEP_INTERVAL_SEC`, `BLOB_STORE_SWEEP_MAX_AGE_SEC`;
+  document both in `config.yaml` with the dev-ovh-1 rationale
+- [x] 1.3 Load() validation: reject negative `sweepIntervalSec`; reject nonzero
+  `sweepMaxAgeSec < 600` (the one-block-interval floor); tests for defaults, env
+  overrides, and the validation table
+
+## 2. Metrics
+
+- [x] 2.1 New `internal/metrics/blobstore.go`: `merkle_blobstore_swept_files_total` and
+  `merkle_blobstore_swept_bytes_total` counters + `AddBlobSweep(files, bytes)`
+
+## 3. Sweeper
+
+- [x] 3.1 `isSubtreeBlobName` (64 lowercase hex) + `SweepOlderThan(maxAge) (files int,
+  bytes int64, err error)` on `FileBlobStore`: top-level subtree blobs older than
+  maxAge removed; zero-byte files older than 5min removed anywhere outside `.dah/`;
+  STUMP (`stump/`) blobs and `.dah/` never touched; per-file errors non-fatal;
+  replaces `SweepOrphans`
+- [x] 3.2 `StartAgeSweeper(interval, maxAge, logger)`: immediate sweep, then ticker;
+  metrics updated every pass; INFO log (files/bytes/maxAge/duration) only when
+  files > 0; idempotent stop; interval clamp guard; replaces `StartOrphanSweeper`
+- [x] 3.3 `StartAgeSweeperFromConfig(blob, cfg, logger)`: no-op for memory stores,
+  interval 0, or max age 0; replaces `StartBlobSweeperFromConfig`
+
+## 4. Wiring (block-processor only)
+
+- [x] 4.1 `store.Registry` gains `Blob BlobStore`; set in the Aerospike and SQL
+  factories; per-process sweeper start removed from both
+- [x] 4.2 `cmd/block-processor/main.go` starts `StartAgeSweeperFromConfig(registry.Blob,
+  cfg.BlobStore, logger)` after registry construction and stops it on shutdown
+
+## 5. Tests
+
+- [x] 5.1 `internal/store/file_blob_sweep_test.go` rewritten for the new contract: old
+  subtree blob swept with bytes accounted; fresh blob kept; aged STUMP never swept;
+  uppercase/63-char/non-hex names never swept; `.dah/` manifests untouched and still
+  firing; zero-byte litter reaped at 10min under a 30min maxAge (including under
+  `stump/`), fresh zero-byte kept, zero-byte `.dah/` file kept; runner sweeps
+  immediately with metric deltas and idempotent stop; from-config helper covers the
+  enabled / interval-0 / max-age-0 / memory-store cases
+- [x] 5.2 Gates: `go build ./...`, `go test ./... -count=1`, `go test -race` on
+  internal/store + internal/config + internal/metrics, `make lint`


### PR DESCRIPTION
Fixes #188.

## Problem

A subtree blob only gets a delete-at-height schedule when its work item completes; anything that never completes (trimmed queues during incident recovery, long parking, crashes between store and schedule) leaks forever. On dev-ovh-1 the store went from ~2% to **100% of 1TiB in ~3 hours** (39,477 orphans + 13,433 zero-byte ENOSPC litter), which then cascaded: fetcher parking, prune-scheduling failures, and peer-health poisoning (#189).

The existing `SweepOrphans` (from #177) made this worse, not better: it swept **every** file older than 24h — **including STUMP blobs**, which callback-delivery reads at delivery time — and ran in every process (a 10-pod sweep herd on shared CephFS). It is replaced wholesale.

## Change

- `SweepOlderThan(maxAge)`: deletes only **top-level 64-lowercase-hex files** (subtree blobs — content-addressed and re-fetchable from DataHub; the miss path carried an entire block at 100% miss rate on 15 Jul) older than `blobStore.sweepMaxAgeSec` (default 1800s ≈ 3 blocks, validated ≥600s so a misconfig can't touch the in-flight block). Zero-byte files are reaped after 5 minutes regardless (including under `stump/`, where an empty blob would be served as empty bytes instead of not-found). `.dah/` is never touched. STUMP blobs keep their existing 6-block DAH — they are deliberately NOT age-swept (delivery retry windows reach ~1h).
- Runs **only in block-processor** (single replica; it already executes the DAH prunes on the same mount) — immediate sweep at startup, then every `blobStore.sweepIntervalSec` (default 300s, 0 disables).
- Config key renamed `orphanMaxAgeSec` → `sweepMaxAgeSec` deliberately: stale operator configs fall back to the new safe defaults instead of silently keeping 24h sweep-everything semantics.
- New metrics: `merkle_blobstore_swept_files_total`, `merkle_blobstore_swept_bytes_total` (scraped since the PodMonitor landed).

DAH remains the precise per-block delete path (height+1 for completed items — steady state stays ~2 blocks of data); the sweeper is the bound on everything DAH misses.

## Verification

- `go build ./...`; `go test ./... -count=1` 21 packages ok; `-race` clean on internal/store, internal/store/sql, internal/config, internal/metrics; `make lint` 0 issues.
- Tests pin: old subtree swept / fresh kept / aged STUMP kept / uppercase-and-non-hex names kept / `.dah` untouched and still functional / zero-byte reaped early incl. under `stump/` / disabled-when-0 / 600s floor validation / metric deltas / idempotent stop.
- openspec change `blobstore-age-sweeper` validates.