### PR TITLE
fix(datahub): stop poisoning the peer-health breaker — caller cancellations and lag-aged 404s are not peer failures

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -495,6 +495,34 @@ datahub:
   # Env: DATAHUB_MAX_SUBTREE_BYTES
   maxSubtreeBytes: 1073741824
 
+  # Peer-health breaker: after failureThreshold consecutive attributed
+  # failures against a peer's host, its announcements are ack-and-dropped
+  # for cooldownSec. Caller cancellations are never attributed, and 404s on
+  # subtree announcements older than stale404GraceSec are attributed to our
+  # own consumer lag (teranode's asset cache holds subtree data ~2h) rather
+  # than the peer — the 2026-07-15 dev-ovh-1 incident showed both
+  # mis-attributions keeping the breaker open indefinitely in a single-peer
+  # topology. Breaker state is visible via merkle_datahub_peer_healthy and
+  # merkle_datahub_peer_unhealthy_transitions_total.
+  peerHealth:
+    # Consecutive attributed failures before a peer host is marked
+    # unhealthy. <= 0 selects the built-in default (3).
+    # Env: DATAHUB_PEER_HEALTH_FAILURE_THRESHOLD
+    failureThreshold: 3
+
+    # Seconds a peer stays unhealthy once tripped; expiry is checked lazily.
+    # <= 0 selects the built-in default (300).
+    # Env: DATAHUB_PEER_HEALTH_COOLDOWN_SEC
+    cooldownSec: 300
+
+    # Announcement age (seconds, from the message's announcedAtUnixMs stamp)
+    # beyond which a subtree-fetch 404 is treated as consumer lag and NOT
+    # counted against the peer. The message still routes to the DLQ; only
+    # peer attribution changes. Unstamped messages are treated as fresh.
+    # <= 0 selects the built-in default (3600).
+    # Env: DATAHUB_PEER_HEALTH_STALE404_GRACE_SEC
+    stale404GraceSec: 3600
+
 # ---------------------------------------------------------------------------
 # Registry — policy for the txid -> callback URL registration store.
 # (applies regardless of whether the backend is Aerospike or SQL)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -572,6 +572,19 @@ type PeerHealthConfig struct {
 	// threshold is reached. Expiry is checked lazily on the next
 	// IsHealthy call.
 	CooldownSec int `yaml:"cooldownSec" mapstructure:"cooldownsec"`
+
+	// Stale404GraceSec is the announcement age (seconds, measured from the
+	// subtree message's AnnouncedAtUnixMs stamp) beyond which a DataHub 404
+	// is attributed to our own consumer lag instead of the peer: teranode's
+	// asset cache retains subtree data for a bounded window (~2h), so a 404
+	// on an announcement that sat in Kafka past this grace says nothing
+	// about the peer's honesty and is not counted against its health. The
+	// message itself still routes to the DLQ as a permanent failure — only
+	// the peer attribution changes. Messages without a stamp are treated
+	// as fresh (404 counted). Default 3600 (see the 2026-07-15 dev-ovh-1
+	// incident: lag-aged 404s re-tripped the breaker after every cooldown,
+	// ack-and-dropping 100% of announcements in a single-peer topology).
+	Stale404GraceSec int `yaml:"stale404GraceSec" mapstructure:"stale404gracesec"`
 }
 
 // registerDefaults sets all default values in the Viper instance.
@@ -721,6 +734,9 @@ func registerDefaults(v *viper.Viper) {
 	// Peer-health tracker defaults: 3 consecutive failures → 5m unhealthy.
 	v.SetDefault("datahub.peerhealth.failurethreshold", 3)
 	v.SetDefault("datahub.peerhealth.cooldownsec", 300)
+	// 404s on announcements older than an hour are our consumer lag, not a
+	// lying peer (teranode's asset cache holds ~2h) — don't count them.
+	v.SetDefault("datahub.peerhealth.stale404gracesec", 3600)
 
 	// Registry
 	v.SetDefault("registry.maxcallbackspertxid", 10)
@@ -873,6 +889,7 @@ func bindEnvVars(v *viper.Viper) {
 		"datahub.fallbackurls":                "DATAHUB_FALLBACK_URLS",
 		"datahub.peerhealth.failurethreshold": "DATAHUB_PEER_HEALTH_FAILURE_THRESHOLD",
 		"datahub.peerhealth.cooldownsec":      "DATAHUB_PEER_HEALTH_COOLDOWN_SEC",
+		"datahub.peerhealth.stale404gracesec": "DATAHUB_PEER_HEALTH_STALE404_GRACE_SEC",
 
 		// Registry
 		"registry.maxcallbackspertxid": "REGISTRY_MAX_CALLBACKS_PER_TXID",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -506,6 +506,57 @@ func TestLoad_LogLevelEnvOverride(t *testing.T) {
 	}
 }
 
+// TestLoad_DataHubPeerHealthDefaults pins the peer-health breaker defaults,
+// including the stale-404 grace added after the 2026-07-15 dev-ovh-1
+// incident (consumer lag aged announcements past teranode's ~2h asset-cache
+// retention; every resulting 404 re-tripped the breaker after each
+// cooldown even though the peer was fine).
+func TestLoad_DataHubPeerHealthDefaults(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	if cfg.DataHub.PeerHealth.FailureThreshold != 3 {
+		t.Errorf("DataHub.PeerHealth.FailureThreshold: expected 3, got %d", cfg.DataHub.PeerHealth.FailureThreshold)
+	}
+	if cfg.DataHub.PeerHealth.CooldownSec != 300 {
+		t.Errorf("DataHub.PeerHealth.CooldownSec: expected 300, got %d", cfg.DataHub.PeerHealth.CooldownSec)
+	}
+	if cfg.DataHub.PeerHealth.Stale404GraceSec != 3600 {
+		t.Errorf("DataHub.PeerHealth.Stale404GraceSec: expected 3600, got %d", cfg.DataHub.PeerHealth.Stale404GraceSec)
+	}
+}
+
+// TestLoad_DataHubPeerHealthEnvBinding proves the bindEnvVars entries for
+// the datahub.peerhealth keys — a missing binding would silently leave the
+// env var ignored.
+func TestLoad_DataHubPeerHealthEnvBinding(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")
+	t.Setenv("DATAHUB_PEER_HEALTH_FAILURE_THRESHOLD", "5")
+	t.Setenv("DATAHUB_PEER_HEALTH_COOLDOWN_SEC", "120")
+	t.Setenv("DATAHUB_PEER_HEALTH_STALE404_GRACE_SEC", "900")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	if cfg.DataHub.PeerHealth.FailureThreshold != 5 {
+		t.Errorf("DataHub.PeerHealth.FailureThreshold: expected 5, got %d", cfg.DataHub.PeerHealth.FailureThreshold)
+	}
+	if cfg.DataHub.PeerHealth.CooldownSec != 120 {
+		t.Errorf("DataHub.PeerHealth.CooldownSec: expected 120, got %d", cfg.DataHub.PeerHealth.CooldownSec)
+	}
+	if cfg.DataHub.PeerHealth.Stale404GraceSec != 900 {
+		t.Errorf("DataHub.PeerHealth.Stale404GraceSec: expected 900, got %d", cfg.DataHub.PeerHealth.Stale404GraceSec)
+	}
+}
+
 func TestLoad_TelemetryDefaults(t *testing.T) {
 	clearConfigEnv(t)
 	t.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")

--- a/internal/datahub/client.go
+++ b/internal/datahub/client.go
@@ -109,11 +109,33 @@ type Client struct {
 }
 
 // SetPeerHealth attaches a PeerHealth tracker. After this call, every
-// Fetch* invocation records success or failure against the tracker
-// before returning. Passing nil disables tracking. Safe to call once at
+// Fetch* invocation records success or failure against the tracker before
+// returning — unless the caller's ctx is already dead at record time
+// (cancellation says nothing about the peer; see recordPeerOutcome) or the
+// call site opted out via WithoutPeerRecording to classify and record the
+// outcome itself. Passing nil disables tracking. Safe to call once at
 // startup; not safe to call concurrently with in-flight requests.
 func (c *Client) SetPeerHealth(p *PeerHealth) {
 	c.peerHealth = p
+}
+
+// FetchOption customizes a single fetch call. Currently only used to opt a
+// call site out of the client's internal peer-health recording.
+type FetchOption func(*fetchOptions)
+
+type fetchOptions struct {
+	skipPeerRecording bool
+}
+
+// WithoutPeerRecording disables the client's internal peer-health recording
+// for one fetch. Call sites that can classify outcomes better than the
+// client — the subtree processor knows the announcement's age and can tell
+// a stale-announcement 404 (our consumer lag) from a peer lying about fresh
+// data — use this and record against Client.PeerHealth() themselves.
+func WithoutPeerRecording() FetchOption {
+	return func(o *fetchOptions) {
+		o.skipPeerRecording = true
+	}
 }
 
 // PeerHealth returns the attached tracker, or nil if none was set. Call
@@ -256,14 +278,22 @@ type BlockMetadata struct {
 // FetchSubtreeRaw fetches raw binary subtree data from a DataHub endpoint.
 // dataHubURL is treated as untrusted (it flows from peer-controlled P2P
 // announcements) and is validated against the SSRF predicate before any
-// network I/O happens.
-func (c *Client) FetchSubtreeRaw(ctx context.Context, dataHubURL, hash string) ([]byte, error) {
+// network I/O happens. Pass WithoutPeerRecording to suppress the client's
+// internal peer-health recording for this call (the subtree processor does,
+// so it can classify 404s by announcement age before recording).
+func (c *Client) FetchSubtreeRaw(ctx context.Context, dataHubURL, hash string, opts ...FetchOption) ([]byte, error) {
+	var o fetchOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
 	if err := c.validateDataHubURL(dataHubURL); err != nil {
 		return nil, err
 	}
 	url := fmt.Sprintf("%s/subtree/%s", dataHubURL, hash)
 	data, err := c.doGetWithRetry(ctx, url, c.maxSubtreeBytes)
-	c.recordPeerOutcome(dataHubURL, err)
+	if !o.skipPeerRecording {
+		c.recordPeerOutcome(ctx, dataHubURL, err)
+	}
 	return data, err
 }
 
@@ -371,7 +401,7 @@ func (c *Client) FetchBlockMetadata(ctx context.Context, dataHubURL, hash string
 	url := fmt.Sprintf("%s/block/%s", dataHubURL, hash)
 	data, err := c.doGetWithRetry(ctx, url, c.maxBlockBytes)
 	if err != nil {
-		c.recordPeerOutcome(dataHubURL, err)
+		c.recordPeerOutcome(ctx, dataHubURL, err)
 		return nil, fmt.Errorf("fetching block metadata %s: %w", hash, err)
 	}
 
@@ -380,28 +410,51 @@ func (c *Client) FetchBlockMetadata(ctx context.Context, dataHubURL, hash string
 		// Parse failure is a peer-side issue (malformed response): the
 		// transport succeeded but the body the peer returned cannot be
 		// trusted. Count it against the peer.
-		c.recordPeerOutcome(dataHubURL, err)
+		c.recordPeerOutcome(ctx, dataHubURL, err)
 		return nil, fmt.Errorf("parsing block metadata %s: %w", hash, err)
 	}
 
-	c.recordPeerOutcome(dataHubURL, nil)
+	c.recordPeerOutcome(ctx, dataHubURL, nil)
 	return meta, nil
 }
 
 // recordPeerOutcome forwards a fetch outcome to the attached PeerHealth
-// tracker, if any. A nil err counts as a success and resets the peer's
+// tracker, if any.
+//
+// Cancellation-neutral: when the CALLER's ctx is already dead at record
+// time, nothing is recorded — neither failure nor success. A pod shutdown,
+// consumer rebalance, or partition loss aborting an in-flight fetch says
+// nothing about the peer, and on dev-ovh-1 (2026-07-15) exactly those
+// context.Canceled errors tripped the breaker on fresh pods within minutes
+// of a rollout. The client's OWN HTTP timeout firing while the caller ctx
+// is alive still records a failure: peer slowness is peer-attributable.
+// The two cases are distinguished via ctx.Err(), never by error string.
+//
+// Otherwise a nil err counts as a success and resets the peer's
 // consecutive-failure counter; a non-nil err counts as a failure regardless
 // of category (404, 5xx, timeout, network, parse) so a peer that lies
-// about the data it has is treated as unhealthy.
-func (c *Client) recordPeerOutcome(dataHubURL string, err error) {
+// about the data it has is treated as unhealthy. A breaker-opening failure
+// is WARN-logged here with the breaker parameters.
+func (c *Client) recordPeerOutcome(ctx context.Context, dataHubURL string, err error) {
 	if c.peerHealth == nil {
+		return
+	}
+	if ctx.Err() != nil {
 		return
 	}
 	if err == nil {
 		c.peerHealth.RecordSuccess(dataHubURL)
 		return
 	}
-	c.peerHealth.RecordFailure(dataHubURL)
+	if tripped := c.peerHealth.RecordFailure(dataHubURL); tripped {
+		c.logger.Warn(
+			"DataHub peer marked unhealthy: consecutive-failure threshold reached",
+			logfields.DataHubURL(dataHubURL),
+			"failureThreshold", c.peerHealth.Threshold(),
+			"cooldown", c.peerHealth.Cooldown().String(),
+			"error", err,
+		)
+	}
 }
 
 // dataHubURLValidationTTL bounds how long a successful SSRF validation of a

--- a/internal/datahub/client_test.go
+++ b/internal/datahub/client_test.go
@@ -3,6 +3,7 @@ package datahub
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -566,6 +567,128 @@ func TestFetch_RecordsPeerHealth(t *testing.T) {
 	}
 	if !ph.IsHealthy(server.URL) {
 		t.Fatal("success should restore peer health")
+	}
+}
+
+// TestRecordPeerOutcome_CanceledContextRecordsNothing pins the
+// cancellation-neutral contract at the recording chokepoint: when the
+// caller's ctx is already dead at record time, NOTHING is recorded —
+// neither a failure (a pod shutdown/rebalance aborting an in-flight fetch
+// says nothing about the peer; on dev-ovh-1 one rollout tripped the breaker
+// on fresh pods within minutes) nor a success (a dead ctx must not reset a
+// genuinely failing peer's counter either).
+func TestRecordPeerOutcome_CanceledContextRecordsNothing(t *testing.T) {
+	client := NewClient(5, 0, testLogger())
+	ph := NewPeerHealth(3, 10*time.Minute)
+	client.SetPeerHealth(ph)
+	url := "https://cancel-neutral.example.com/api"
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	live := context.Background()
+
+	// Failure with a dead ctx: not recorded, even many times over threshold.
+	for i := 0; i < 5; i++ {
+		client.recordPeerOutcome(canceled, url, errors.New("connection reset"))
+	}
+	if !ph.IsHealthy(url) {
+		t.Fatal("failures recorded under a canceled ctx must not count against the peer")
+	}
+
+	// Success with a dead ctx: not recorded either. Two live failures, a
+	// canceled-ctx success, then a third live failure must still trip —
+	// proving the success did not reset the consecutive-failure counter.
+	client.recordPeerOutcome(live, url, errors.New("boom"))
+	client.recordPeerOutcome(live, url, errors.New("boom"))
+	client.recordPeerOutcome(canceled, url, nil)
+	client.recordPeerOutcome(live, url, errors.New("boom"))
+	if ph.IsHealthy(url) {
+		t.Fatal("a canceled-ctx success must not reset the failure counter")
+	}
+}
+
+// TestFetchSubtreeRaw_CallerCancellationNotRecorded drives the incident path
+// end to end: a caller ctx canceled mid-fetch (shutdown, rebalance,
+// partition loss) aborts the request, and the resulting error must not be
+// attributed to the peer.
+func TestFetchSubtreeRaw_CallerCancellationNotRecorded(t *testing.T) {
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release // hold the request open until the client has gone away
+	}))
+	defer server.Close()
+	defer close(release)
+
+	client := NewClient(5, 0, testLogger())
+	ph := NewPeerHealth(1, 10*time.Minute) // a single counted failure would trip
+	client.SetPeerHealth(ph)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	if _, err := client.FetchSubtreeRaw(ctx, server.URL, "abc123"); err == nil {
+		t.Fatal("expected an error from the canceled fetch")
+	}
+	if !ph.IsHealthy(server.URL) {
+		t.Fatal("caller cancellation must not be recorded as a peer failure")
+	}
+}
+
+// TestFetchSubtreeRaw_ClientTimeoutRecordsFailure pins the flip side of
+// cancellation neutrality: when the client's own HTTP timeout fires while
+// the caller ctx is still alive, the peer really was too slow — that IS
+// peer-attributable and must count. The two cases are distinguished by
+// ctx.Err(), never by matching error strings.
+func TestFetchSubtreeRaw_ClientTimeoutRecordsFailure(t *testing.T) {
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release // slower than the client timeout below
+	}))
+	defer server.Close()
+	defer close(release)
+
+	client := NewClient(5, 0, testLogger())
+	client.httpClient.Timeout = 50 * time.Millisecond
+	ph := NewPeerHealth(1, 10*time.Minute)
+	client.SetPeerHealth(ph)
+
+	if _, err := client.FetchSubtreeRaw(context.Background(), server.URL, "abc123"); err == nil {
+		t.Fatal("expected a timeout error")
+	}
+	if ph.IsHealthy(server.URL) {
+		t.Fatal("client HTTP timeout with a live caller ctx must count against the peer")
+	}
+}
+
+// TestFetchSubtreeRaw_WithoutPeerRecording verifies the opt-out the subtree
+// processor uses to take over recording: with the option the client records
+// neither success nor failure, and without it the default recording path is
+// unchanged.
+func TestFetchSubtreeRaw_WithoutPeerRecording(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := NewClient(5, 0, testLogger())
+	ph := NewPeerHealth(1, 10*time.Minute)
+	client.SetPeerHealth(ph)
+
+	_, err := client.FetchSubtreeRaw(context.Background(), server.URL, "abc123", WithoutPeerRecording())
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+	if !ph.IsHealthy(server.URL) {
+		t.Fatal("WithoutPeerRecording must suppress the client's internal failure recording")
+	}
+
+	// Default path (no option) still records.
+	_, _ = client.FetchSubtreeRaw(context.Background(), server.URL, "abc123")
+	if ph.IsHealthy(server.URL) {
+		t.Fatal("default FetchSubtreeRaw must still record the failure")
 	}
 }
 

--- a/internal/datahub/peerhealth.go
+++ b/internal/datahub/peerhealth.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 )
 
 // DefaultPeerHealthFailureThreshold is the number of consecutive failures
@@ -15,6 +17,14 @@ const DefaultPeerHealthFailureThreshold = 3
 // unhealthy after crossing the failure threshold. Cooldown expiry is
 // checked lazily on the next IsHealthy call.
 const DefaultPeerHealthCooldown = 5 * time.Minute
+
+// DefaultStale404Grace is the default announcement age beyond which a 404
+// on a subtree fetch is attributed to our own consumer lag rather than the
+// announcing peer (config key datahub.peerhealth.stale404GraceSec).
+// Teranode's asset cache retains subtree data for a bounded window (~2h);
+// an announcement that sat in Kafka for over an hour can legitimately 404
+// on an honest peer, so such a 404 must not feed the peer-health breaker.
+const DefaultStale404Grace = time.Hour
 
 // PeerHealth tracks consecutive-failure state per DataHub peer so call
 // sites (block-processor metadata fetch, /reprocess probe loop) can skip
@@ -66,9 +76,30 @@ func NewPeerHealth(threshold int, cooldown time.Duration) *PeerHealth {
 	}
 }
 
+// Threshold returns the consecutive-failure threshold. Zero for a nil
+// receiver. Exposed so trip-logging call sites can include the breaker
+// parameters in their WARN line.
+func (p *PeerHealth) Threshold() int {
+	if p == nil {
+		return 0
+	}
+	return p.threshold
+}
+
+// Cooldown returns how long a peer stays unhealthy once tripped. Zero for
+// a nil receiver.
+func (p *PeerHealth) Cooldown() time.Duration {
+	if p == nil {
+		return 0
+	}
+	return p.cooldown
+}
+
 // IsHealthy reports whether rawURL's host is currently considered healthy.
 // An unknown peer is healthy by default. An unhealthy entry whose cooldown
-// has elapsed is auto-cleared and reported healthy.
+// has elapsed is auto-cleared and reported healthy. The per-peer health
+// gauge is refreshed on every call so first sight and lazy cooldown-expiry
+// recovery are both visible in metrics.
 func (p *PeerHealth) IsHealthy(rawURL string) bool {
 	if p == nil {
 		return true
@@ -81,28 +112,37 @@ func (p *PeerHealth) IsHealthy(rawURL string) bool {
 	defer p.mu.Unlock()
 	st, ok := p.state[key]
 	if !ok {
+		metrics.SetPeerHealthy(rawURL, true)
 		return true
 	}
 	if st.unhealthyUntil.IsZero() {
+		metrics.SetPeerHealthy(rawURL, true)
 		return true
 	}
 	if !p.now().Before(st.unhealthyUntil) {
 		st.unhealthyUntil = time.Time{}
 		st.consecutiveFailures = 0
+		metrics.SetPeerHealthy(rawURL, true)
 		return true
 	}
+	metrics.SetPeerHealthy(rawURL, false)
 	return false
 }
 
-// RecordFailure increments rawURL's consecutive-failure counter and
-// marks the peer unhealthy once Threshold is reached.
-func (p *PeerHealth) RecordFailure(rawURL string) {
+// RecordFailure increments rawURL's consecutive-failure counter and marks
+// the peer unhealthy once Threshold is reached. It reports whether THIS
+// call transitioned the peer from healthy to unhealthy — true exactly once
+// per breaker opening (a peer whose cooldown has lapsed counts as healthy
+// again, so re-tripping after expiry reports a new transition). Callers
+// use the signal to WARN-log breaker openings; the transition counter and
+// health gauge are updated here so every caller is covered.
+func (p *PeerHealth) RecordFailure(rawURL string) bool {
 	if p == nil {
-		return
+		return false
 	}
 	key := peerKey(rawURL)
 	if key == "" {
-		return
+		return false
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -111,14 +151,25 @@ func (p *PeerHealth) RecordFailure(rawURL string) {
 		st = &peerState{}
 		p.state[key] = st
 	}
+	now := p.now()
+	wasUnhealthy := !st.unhealthyUntil.IsZero() && now.Before(st.unhealthyUntil)
 	st.consecutiveFailures++
+	tripped := false
 	if st.consecutiveFailures >= p.threshold {
-		st.unhealthyUntil = p.now().Add(p.cooldown)
+		st.unhealthyUntil = now.Add(p.cooldown)
+		tripped = !wasUnhealthy
 	}
+	if tripped {
+		metrics.IncPeerUnhealthyTransition(rawURL)
+	}
+	stillHealthy := st.unhealthyUntil.IsZero() || !now.Before(st.unhealthyUntil)
+	metrics.SetPeerHealthy(rawURL, stillHealthy)
+	return tripped
 }
 
 // RecordSuccess clears any unhealthy flag and resets the consecutive
-// failure counter for rawURL.
+// failure counter for rawURL, and refreshes the health gauge (first sight
+// of a peer via a successful fetch also registers it as healthy).
 func (p *PeerHealth) RecordSuccess(rawURL string) {
 	if p == nil {
 		return
@@ -129,6 +180,7 @@ func (p *PeerHealth) RecordSuccess(rawURL string) {
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	metrics.SetPeerHealthy(rawURL, true)
 	st, ok := p.state[key]
 	if !ok {
 		return

--- a/internal/datahub/peerhealth_test.go
+++ b/internal/datahub/peerhealth_test.go
@@ -4,6 +4,10 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
 )
 
 func TestPeerHealth_HealthyByDefault(t *testing.T) {
@@ -113,6 +117,161 @@ func TestPeerHealth_NilReceiverIsSafe(t *testing.T) {
 	p.RecordSuccess("https://x.example.com/")
 	if !p.IsHealthy("https://x.example.com/") {
 		t.Fatal("nil PeerHealth should report all peers healthy")
+	}
+}
+
+// TestPeerHealth_RecordFailureReportsTripExactlyOnce pins the breaker-trip
+// signal call sites use for WARN logging: RecordFailure returns true exactly
+// once per healthy→unhealthy transition — not before the threshold, and not
+// again while the breaker is already open.
+func TestPeerHealth_RecordFailureReportsTripExactlyOnce(t *testing.T) {
+	p := NewPeerHealth(3, time.Minute)
+	url := "https://trip.example.com/api"
+
+	if p.RecordFailure(url) {
+		t.Fatal("failure 1 of 3 must not report a trip")
+	}
+	if p.RecordFailure(url) {
+		t.Fatal("failure 2 of 3 must not report a trip")
+	}
+	if !p.RecordFailure(url) {
+		t.Fatal("failure 3 of 3 must report the healthy→unhealthy transition")
+	}
+	if p.RecordFailure(url) {
+		t.Fatal("failure while already unhealthy must not report a second trip")
+	}
+
+	// Recovery and a fresh run of failures reports a fresh trip.
+	p.RecordSuccess(url)
+	p.RecordFailure(url)
+	p.RecordFailure(url)
+	if !p.RecordFailure(url) {
+		t.Fatal("re-tripping after a success-reset must report the transition again")
+	}
+}
+
+// TestPeerHealth_RecordFailureReportsTripAfterCooldownExpiry covers the lazy
+// recovery path: once the cooldown has elapsed the peer is healthy again, so
+// the next threshold-crossing failure is a new healthy→unhealthy transition.
+func TestPeerHealth_RecordFailureReportsTripAfterCooldownExpiry(t *testing.T) {
+	p := NewPeerHealth(2, time.Minute)
+	now := time.Unix(1_700_000_000, 0)
+	p.now = func() time.Time { return now }
+	url := "https://retrip.example.com/api"
+
+	p.RecordFailure(url)
+	if !p.RecordFailure(url) {
+		t.Fatal("threshold crossing must report a trip")
+	}
+
+	// Cooldown elapses; the peer is healthy again even without an IsHealthy
+	// call having cleared the state.
+	now = now.Add(2 * time.Minute)
+	if !p.RecordFailure(url) {
+		t.Fatal("first re-trip after cooldown expiry must report a new transition")
+	}
+	if p.RecordFailure(url) {
+		t.Fatal("failure while the re-opened breaker is unexpired must not report a trip")
+	}
+}
+
+// TestPeerHealth_ThresholdCooldownAccessors pins the getters trip-logging
+// call sites use to include breaker parameters in the WARN line.
+func TestPeerHealth_ThresholdCooldownAccessors(t *testing.T) {
+	p := NewPeerHealth(4, 7*time.Minute)
+	if p.Threshold() != 4 {
+		t.Errorf("Threshold: expected 4, got %d", p.Threshold())
+	}
+	if p.Cooldown() != 7*time.Minute {
+		t.Errorf("Cooldown: expected 7m, got %s", p.Cooldown())
+	}
+}
+
+// TestPeerHealth_NilRecordFailureReturnsFalse extends the nil-receiver
+// contract to the trip signal.
+func TestPeerHealth_NilRecordFailureReturnsFalse(t *testing.T) {
+	var p *PeerHealth
+	if p.RecordFailure("https://x.example.com/") {
+		t.Fatal("nil PeerHealth must never report a trip")
+	}
+}
+
+// TestPeerHealth_BreakerMetrics verifies the observability surface added for
+// the 2026-07-15 breaker-poisoning incident: a transitions counter that
+// increments once per healthy→unhealthy flip, and a per-peer health gauge
+// that tracks state through trip, success recovery, and cooldown-expiry
+// recovery (both inside IsHealthy and inside RecordFailure's lazy check).
+func TestPeerHealth_BreakerMetrics(t *testing.T) {
+	p := NewPeerHealth(2, time.Minute)
+	now := time.Unix(1_700_000_000, 0)
+	p.now = func() time.Time { return now }
+
+	// Unique host per test run concern: this test owns this label.
+	url := "https://metrics-peer.example.com/api"
+	const host = "metrics-peer.example.com"
+
+	transitions := func() float64 {
+		return testutil.ToFloat64(metrics.PeerUnhealthyTransitionsTotal.WithLabelValues(host))
+	}
+	gauge := func() float64 {
+		return testutil.ToFloat64(metrics.PeerHealthyGauge.WithLabelValues(host))
+	}
+
+	// First sight via IsHealthy: gauge exists and reads healthy.
+	if !p.IsHealthy(url) {
+		t.Fatal("unknown peer should be healthy")
+	}
+	if gauge() != 1 {
+		t.Errorf("gauge after first sight: expected 1, got %v", gauge())
+	}
+
+	base := transitions()
+
+	// One failure below threshold: still healthy.
+	p.RecordFailure(url)
+	if gauge() != 1 {
+		t.Errorf("gauge below threshold: expected 1, got %v", gauge())
+	}
+	if transitions() != base {
+		t.Errorf("transitions below threshold: expected %v, got %v", base, transitions())
+	}
+
+	// Trip.
+	p.RecordFailure(url)
+	if gauge() != 0 {
+		t.Errorf("gauge after trip: expected 0, got %v", gauge())
+	}
+	if transitions() != base+1 {
+		t.Errorf("transitions after trip: expected %v, got %v", base+1, transitions())
+	}
+
+	// Additional failure while open: no new transition.
+	p.RecordFailure(url)
+	if transitions() != base+1 {
+		t.Errorf("transitions while open: expected %v, got %v", base+1, transitions())
+	}
+
+	// Recovery via RecordSuccess.
+	p.RecordSuccess(url)
+	if gauge() != 1 {
+		t.Errorf("gauge after success recovery: expected 1, got %v", gauge())
+	}
+
+	// Trip again, then recover via cooldown expiry observed by IsHealthy.
+	p.RecordFailure(url)
+	p.RecordFailure(url)
+	if transitions() != base+2 {
+		t.Errorf("transitions after second trip: expected %v, got %v", base+2, transitions())
+	}
+	if gauge() != 0 {
+		t.Errorf("gauge after second trip: expected 0, got %v", gauge())
+	}
+	now = now.Add(2 * time.Minute)
+	if !p.IsHealthy(url) {
+		t.Fatal("peer should recover after cooldown")
+	}
+	if gauge() != 1 {
+		t.Errorf("gauge after cooldown-expiry recovery: expected 1, got %v", gauge())
 	}
 }
 

--- a/internal/kafka/messages.go
+++ b/internal/kafka/messages.go
@@ -25,6 +25,17 @@ type SubtreeMessage struct {
 	PeerID       string `json:"peerId"`
 	ClientName   string `json:"clientName"`
 	AttemptCount int    `json:"attemptCount,omitempty"`
+
+	// AnnouncedAtUnixMs is the wall-clock time (Unix milliseconds) at which
+	// the P2P client observed the announcement and published this message.
+	// The subtree-fetcher uses it to classify a DataHub 404: teranode's
+	// asset cache only retains subtree data for a bounded window (~2h), so
+	// a 404 on a message that sat in Kafka past
+	// datahub.peerhealth.stale404GraceSec is our own consumer lag, not a
+	// lying peer, and must not poison the peer-health breaker. Zero or
+	// missing (messages produced before this field existed, retries of
+	// such messages) means "age unknown" and is treated as fresh.
+	AnnouncedAtUnixMs int64 `json:"announcedAtUnixMs,omitempty"`
 }
 
 // BlockMessage represents a block announcement received from P2P, or an

--- a/internal/kafka/messages_test.go
+++ b/internal/kafka/messages_test.go
@@ -38,6 +38,55 @@ func TestSubtreeMessage_EncodeDecode(t *testing.T) {
 	}
 }
 
+// TestSubtreeMessage_AnnouncedAtRoundTrip pins the announcement-time stamp
+// the subtree-fetcher uses for stale-404 peer-health attribution: the field
+// must survive an encode/decode round trip (including through the retry
+// republish path, which re-encodes the same struct).
+func TestSubtreeMessage_AnnouncedAtRoundTrip(t *testing.T) {
+	announced := time.Now().Add(-2 * time.Hour).UnixMilli()
+	msg := &SubtreeMessage{
+		Hash:              "subtree-hash-123",
+		DataHubURL:        "https://datahub.example.com/subtree/123",
+		AnnouncedAtUnixMs: announced,
+	}
+
+	data, err := msg.Encode()
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+	decoded, err := DecodeSubtreeMessage(data)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if decoded.AnnouncedAtUnixMs != announced {
+		t.Errorf("announcedAtUnixMs: expected %d, got %d", announced, decoded.AnnouncedAtUnixMs)
+	}
+}
+
+// TestSubtreeMessage_AnnouncedAtBackwardCompatible pins wire compatibility
+// with in-flight messages produced before the stamp existed: decoding JSON
+// without the field yields zero ("age unknown"), and encoding a zero stamp
+// omits the field entirely so older consumers see an unchanged payload.
+func TestSubtreeMessage_AnnouncedAtBackwardCompatible(t *testing.T) {
+	legacy := []byte(`{"hash":"h1","dataHubUrl":"https://dh.example/api","peerId":"p","clientName":"c"}`)
+	decoded, err := DecodeSubtreeMessage(legacy)
+	if err != nil {
+		t.Fatalf("decode legacy payload failed: %v", err)
+	}
+	if decoded.AnnouncedAtUnixMs != 0 {
+		t.Errorf("legacy payload should decode with zero announcedAtUnixMs, got %d", decoded.AnnouncedAtUnixMs)
+	}
+
+	msg := &SubtreeMessage{Hash: "h1", DataHubURL: "https://dh.example/api"}
+	data, err := msg.Encode()
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+	if strings.Contains(string(data), "announcedAtUnixMs") {
+		t.Errorf("zero announcedAtUnixMs must be omitted from JSON, got %s", data)
+	}
+}
+
 func TestBlockMessage_EncodeDecode(t *testing.T) {
 	msg := &BlockMessage{
 		Hash:       "blockhash123",

--- a/internal/metrics/peerhealth.go
+++ b/internal/metrics/peerhealth.go
@@ -1,0 +1,55 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// PeerUnhealthyTransitionsTotal counts healthy→unhealthy transitions of the
+// DataHub peer-health breaker, per peer host. This is the visibility the
+// 2026-07-15 dev-ovh-1 incident lacked: the breaker silently opened on
+// mis-attributed failures (caller cancellations, stale-announcement 404s)
+// and, in a single-peer topology, ack-and-dropped 100% of subtree
+// announcements with nothing on a dashboard to say why.
+var PeerUnhealthyTransitionsTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "merkle_datahub_peer_unhealthy_transitions_total",
+		Help: "Healthy-to-unhealthy transitions of the DataHub peer-health breaker, per peer host.",
+	},
+	[]string{labelPeerHost},
+)
+
+// PeerHealthyGauge reports the current DataHub peer-health breaker state per
+// peer host: 1 healthy, 0 unhealthy (in its cooldown window). Set on first
+// sight of a peer and on every transition, including lazy cooldown-expiry
+// recovery.
+var PeerHealthyGauge = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "merkle_datahub_peer_healthy",
+		Help: "Whether a DataHub peer is currently considered healthy (1) or in its unhealthy cooldown (0).",
+	},
+	[]string{labelPeerHost},
+)
+
+func init() {
+	Registry.MustRegister(
+		PeerUnhealthyTransitionsTotal,
+		PeerHealthyGauge,
+	)
+}
+
+// IncPeerUnhealthyTransition records one healthy→unhealthy breaker
+// transition for the peer identified by peerURL (labeled by host only, per
+// the registry cardinality policy).
+func IncPeerUnhealthyTransition(peerURL string) {
+	PeerUnhealthyTransitionsTotal.WithLabelValues(HostLabel(peerURL)).Inc()
+}
+
+// SetPeerHealthy sets the per-peer health gauge for the peer identified by
+// peerURL (labeled by host only, per the registry cardinality policy).
+func SetPeerHealthy(peerURL string, healthy bool) {
+	v := 0.0
+	if healthy {
+		v = 1.0
+	}
+	PeerHealthyGauge.WithLabelValues(HostLabel(peerURL)).Set(v)
+}

--- a/internal/p2p/client.go
+++ b/internal/p2p/client.go
@@ -540,6 +540,11 @@ func (c *Client) handleSubtreeMessage(ctx context.Context, msg teranode.SubtreeM
 		DataHubURL: msg.DataHubURL,
 		PeerID:     msg.PeerID,
 		ClientName: msg.ClientName,
+		// Stamp the announcement time so the subtree-fetcher can classify a
+		// later DataHub 404: consumer lag can age a message past teranode's
+		// ~2h asset-cache retention, and a 404 on such a stale announcement
+		// is our lag — it must not count against the peer's health.
+		AnnouncedAtUnixMs: time.Now().UnixMilli(),
 	}
 
 	encoded, err := kafkaMsg.Encode()

--- a/internal/p2p/client_test.go
+++ b/internal/p2p/client_test.go
@@ -128,6 +128,38 @@ func TestHandleSubtreeMessage_ValidMessage(t *testing.T) {
 	}
 }
 
+// TestHandleSubtreeMessage_StampsAnnouncedAt verifies the P2P client stamps
+// AnnouncedAtUnixMs at publish time, so the subtree-fetcher can tell a
+// stale-announcement 404 (our consumer lag) from a peer 404 on fresh data.
+func TestHandleSubtreeMessage_StampsAnnouncedAt(t *testing.T) {
+	client, mockProducer, _ := newTestClient(t)
+
+	msg := teranode.SubtreeMessage{
+		Hash:       "subtree-stamped",
+		DataHubURL: "https://datahub.example.com/subtree/abc",
+		PeerID:     "peer1",
+	}
+
+	before := time.Now().UnixMilli()
+	if err := client.handleSubtreeMessage(context.Background(), msg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	after := time.Now().UnixMilli()
+
+	published := mockProducer.getMessages()
+	if len(published) != 1 {
+		t.Fatalf("expected 1 published message, got %d", len(published))
+	}
+	decoded, err := kafka.DecodeSubtreeMessage(published[0].Value)
+	if err != nil {
+		t.Fatalf("failed to decode published subtree message: %v", err)
+	}
+	if decoded.AnnouncedAtUnixMs < before || decoded.AnnouncedAtUnixMs > after {
+		t.Errorf("announcedAtUnixMs %d outside publish window [%d, %d]",
+			decoded.AnnouncedAtUnixMs, before, after)
+	}
+}
+
 func TestHandleSubtreeMessage_EmptyHash(t *testing.T) {
 	client, mockProducer, _ := newTestClient(t)
 

--- a/internal/subtree/processor.go
+++ b/internal/subtree/processor.go
@@ -101,8 +101,10 @@ func (p *Processor) Init(_ interface{}) error {
 	// operator opts in via DataHub.AllowPrivateIPs (F-028). A PeerHealth
 	// tracker is attached so subtree fetch outcomes feed into the same
 	// "is this peer dead?" signal /reprocess uses — note the subtree
-	// processor does not skip peers itself (the announced URL is
-	// authoritative for which peer has the subtree), it only records.
+	// processor does not fail over to other peers itself (the announced
+	// URL is authoritative for which peer has the subtree); it gates on
+	// IsHealthy and records outcomes after classifying them by ctx state
+	// and announcement age (see recordPeerFetchOutcome).
 	p.dataHubClient = datahub.NewClientWithSSRFGuard(
 		p.cfg.DataHub.TimeoutSec,
 		p.cfg.DataHub.MaxRetries,
@@ -348,17 +350,25 @@ func (p *Processor) handleMessage(ctx context.Context, msg *kafka.Message) error
 		return nil
 	}
 
-	// 3.2: Fetch binary subtree data from DataHub.
+	// 3.2: Fetch binary subtree data from DataHub. The client's internal
+	// peer-health recording is suppressed for this call site: only the
+	// processor knows the announcement's age, so it classifies the outcome
+	// and records explicitly (see recordPeerFetchOutcome) — a blanket
+	// "any error is a peer failure" rule is exactly what poisoned the
+	// breaker on dev-ovh-1 (caller cancellations and lag-aged 404s).
 	fetchStart := time.Now()
-	rawData, err := p.dataHubClient.FetchSubtreeRaw(ctx, subtreeMsg.DataHubURL, subtreeMsg.Hash)
+	rawData, err := p.dataHubClient.FetchSubtreeRaw(ctx, subtreeMsg.DataHubURL, subtreeMsg.Hash, datahub.WithoutPeerRecording())
 	metrics.ObserveSubtreeDataHubFetch(subtreeMsg.DataHubURL, time.Since(fetchStart), len(rawData), err)
+	p.recordPeerFetchOutcome(ctx, subtreeMsg, err)
 	if err != nil {
 		// A 404 from the announcing peer is permanent for that peer: subtrees
 		// are content-addressable, so retrying the same URL cannot recover.
-		// Route straight to DLQ; the peer-health tracker has already counted
-		// this failure and will cause subsequent announcements of any hash
-		// from the same host to short-circuit at the IsHealthy gate above
-		// once the threshold is reached.
+		// Route straight to DLQ. Peer-health attribution happened in
+		// recordPeerFetchOutcome above: only a 404 on a fresh announcement
+		// counts against the peer (and, at the threshold, short-circuits
+		// subsequent announcements from the same host at the IsHealthy gate);
+		// a stale announcement's 404 is our own consumer lag and is not
+		// attributed, though the message still lands here.
 		if errors.Is(err, datahub.ErrNotFound) {
 			return p.handlePermanentFailure(ctx, subtreeMsg, "fetching subtree from DataHub", err, start)
 		}
@@ -428,6 +438,79 @@ func (p *Processor) handleMessage(ctx context.Context, msg *kafka.Message) error
 	metrics.ObserveSubtreeAttemptCount(subtreeMsg.AttemptCount)
 	metrics.ObserveSubtreeProcessing(metrics.OutcomeProcessed, time.Since(start))
 	return nil
+}
+
+// recordPeerFetchOutcome records a subtree fetch outcome against the peer
+// health tracker, replacing the client's internal recording (suppressed via
+// WithoutPeerRecording) for this call site. Classification:
+//
+//   - caller ctx dead at record time → record NOTHING, success or failure:
+//     a shutdown/rebalance/partition-loss abort says nothing about the peer
+//     (a rollout used to trip the breaker on fresh pods within minutes);
+//   - success → RecordSuccess;
+//   - 404 on an announcement older than the stale-404 grace → record
+//     NOTHING: consumer lag aged the message past teranode's ~2h
+//     asset-cache retention, so the 404 is our lag, not a lying peer. The
+//     message itself still routes to handlePermanentFailure/DLQ exactly as
+//     before — only the peer attribution changes;
+//   - anything else (404 on fresh or unstamped announcements, transport,
+//     5xx, parse) → RecordFailure: a peer lying about FRESH data is still
+//     unhealthy. A breaker-opening failure is WARN-logged.
+func (p *Processor) recordPeerFetchOutcome(ctx context.Context, subtreeMsg *kafka.SubtreeMessage, fetchErr error) {
+	ph := p.dataHubClient.PeerHealth()
+	if ph == nil {
+		return
+	}
+	if ctx.Err() != nil {
+		return
+	}
+	if fetchErr == nil {
+		ph.RecordSuccess(subtreeMsg.DataHubURL)
+		return
+	}
+	if errors.Is(fetchErr, datahub.ErrNotFound) &&
+		isStaleAnnouncement(subtreeMsg.AnnouncedAtUnixMs, time.Now(), p.stale404Grace()) {
+		p.Logger.Debug(
+			"suppressing peer-health failure: 404 on a stale announcement is our consumer lag, not the peer",
+			logfields.SubtreeHash(subtreeMsg.Hash),
+			logfields.DataHubURL(subtreeMsg.DataHubURL),
+			"announcedAtUnixMs", subtreeMsg.AnnouncedAtUnixMs,
+			"graceSec", int(p.stale404Grace().Seconds()),
+		)
+		return
+	}
+	if tripped := ph.RecordFailure(subtreeMsg.DataHubURL); tripped {
+		p.Logger.Warn(
+			"DataHub peer marked unhealthy: consecutive-failure threshold reached; announcements from this host will be ack-and-dropped until the cooldown expires",
+			logfields.DataHubURL(subtreeMsg.DataHubURL),
+			"failureThreshold", ph.Threshold(),
+			"cooldown", ph.Cooldown().String(),
+			"error", fetchErr,
+		)
+	}
+}
+
+// isStaleAnnouncement reports whether a subtree announcement stamped at
+// announcedAtUnixMs is strictly older than grace at time now. A zero or
+// negative stamp (messages published before the field existed) means "age
+// unknown" and reads as fresh, so their 404s keep counting against the
+// peer — backward compatible in the conservative direction.
+func isStaleAnnouncement(announcedAtUnixMs int64, now time.Time, grace time.Duration) bool {
+	if announcedAtUnixMs <= 0 {
+		return false
+	}
+	return now.Sub(time.UnixMilli(announcedAtUnixMs)) > grace
+}
+
+// stale404Grace returns the configured stale-404 attribution grace. A nil
+// cfg (struct-literal test processors) or a non-positive configured value
+// selects datahub.DefaultStale404Grace — a zero grace would classify every
+// stamped 404 as stale and blind the breaker to genuinely lying peers.
+func (p *Processor) stale404Grace() time.Duration {
+	if p.cfg == nil || p.cfg.DataHub.PeerHealth.Stale404GraceSec <= 0 {
+		return datahub.DefaultStale404Grace
+	}
+	return time.Duration(p.cfg.DataHub.PeerHealth.Stale404GraceSec) * time.Second
 }
 
 // subtreeRetryBackoffCap bounds the exponential retry backoff (see

--- a/internal/subtree/processor_peerhealth_test.go
+++ b/internal/subtree/processor_peerhealth_test.go
@@ -1,0 +1,307 @@
+package subtree
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/merkle-service/internal/config"
+	"github.com/bsv-blockchain/merkle-service/internal/datahub"
+	"github.com/bsv-blockchain/merkle-service/internal/kafka"
+)
+
+// newPeerHealthTestProcessor builds a Processor whose DataHub client has a
+// PeerHealth tracker attached, wired with mock retry/DLQ producers so
+// handleMessage's failure paths are drivable end to end. The stale-404
+// grace is fixed at 3600s (the shipped default); grace variation is covered
+// by TestIsStaleAnnouncement and TestStale404Grace_Defaulting.
+func newPeerHealthTestProcessor(t *testing.T, threshold int) (*Processor, *datahub.PeerHealth, *mockSyncProducer, *mockSyncProducer) {
+	const graceSec = 3600
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	client := datahub.NewClient(5, 0, logger)
+	ph := datahub.NewPeerHealth(threshold, 10*time.Minute)
+	client.SetPeerHealth(ph)
+
+	retryMock := &mockSyncProducer{}
+	dlqMock := &mockSyncProducer{}
+	p := &Processor{
+		cfg: &config.Config{
+			Subtree: config.SubtreeConfig{
+				MaxAttempts:        3,
+				RetryBackoffBaseMs: 1,
+			},
+			DataHub: config.DataHubConfig{
+				PeerHealth: config.PeerHealthConfig{
+					FailureThreshold: threshold,
+					CooldownSec:      600,
+					Stale404GraceSec: graceSec,
+				},
+			},
+		},
+		registrationStore: &mockRegStore{registrations: map[string][]string{}},
+		seenCounterStore:  &mockSeenCounter{},
+		retryProducer:     kafka.NewTestProducer(retryMock, "subtree-test", logger),
+		dlqProducer:       kafka.NewTestProducer(dlqMock, "subtree-dlq-test", logger),
+		dataHubClient:     client,
+	}
+	p.InitBase("subtree-peerhealth-test")
+	p.Logger = logger
+	return p, ph, retryMock, dlqMock
+}
+
+// TestIsStaleAnnouncement pins the age classification used to decide
+// whether a 404 is attributed to the peer: strictly older than the grace is
+// stale; exactly at the grace, younger, or unstamped (zero/negative — any
+// message produced before AnnouncedAtUnixMs existed) is fresh.
+func TestIsStaleAnnouncement(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	grace := time.Hour
+
+	cases := []struct {
+		name        string
+		announcedAt int64
+		want        bool
+	}{
+		{"zero stamp is fresh (age unknown)", 0, false},
+		{"negative stamp is fresh (age unknown)", -5, false},
+		{"younger than grace is fresh", now.Add(-30 * time.Minute).UnixMilli(), false},
+		{"exactly at grace is fresh", now.Add(-time.Hour).UnixMilli(), false},
+		{"one ms past grace is stale", now.Add(-time.Hour).Add(-time.Millisecond).UnixMilli(), true},
+		{"two hours old is stale", now.Add(-2 * time.Hour).UnixMilli(), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isStaleAnnouncement(tc.announcedAt, now, grace); got != tc.want {
+				t.Errorf("isStaleAnnouncement(%d) = %v, want %v", tc.announcedAt, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRecordPeerFetchOutcome_Classification drives every branch of the
+// processor-side recording that replaces the client's blanket "any error is
+// a peer failure" rule for the subtree fetch path.
+func TestRecordPeerFetchOutcome_Classification(t *testing.T) {
+	url := "https://classify.example.com/api"
+	canceledCtx := func() context.Context {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		return ctx
+	}
+
+	cases := []struct {
+		name        string
+		ctx         context.Context
+		announcedAt int64
+		fetchErr    error
+		wantHealthy bool // with threshold 1, "healthy" == nothing was recorded
+	}{
+		{
+			name:        "canceled ctx with error records nothing",
+			ctx:         canceledCtx(),
+			fetchErr:    errors.New("context canceled"),
+			wantHealthy: true,
+		},
+		{
+			name:        "stale-announcement 404 records nothing",
+			ctx:         context.Background(),
+			announcedAt: time.Now().Add(-2 * time.Hour).UnixMilli(),
+			fetchErr:    fmt.Errorf("wrapped: %w", datahub.ErrNotFound),
+			wantHealthy: true,
+		},
+		{
+			name:        "fresh 404 counts against the peer",
+			ctx:         context.Background(),
+			announcedAt: time.Now().UnixMilli(),
+			fetchErr:    fmt.Errorf("wrapped: %w", datahub.ErrNotFound),
+			wantHealthy: false,
+		},
+		{
+			name:        "unstamped 404 counts against the peer",
+			ctx:         context.Background(),
+			announcedAt: 0,
+			fetchErr:    fmt.Errorf("wrapped: %w", datahub.ErrNotFound),
+			wantHealthy: false,
+		},
+		{
+			name:        "stale announcement with a transport error still counts",
+			ctx:         context.Background(),
+			announcedAt: time.Now().Add(-2 * time.Hour).UnixMilli(),
+			fetchErr:    errors.New("connection refused"),
+			wantHealthy: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, ph, _, _ := newPeerHealthTestProcessor(t, 1)
+			msg := &kafka.SubtreeMessage{
+				Hash:              "h1",
+				DataHubURL:        url,
+				AnnouncedAtUnixMs: tc.announcedAt,
+			}
+			p.recordPeerFetchOutcome(tc.ctx, msg, tc.fetchErr)
+			if got := ph.IsHealthy(url); got != tc.wantHealthy {
+				t.Errorf("IsHealthy = %v, want %v", got, tc.wantHealthy)
+			}
+		})
+	}
+}
+
+// TestRecordPeerFetchOutcome_SuccessAndCanceledSuccess: a success resets the
+// counter, but a success observed under a dead ctx records nothing (it must
+// not reset a genuinely failing peer's counter).
+func TestRecordPeerFetchOutcome_SuccessAndCanceledSuccess(t *testing.T) {
+	url := "https://classify-success.example.com/api"
+	p, ph, _, _ := newPeerHealthTestProcessor(t, 3)
+	msg := &kafka.SubtreeMessage{Hash: "h1", DataHubURL: url, AnnouncedAtUnixMs: time.Now().UnixMilli()}
+
+	live := context.Background()
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Two live failures, a live success: counter reset, two more failures
+	// don't trip.
+	transport := errors.New("connection refused")
+	p.recordPeerFetchOutcome(live, msg, transport)
+	p.recordPeerFetchOutcome(live, msg, transport)
+	p.recordPeerFetchOutcome(live, msg, nil)
+	p.recordPeerFetchOutcome(live, msg, transport)
+	p.recordPeerFetchOutcome(live, msg, transport)
+	if !ph.IsHealthy(url) {
+		t.Fatal("a live success must reset the consecutive-failure counter")
+	}
+
+	// A canceled-ctx success must NOT reset: the third live failure trips.
+	p.recordPeerFetchOutcome(canceled, msg, nil)
+	p.recordPeerFetchOutcome(live, msg, transport)
+	if ph.IsHealthy(url) {
+		t.Fatal("a canceled-ctx success must not reset the failure counter")
+	}
+}
+
+// TestHandleMessage_Stale404sDoNotOpenBreaker is the incident regression: a
+// stream of announcements aged past the grace, all 404ing (teranode pruned
+// them from its asset cache long ago), must route to the DLQ as before but
+// must NOT open the peer-health breaker — pre-fix, every cooldown expiry was
+// followed by three stale 404s re-opening it, keeping the pre-store path
+// dead in a single-peer topology.
+func TestHandleMessage_Stale404sDoNotOpenBreaker(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	p, ph, retryMock, dlqMock := newPeerHealthTestProcessor(t, 3)
+	stale := time.Now().Add(-2 * time.Hour).UnixMilli()
+
+	const n = 10
+	for i := 0; i < n; i++ {
+		msg := &kafka.SubtreeMessage{
+			Hash:              fmt.Sprintf("stale-%02d", i),
+			DataHubURL:        server.URL,
+			AnnouncedAtUnixMs: stale,
+		}
+		value, err := msg.Encode()
+		if err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		if err := p.handleMessage(context.Background(), &kafka.Message{Value: value}); err != nil {
+			t.Fatalf("handleMessage %d: %v", i, err)
+		}
+	}
+
+	if !ph.IsHealthy(server.URL) {
+		t.Fatalf("%d sequential stale-404 messages must not open the breaker", n)
+	}
+	// The messages themselves are still permanent failures: straight to DLQ,
+	// no retry budget burned.
+	if got := len(dlqMock.getMessages()); got != n {
+		t.Errorf("expected %d DLQ publishes, got %d", n, got)
+	}
+	if got := len(retryMock.getMessages()); got != 0 {
+		t.Errorf("expected 0 retry publishes, got %d", got)
+	}
+}
+
+// TestHandleMessage_Fresh404sStillOpenBreaker pins the unchanged half of the
+// contract: a peer 404ing on FRESH announcements is lying about data it
+// claims to serve — the breaker must still open at the threshold, and once
+// open the IsHealthy gate must ack-and-drop without touching the DLQ.
+func TestHandleMessage_Fresh404sStillOpenBreaker(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	p, ph, _, dlqMock := newPeerHealthTestProcessor(t, 3)
+
+	for i := 0; i < 3; i++ {
+		msg := &kafka.SubtreeMessage{
+			Hash:              fmt.Sprintf("fresh-%02d", i),
+			DataHubURL:        server.URL,
+			AnnouncedAtUnixMs: time.Now().UnixMilli(),
+		}
+		value, err := msg.Encode()
+		if err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		if err := p.handleMessage(context.Background(), &kafka.Message{Value: value}); err != nil {
+			t.Fatalf("handleMessage %d: %v", i, err)
+		}
+	}
+	if ph.IsHealthy(server.URL) {
+		t.Fatal("three fresh 404s must open the breaker")
+	}
+	if got := len(dlqMock.getMessages()); got != 3 {
+		t.Errorf("expected 3 DLQ publishes, got %d", got)
+	}
+
+	// Fourth message: skipped at the IsHealthy gate (ack-and-drop), no new
+	// DLQ entry, no error returned.
+	msg := &kafka.SubtreeMessage{
+		Hash:              "fresh-gated",
+		DataHubURL:        server.URL,
+		AnnouncedAtUnixMs: time.Now().UnixMilli(),
+	}
+	value, err := msg.Encode()
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if err := p.handleMessage(context.Background(), &kafka.Message{Value: value}); err != nil {
+		t.Fatalf("handleMessage gated: %v", err)
+	}
+	if got := len(dlqMock.getMessages()); got != 3 {
+		t.Errorf("gated message must not reach the DLQ; expected 3 publishes, got %d", got)
+	}
+}
+
+// TestStale404Grace_Defaulting: a nil cfg (struct-literal test processors)
+// and a zero/negative configured grace both select the built-in default
+// rather than disabling the suppression with a zero grace (which would
+// classify EVERY stamped 404 as stale).
+func TestStale404Grace_Defaulting(t *testing.T) {
+	p := &Processor{}
+	if got := p.stale404Grace(); got != datahub.DefaultStale404Grace {
+		t.Errorf("nil cfg: expected default grace %s, got %s", datahub.DefaultStale404Grace, got)
+	}
+
+	p = &Processor{cfg: &config.Config{}}
+	if got := p.stale404Grace(); got != datahub.DefaultStale404Grace {
+		t.Errorf("zero grace: expected default grace %s, got %s", datahub.DefaultStale404Grace, got)
+	}
+
+	p = &Processor{cfg: &config.Config{DataHub: config.DataHubConfig{
+		PeerHealth: config.PeerHealthConfig{Stale404GraceSec: 900},
+	}}}
+	if got := p.stale404Grace(); got != 15*time.Minute {
+		t.Errorf("configured grace: expected 15m, got %s", got)
+	}
+}

--- a/openspec/changes/peer-health-attribution/design.md
+++ b/openspec/changes/peer-health-attribution/design.md
@@ -1,0 +1,125 @@
+# Design: peer-health attribution
+
+## Context
+
+`PeerHealth` (internal/datahub/peerhealth.go) is an in-memory, host-keyed
+consecutive-failure breaker shared by three call sites: the subtree-fetcher's
+`IsHealthy` ack-and-drop gate, block-processor failover ordering, and the /reprocess
+probe loop. Failures were recorded in one place — the DataHub client's
+`recordPeerOutcome` — with a blanket rule: any non-nil error counts against the peer.
+
+That rule is wrong in exactly two ways, both observed on dev-ovh-1 (15 Jul 2026):
+
+- **Caller cancellations.** The subtree consumer cancels in-flight handler contexts on
+  shutdown, rebalance, and partition loss. Each aborted fetch surfaced as
+  `context.Canceled` → `RecordFailure`. Three per host opens the breaker; a rollout
+  produces far more than three.
+- **Stale-announcement 404s.** Teranode's asset cache serves subtree data for a bounded
+  window (~2h). Under consumer lag, announcements age past that window while parked in
+  Kafka; the eventual fetch 404s on an honest peer. Deep backlogs produce an unbroken
+  run of these, so the breaker re-opened after every 5m cooldown — with a single peer,
+  the pre-store path stayed dead for hours.
+
+The breaker also had zero observability: no trip log, no metrics — the incident was
+only diagnosable from DEBUG-level "skipping subtree fetch" lines.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- An aborted fetch whose caller ctx is dead records nothing (success or failure).
+- A client-side HTTP timeout with a live caller ctx still counts — peer slowness is
+  peer-attributable. Distinguish via `ctx.Err()`, never error-string matching.
+- A 404 on an announcement older than a configurable grace is attributed to our lag,
+  not the peer; the message still routes to the DLQ unchanged.
+- Every breaker opening is observable: WARN log at the recording site + a transitions
+  counter + a per-peer health gauge.
+- Wire compatibility: in-flight `SubtreeMessage`s without the new stamp behave exactly
+  as before (404 counted).
+
+**Non-Goals:**
+
+- Changing the `IsHealthy` gate's ack-and-drop semantics, 404 → permanent-DLQ routing,
+  ENOSPC parking, or the threshold/cooldown defaults.
+- Cross-pod breaker state (stays in-memory per process).
+- Age-aware attribution for the block-metadata path: block fetches fail over across
+  peers and re-drive via bounded retries, so a lag-aged block 404 self-heals; only the
+  subtree path (announced URL is authoritative, no failover) had the poisoning loop.
+
+## Decisions
+
+### 1. Cancellation neutrality lives at the recording chokepoint, keyed on ctx.Err()
+
+`recordPeerOutcome` gains the ctx and returns early when `ctx.Err() != nil` — including
+for successes: a success observed while the ctx is dead must not reset a genuinely
+failing peer's counter either. Matching on `errors.Is(err, context.Canceled)` instead
+was rejected: the client's own `http.Client.Timeout` also surfaces as a
+context-cancellation-shaped error on the request's derived context, and that case (peer
+too slow while the caller still wants the data) must keep counting. `ctx.Err()` on the
+caller's context is the only signal that separates "we gave up" from "the peer failed".
+
+### 2. The subtree processor owns recording for its fetch, via a per-call opt-out
+
+Only the processor knows the announcement's age, so the client can't classify 404s
+itself. `FetchSubtreeRaw` gains a variadic `FetchOption` with `WithoutPeerRecording()`
+(variadic keeps every existing call site source-compatible), and the processor records
+after classifying. The alternative — threading the announcement timestamp into the
+client — was rejected: it leaks message-bus concepts into the HTTP client and would
+have forced every other `FetchSubtreeRaw` caller (block-processor probe paths) to
+supply a meaningless age.
+
+Classification order: ctx dead → nothing; success → RecordSuccess; `ErrNotFound` AND
+age strictly > grace → nothing (log at DEBUG); everything else → RecordFailure. A 404
+with a zero/missing stamp counts — treating unknown age as stale would blind the
+breaker to genuinely lying peers during the rollout window, the conservative direction
+is to keep pre-change behavior.
+
+### 3. Announcement age travels in the message, stamped at P2P publish time
+
+`SubtreeMessage.AnnouncedAtUnixMs` (`omitempty`) is set by the P2P client when it maps
+the teranode announcement to Kafka. Retries re-encode the same struct, so the original
+stamp survives the retry pipeline — age reflects time since announcement, not time
+since last attempt, which is what the asset-cache-retention argument needs. Kafka
+record timestamps were rejected as the age source: the retry republish resets them,
+and the consumer API surfaces them less uniformly than a message field.
+
+### 4. Trip signal from RecordFailure; metrics inside PeerHealth
+
+`RecordFailure` returns true exactly once per healthy→unhealthy transition ("healthy"
+includes an expired-but-not-yet-cleared cooldown, so re-tripping after expiry reports a
+new transition). The WARN log stays at the recording call sites (client and processor)
+where the causing error is in hand. The counter/gauge updates live inside `PeerHealth`
+itself — it is the only place transitions are detectable under the lock, and it covers
+every current and future caller. Gauge is refreshed on first sight and every
+state-affecting call, including lazy cooldown-expiry recovery inside `IsHealthy`.
+
+### 5. Metric label is the peer host, not the base URL
+
+The proposal sketch said "peer label = the DataHub base URL", but internal/metrics'
+registry policy is explicit: URL-derived labels MUST be hostname-only via `HostLabel`,
+never the full URL (cardinality guard). `PeerHealth` already keys state on the URL
+host, so `peer_host` (the existing label constant) loses nothing at ~3 peers and keeps
+the new series joinable with `merkle_subtree_datahub_fetch_*{peer_host}`.
+
+### 6. Grace config follows the existing peerhealth key pattern
+
+`datahub.peerhealth.stale404gracesec`, default 3600, env
+`DATAHUB_PEER_HEALTH_STALE404_GRACE_SEC` (matching the existing
+`DATAHUB_PEER_HEALTH_FAILURE_THRESHOLD` / `DATAHUB_PEER_HEALTH_COOLDOWN_SEC` spelling).
+Zero/negative selects the default rather than disabling suppression — a zero grace
+would classify every stamped 404 as stale, which is never what an operator means.
+
+## Risks / Trade-offs
+
+- **A peer that prunes faster than the grace** (serves <1h) can 404 on stale-but-
+  in-grace announcements and still trip the breaker. Acceptable: that peer genuinely
+  fails announcements at a rate the gate exists to contain, and the grace is tunable.
+- **A lying peer under deep consumer lag** (404s on data it announced >grace ago) is no
+  longer breaker-visible for those messages. Acceptable: the messages still DLQ, the
+  per-peer fetch metrics still show the 404 rate, and fresh announcements from the same
+  peer keep counting.
+- **Gauge writes on the hot path** (`IsHealthy` per message): one bounded-label
+  `GaugeVec.Set` per call, negligible next to the existing per-message histogram work.
+- **Two peers sharing a hostname on different ports** collapse to one `peer_host`
+  metric series while breaker state stays per host:port. Not a real topology today;
+  breaker behavior is unaffected.

--- a/openspec/changes/peer-health-attribution/proposal.md
+++ b/openspec/changes/peer-health-attribution/proposal.md
@@ -1,0 +1,73 @@
+# Correct peer-health attribution for DataHub fetch failures
+
+## Why
+
+The peer-health breaker (threshold 3, cooldown 5m) counts **any** non-nil fetch error as
+a peer failure (`recordPeerOutcome`, internal/datahub/client.go). Two mis-attributions
+observed on dev-ovh-1 (15 Jul 2026) poisoned it:
+
+1. **Caller cancellations.** A pod shutdown, consumer rebalance, or partition loss
+   aborting an in-flight fetch recorded `context.Canceled` against the peer — one
+   rollout tripped the breaker on fresh pods within minutes.
+2. **Stale-announcement 404s.** Consumer lag aged subtree announcements past teranode's
+   ~2h asset-cache retention; each resulting 404 (our lag, not a lying peer) re-tripped
+   the breaker after every cooldown.
+
+In the single-peer topology an open breaker means 100% of subtree announcements are
+ack-and-dropped at the `IsHealthy` gate (internal/subtree/processor.go) — the entire
+pre-store path is dead, and nothing on a dashboard says why: the breaker had no metrics
+and no trip log.
+
+## What Changes
+
+- **Cancellation-neutral recording (all client call sites).** `recordPeerOutcome` takes
+  the caller ctx; when `ctx.Err() != nil` at record time it records NOTHING — neither
+  success nor failure. The client's own HTTP timeout firing while the caller ctx is
+  alive still records a failure (peer slowness is peer-attributable); the two are
+  distinguished via `ctx.Err()`, never by error string.
+- **Age-aware 404 attribution (subtree fetch path only).** `kafka.SubtreeMessage` gains
+  `announcedAtUnixMs`, stamped by the P2P client at publish time (missing/zero = age
+  unknown = fresh, backward compatible with in-flight messages). The subtree processor
+  fetches with a new `datahub.WithoutPeerRecording()` option and records explicitly
+  after classifying: success → RecordSuccess; ctx canceled → nothing; 404 on an
+  announcement older than `datahub.peerhealth.stale404GraceSec` (new config, default
+  3600, env `DATAHUB_PEER_HEALTH_STALE404_GRACE_SEC`) → nothing; everything else
+  (fresh/unstamped 404, transport, 5xx, parse) → RecordFailure. The message itself
+  still routes to the DLQ as a permanent failure — only peer attribution changes.
+- **Breaker-trip observability.** `PeerHealth.RecordFailure` returns `tripped bool`
+  (true exactly once per healthy→unhealthy transition); recording call sites WARN-log
+  the trip with the peer URL, threshold, and cooldown. New metrics:
+  `merkle_datahub_peer_unhealthy_transitions_total{peer_host}` counter and
+  `merkle_datahub_peer_healthy{peer_host}` gauge (1/0, set on first sight and every
+  transition, including lazy cooldown-expiry recovery).
+- **Unchanged:** the `IsHealthy` gate's ack-and-drop semantics, 404 → permanent DLQ
+  routing for the message, ENOSPC parking, threshold/cooldown defaults.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `subtree-processing`: subtree fetch outcomes are classified (ctx state, announcement
+  age) before feeding the peer-health breaker, instead of blanket-counting every error.
+- `datahub-client`: peer-health recording is cancellation-neutral, per-call opt-out-able,
+  and breaker transitions are observable via log + metrics.
+
+## Impact
+
+- **`internal/datahub/client.go`**: `recordPeerOutcome(ctx, ...)`; `FetchOption` /
+  `WithoutPeerRecording`; trip WARN log.
+- **`internal/datahub/peerhealth.go`**: `RecordFailure` returns `tripped`;
+  `Threshold()`/`Cooldown()` accessors; gauge/counter updates; `DefaultStale404Grace`.
+- **`internal/subtree/processor.go`**: fetch opts out of client recording;
+  `recordPeerFetchOutcome` classification; stale comment fixes.
+- **`internal/kafka/messages.go`**: `SubtreeMessage.AnnouncedAtUnixMs`.
+- **`internal/p2p/client.go`**: stamps `AnnouncedAtUnixMs` at publish time.
+- **`internal/config/config.go` / `config.yaml`**: `datahub.peerhealth.stale404gracesec`
+  default + env binding; documented `peerHealth` block.
+- **`internal/metrics/peerhealth.go`** (new): the transitions counter and health gauge.
+- **Operational**: zero-downtime — unstamped in-flight messages classify as fresh
+  (pre-change attribution), and the new config key defaults on.

--- a/openspec/changes/peer-health-attribution/specs/datahub-client/spec.md
+++ b/openspec/changes/peer-health-attribution/specs/datahub-client/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Peer-health recording is cancellation-neutral
+The DataHub client SHALL NOT record any peer-health outcome — success or failure — for
+a fetch whose caller context is already dead (`ctx.Err() != nil`) at record time. The
+client's own HTTP timeout firing while the caller context is alive SHALL still record
+a failure. The two cases MUST be distinguished via the caller context's error state,
+never by matching error strings.
+
+#### Scenario: Aborted fetch says nothing about the peer
+- **WHEN** the caller's context is canceled while a block or subtree fetch is in flight
+- **THEN** neither a failure nor a success is recorded against the peer
+
+#### Scenario: Peer slowness still counts
+- **WHEN** the client's configured HTTP timeout elapses while the caller's context is still alive
+- **THEN** a failure is recorded against the peer
+
+### Requirement: Call sites can opt out of internal peer-health recording
+The DataHub client SHALL accept a per-call fetch option (`WithoutPeerRecording`) that
+suppresses its internal peer-health recording for that fetch, so a call site with more
+context (the subtree processor, which knows the announcement age) can classify and
+record the outcome itself. Fetches without the option MUST record exactly as before.
+
+#### Scenario: Opt-out fetch records nothing internally
+- **WHEN** a subtree fetch is invoked with WithoutPeerRecording and fails
+- **THEN** the client records no peer-health outcome for it, leaving attribution to the caller
+
+### Requirement: Breaker transitions are observable
+`PeerHealth.RecordFailure` SHALL report whether the call transitioned the peer from
+healthy to unhealthy, returning true exactly once per breaker opening (a peer whose
+cooldown has lapsed counts as healthy again, so a later threshold crossing reports a
+new transition). Recording call sites SHALL log a WARN with the peer URL, failure
+threshold, and cooldown on each trip. The service SHALL expose
+`merkle_datahub_peer_unhealthy_transitions_total{peer_host}` (transitions counter) and
+`merkle_datahub_peer_healthy{peer_host}` (1 healthy / 0 unhealthy), the gauge being set
+on first sight of a peer and on every transition, including lazy cooldown-expiry
+recovery inside `IsHealthy`.
+
+#### Scenario: Breaker opening is logged and counted once
+- **WHEN** a peer's consecutive attributed failures reach the threshold
+- **THEN** exactly one WARN log and one transitions-counter increment are emitted, and the peer's health gauge drops to 0; further failures while open produce neither
+
+#### Scenario: Recovery restores the gauge
+- **WHEN** a tripped peer records a success, or its cooldown expires and it is next consulted
+- **THEN** the peer's health gauge returns to 1

--- a/openspec/changes/peer-health-attribution/specs/subtree-processing/spec.md
+++ b/openspec/changes/peer-health-attribution/specs/subtree-processing/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Subtree fetch outcomes are classified before peer-health attribution
+The subtree processor SHALL record DataHub subtree-fetch outcomes against the
+peer-health tracker only after classifying them: a fetch whose caller context is
+already canceled at record time SHALL record nothing (neither success nor failure); a
+successful fetch SHALL record success; a 404 (`datahub: not found`) on an announcement
+whose `announcedAtUnixMs` stamp is strictly older than
+`datahub.peerhealth.stale404GraceSec` (default 3600) SHALL record nothing; every other
+failure — a 404 on a fresh or unstamped announcement, transport errors, 5xx responses,
+parse failures — SHALL record a failure. Message-level handling MUST be unchanged by
+attribution: a 404 still routes the message to the permanent-failure DLQ path, and an
+unhealthy peer's announcements are still acknowledged and dropped at the health gate.
+
+#### Scenario: Caller cancellation is not attributed to the peer
+- **WHEN** a pod shutdown, consumer rebalance, or partition loss cancels the handler context while a subtree fetch is in flight
+- **THEN** the resulting fetch error is not recorded against the announcing peer, and the peer-health breaker state is unchanged
+
+#### Scenario: Stale-announcement 404 is attributed to consumer lag
+- **WHEN** a subtree announcement older than the stale-404 grace (because it sat in Kafka past teranode's asset-cache retention) fetches a 404 from the announcing peer
+- **THEN** no peer-health failure is recorded, and the message still routes to the subtree DLQ as a permanent failure
+
+#### Scenario: Sequential stale 404s never open the breaker
+- **WHEN** an unbroken run of lag-aged announcements all fetch 404s from the same peer
+- **THEN** the peer remains healthy and subsequent fresh announcements from it are still fetched, instead of the breaker re-opening after every cooldown
+
+#### Scenario: Fresh 404s still open the breaker
+- **WHEN** a peer returns 404 for announcements at or under the grace age (including unstamped messages produced before the stamp existed) failureThreshold times consecutively
+- **THEN** the peer is marked unhealthy and its announcements are acknowledged and dropped at the health gate until the cooldown expires
+
+#### Scenario: Client HTTP timeout with a live caller is attributed
+- **WHEN** the DataHub client's own HTTP timeout fires while the caller's context is still alive
+- **THEN** the failure is recorded against the peer, because peer slowness is peer-attributable
+
+### Requirement: Subtree announcements carry their publish time
+The P2P client SHALL stamp `announcedAtUnixMs` (Unix milliseconds) on every subtree
+message at Kafka publish time. The field MUST survive the retry republish path
+unchanged, MUST be omitted from JSON when zero, and consumers MUST treat a missing or
+zero stamp as "age unknown" and classify such messages as fresh.
+
+#### Scenario: Announcement stamped at publish time
+- **WHEN** the P2P client maps a teranode subtree announcement to a Kafka subtree message
+- **THEN** the published message carries announcedAtUnixMs set to the publish wall-clock time
+
+#### Scenario: Legacy messages remain compatible
+- **WHEN** a subtree message produced before the stamp existed is consumed
+- **THEN** it decodes with a zero stamp and its fetch failures are attributed exactly as before the change

--- a/openspec/changes/peer-health-attribution/tasks.md
+++ b/openspec/changes/peer-health-attribution/tasks.md
@@ -1,0 +1,49 @@
+## 1. Message stamp
+
+- [x] 1.1 `SubtreeMessage.AnnouncedAtUnixMs int64` (`announcedAtUnixMs,omitempty`) in
+  `internal/kafka/messages.go`; round-trip + backward-compatibility tests (legacy JSON
+  decodes to 0; zero stamp omitted on encode)
+- [x] 1.2 P2P client stamps `AnnouncedAtUnixMs: time.Now().UnixMilli()` when mapping a
+  teranode subtree announcement to Kafka (`handleSubtreeMessage`); publish-window test
+
+## 2. Breaker trip signal + metrics
+
+- [x] 2.1 `PeerHealth.RecordFailure` returns `tripped bool` — true exactly once per
+  healthy→unhealthy transition, including re-trips after cooldown expiry; nil receiver
+  returns false; `Threshold()` / `Cooldown()` accessors for trip-log call sites
+- [x] 2.2 New `internal/metrics/peerhealth.go`:
+  `merkle_datahub_peer_unhealthy_transitions_total{peer_host}` counter and
+  `merkle_datahub_peer_healthy{peer_host}` gauge + `IncPeerUnhealthyTransition` /
+  `SetPeerHealthy` helpers (host label via `HostLabel`, per registry cardinality policy)
+- [x] 2.3 Gauge/counter updated inside `PeerHealth` on first sight and every
+  transition, including lazy cooldown-expiry recovery in `IsHealthy`; metric-delta tests
+
+## 3. Cancellation-neutral client recording
+
+- [x] 3.1 `recordPeerOutcome(ctx, url, err)`: dead caller ctx records nothing (success
+  or failure); live-ctx failures WARN-log on trip with threshold/cooldown; all three
+  block-metadata call sites pass ctx
+- [x] 3.2 Tests: canceled-ctx failure and success record nothing; caller cancellation
+  mid-fetch not recorded; client HTTP timeout with live caller ctx IS recorded
+
+## 4. Age-aware 404 attribution in the subtree processor
+
+- [x] 4.1 `FetchOption` + `WithoutPeerRecording()` on `FetchSubtreeRaw` (variadic;
+  existing call sites unchanged); test that the option suppresses recording and the
+  default path still records
+- [x] 4.2 Config `datahub.peerhealth.stale404gracesec` (default 3600, env
+  `DATAHUB_PEER_HEALTH_STALE404_GRACE_SEC`); `datahub.DefaultStale404Grace`; defaults +
+  env-binding tests
+- [x] 4.3 `recordPeerFetchOutcome` in the subtree processor: ctx dead → nothing;
+  success → RecordSuccess; stale 404 → nothing (DEBUG log); fresh/unstamped 404,
+  transport, 5xx, parse → RecordFailure with WARN on trip; stale comments at the fetch
+  site and Init updated
+- [x] 4.4 Classification tests incl. exact-grace boundary; regression: N sequential
+  stale-404 messages never open the breaker (all still DLQ); fresh 404s still open it
+  and the IsHealthy gate still ack-and-drops
+
+## 5. Gates
+
+- [x] 5.1 `go build ./...`, `go test ./... -count=1`, `go test -race` on
+  internal/datahub + internal/subtree + internal/kafka + internal/p2p +
+  internal/config + internal/metrics, `make lint`


### PR DESCRIPTION
Fixes #189.

## Root cause (observed dev-ovh-1, 15 Jul 2026)

`recordPeerOutcome` counted **any** non-nil fetch error as a peer failure. Two mis-attributions poisoned the breaker (threshold 3, cooldown 5m):

1. **Caller cancellations** — pod shutdowns/rebalances aborting in-flight fetches recorded `context.Canceled` against the peer; one rollout tripped the breaker on fresh pods within minutes.
2. **Lag-aged 404s** — announcements older than teranode's ~2h asset-cache retention 404 because of *our* consumer lag, not a lying peer; each one re-tripped the breaker after every cooldown, indefinitely.

On a single-peer topology an open breaker ack-and-drops 100% of announcements: the pre-store path dies and every block degrades to worst-case DataHub fetching at block time (3,328 skipped announcements/hour observed; the trip itself was a DEBUG-level whisper).

## Changes

- **Cancellation-neutral recording** (all client call sites): `recordPeerOutcome(ctx, …)` records nothing when the caller's ctx is dead — success or failure. The client's own HTTP timeout with a live caller ctx **still counts** (peer slowness is peer-attributable; distinguished via `ctx.Err()`, not error strings).
- **Age-aware 404 attribution** (subtree path): `SubtreeMessage.AnnouncedAtUnixMs` stamped by the p2p client at publish; the subtree processor takes over recording via `WithoutPeerRecording()` and suppresses peer-failure attribution for 404s on announcements older than `datahub.peerHealth.stale404GraceSec` (default 3600; zero/missing stamp = fresh, conservative for in-flight messages). The message itself still DLQs exactly as before — only attribution changes. Fresh 404s / transport / 5xx / parse failures still count.
- **Breaker trips are loud now**: `RecordFailure` returns `tripped`; WARN with peer/threshold/cooldown at the recording sites; new `merkle_datahub_peer_unhealthy_transitions_total{peer_host}` counter and `merkle_datahub_peer_healthy{peer_host}` gauge (hostname-only label per the registry cardinality policy — joinable with the existing `merkle_subtree_datahub_fetch_*` series).
- **Unchanged**: the IsHealthy gate's ack-and-drop, 404 → permanent DLQ for the message, ENOSPC parking, threshold/cooldown defaults.

## Verification

- `go build ./...`; `go test ./... -count=1` 21 packages ok; `-race` clean on datahub/subtree/p2p/kafka/config/metrics; `make lint` 0 issues.
- Regression test pins the incident: **10 sequential stale-404 messages leave the breaker healthy** (all 10 DLQ'd, zero retries), while 3 fresh 404s still open it and gate the 4th.
- Full classification table, exact-grace boundary, trip-exactly-once incl. re-trip after cooldown, gauge recovery on cooldown expiry, JSON round-trip with/without the new field, publish-time stamp.