### PR TITLE
feat(block): gate the expected-STUMP set behind block.emitExpectedStumpSet (default on)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -377,6 +377,19 @@ block:
   # Env: BLOCK_BATCH_GET_CONCURRENCY
   batchGetConcurrency: 4
 
+  # Record the per-(block, callbackURL) set of subtree indices that produced a
+  # STUMP and attach it to BLOCK_PROCESSED as expectedSubtreeIndices, so the
+  # receiver can detect a missing STUMP (docs/block-processed-completeness.md).
+  # Default TRUE — deliberately diverging from that doc's original "default
+  # off" rollout plan: the feature has been unconditionally live in production
+  # since v0.4.5 and its write load is already absorbed, so this flag is an
+  # emergency off-switch, not a rollout gate. Disabling turns off BOTH the
+  # recording and the attach together — attaching a set that was never written
+  # would be an empty set, telling the receiver to expect zero STUMPs (silent
+  # loss).
+  # Env: BLOCK_EMIT_EXPECTED_STUMP_SET
+  emitExpectedStumpSet: true
+
 # ---------------------------------------------------------------------------
 # Callback Delivery
 # ---------------------------------------------------------------------------

--- a/config.yaml
+++ b/config.yaml
@@ -237,7 +237,10 @@ kafka:
   # increase). The 'block' and 'callback' topics are intentionally fixed at 1
   # partition and are not configurable here — 'block' is low-rate, and 'callback'
   # depends on single-partition ordering to keep BLOCK_PROCESSED behind its
-  # STUMPs (see docs/callback-topic-partition-design.md).
+  # STUMPs. Widening 'callback' stays deferred until the expectedSubtreeIndices
+  # completeness check is verified end-to-end in arcade — rollout step 4 of
+  # docs/block-processed-completeness.md (which supersedes the earlier
+  # callback-topic-partition-design.md, no longer in the repo).
   # Env: KAFKA_SUBTREE_PARTITIONS
   subtreePartitions: 12
   # Env: KAFKA_SUBTREE_WORK_PARTITIONS

--- a/docs/block-processed-completeness.md
+++ b/docs/block-processed-completeness.md
@@ -73,11 +73,20 @@ This reuses the patterns we already trust:
   exactly like the subtree counter.
 
 **Cost and gating.** Recording an index per (subtree, matched-URL) adds Aerospike
-write load on the MINED hot path. Because arcade can't use the field until its
-side ships, this is behind a config flag (`block.emitExpectedStumpSet`,
-**default off**). Operators turn it on once arcade is ready. The writes are
-batched per subtree (one operation across that subtree's matched URLs), not one
-at a time.
+write load on the MINED hot path. The writes are batched per subtree (one
+operation across that subtree's matched URLs), not one at a time.
+
+The gating shipped differently from the plan above: the feature went live
+**unconditionally** in v0.4.5 (#162), before any flag existed, and its write
+load has been absorbed in production since. The flag was added retroactively as
+`block.emitExpectedStumpSet` (env `BLOCK_EMIT_EXPECTED_STUMP_SET`), **default
+on** — deliberately diverging from the original "default off" rollout gate: it
+is an emergency off-switch for the hot-path write load, not an enablement lever.
+Disabling it turns off **both** the recording and the attach together. That
+coupling is a correctness requirement, not a convenience: attaching a set that
+was never written would ship an *empty* expected set, telling the receiver to
+expect zero STUMPs — which reintroduces the exact silent-loss bug this feature
+exists to fix.
 
 ### Arcade side (separate, owned by the arcade team)
 
@@ -114,9 +123,19 @@ at a time.
 
 ## Rollout
 
-1. Ship the merkle field + aggregation behind `block.emitExpectedStumpSet=false`.
-   No behaviour change, no added load, until enabled.
-2. Arcade ships detection + grace-wait + reprocess recovery, consuming the field.
-3. Enable the flag in an environment where both sides are deployed; verify arcade
-   detects and recovers an injected missing STUMP.
-4. Only then, widen `callback` (separate change) for delivery throughput.
+1. Ship the merkle field + aggregation. — **Shipped** in v0.4.5 (#162),
+   always-on (the planned flag was not implemented at the time). The
+   `block.emitExpectedStumpSet` flag was added retroactively as a
+   **default-true off-switch**; see "Cost and gating" above for the
+   divergence rationale.
+2. Arcade ships detection + grace-wait + reprocess recovery, consuming the
+   field. — **Shipped** in arcade v0.9.10 (reads the field, defers
+   finalization when the STUMP set is incomplete).
+   Skip-the-grace-window-when-complete is **in progress**.
+3. Enable the flag in an environment where both sides are deployed; verify
+   arcade detects and recovers an injected missing STUMP. — **Overtaken by
+   events**: the merkle side has been effectively enabled everywhere since
+   v0.4.5, and the retroactive flag defaults on.
+4. Only then, widen `callback` (separate change) for delivery throughput. —
+   **Still deferred** until step 2's skip-grace change is verified in
+   production.

--- a/internal/block/expected_stump_flag_test.go
+++ b/internal/block/expected_stump_flag_test.go
@@ -1,0 +1,217 @@
+package block
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/bsv-blockchain/merkle-service/internal/config"
+	"github.com/bsv-blockchain/merkle-service/internal/kafka"
+)
+
+// recordedStumpAdd captures one AddSubtreeIndex invocation so tests can assert
+// exactly what the write path recorded.
+type recordedStumpAdd struct {
+	blockHash    string
+	subtreeIndex int
+	urls         []string
+}
+
+// recordingExpectedStump is an ExpectedStumpStore fake that counts writes and
+// reads: AddSubtreeIndex calls are captured, GetSubtreeIndices serves a fixed
+// per-URL set and counts invocations. Used to prove the
+// block.emitExpectedStumpSet flag gates the WRITE path (recording) and the
+// READ path (attach) together.
+type recordingExpectedStump struct {
+	mu    sync.Mutex
+	adds  []recordedStumpAdd
+	reads int
+	byURL map[string][]int
+}
+
+func (r *recordingExpectedStump) AddSubtreeIndex(blockHash string, subtreeIndex int, callbackURLs []string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.adds = append(r.adds, recordedStumpAdd{
+		blockHash:    blockHash,
+		subtreeIndex: subtreeIndex,
+		urls:         append([]string(nil), callbackURLs...),
+	})
+	return nil
+}
+
+func (r *recordingExpectedStump) GetSubtreeIndices(_, url string) ([]int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.reads++
+	return r.byURL[url], nil
+}
+
+func (r *recordingExpectedStump) addCalls() []recordedStumpAdd {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]recordedStumpAdd(nil), r.adds...)
+}
+
+func (r *recordingExpectedStump) readCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.reads
+}
+
+// boolPtr returns a pointer to b, for populating *bool config fields.
+func boolPtr(b bool) *bool { return &b }
+
+// TestEmitBlockProcessed_FlagOff_OmitsExpectedIndices proves the attach path
+// is suppressed when block.emitExpectedStumpSet is explicitly false: the
+// BLOCK_PROCESSED message carries NO expectedSubtreeIndices field (not an
+// empty set — an empty set would tell the receiver to expect zero STUMPs,
+// reintroducing the silent-loss bug), and the store is never even read.
+func TestEmitBlockProcessed_FlagOff_OmitsExpectedIndices(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	mock := &mockSyncProducer{}
+	url := "http://cb.example.test/hook"
+
+	store := &recordingExpectedStump{byURL: map[string][]int{url: {3, 7}}}
+	s := &SubtreeWorkerService{
+		blockCfg:       config.BlockConfig{EmitExpectedStumpSet: boolPtr(false)},
+		urlRegistry:    &fakeURLRegistry{urls: []string{url}},
+		expectedStumps: store,
+	}
+	s.InitBase("subtree-worker-test")
+	s.Logger = logger
+	s.callbackProducer = kafka.NewTestProducer(mock, "callback-test", logger)
+
+	if err := s.emitBlockProcessed(context.Background(), "blk-flag-off", "", "", nil); err != nil {
+		t.Fatalf("emitBlockProcessed: %v", err)
+	}
+	if len(mock.messages) != 1 {
+		t.Fatalf("published %d messages, want 1", len(mock.messages))
+	}
+
+	var msg kafka.CallbackTopicMessage
+	if err := json.Unmarshal(mock.messages[0].Value, &msg); err != nil {
+		t.Fatalf("decode BLOCK_PROCESSED: %v", err)
+	}
+	if msg.Type != kafka.CallbackBlockProcessed {
+		t.Fatalf("type = %q, want BLOCK_PROCESSED", msg.Type)
+	}
+	if msg.ExpectedSubtreeIndices != nil {
+		t.Errorf("ExpectedSubtreeIndices = %v, want nil when flag is off", msg.ExpectedSubtreeIndices)
+	}
+	// omitempty must drop the key entirely so older/newer receivers treat the
+	// payload exactly like a pre-feature one.
+	if bytes.Contains(mock.messages[0].Value, []byte("expectedSubtreeIndices")) {
+		t.Errorf("raw BLOCK_PROCESSED payload contains expectedSubtreeIndices key with flag off: %s", mock.messages[0].Value)
+	}
+	if got := store.readCount(); got != 0 {
+		t.Errorf("GetSubtreeIndices called %d times, want 0 when flag is off", got)
+	}
+}
+
+// TestHandleMessage_FlagOff_SkipsAddSubtreeIndex proves the WRITE path is
+// gated: with the flag explicitly false, a successfully processed subtree that
+// matched a callback URL records nothing into the expected-STUMP store, while
+// the STUMP callback still publishes and the per-block counter still
+// decrements exactly once.
+func TestHandleMessage_FlagOff_SkipsAddSubtreeIndex(t *testing.T) {
+	cbMock := &callbackFailingProducer{}
+	retryMock := &callbackFailingProducer{}
+	dlqMock := &callbackFailingProducer{}
+
+	const blockHash = "block-flag-off"
+	counter := newCountingSubtreeCounter()
+	// Pre-seed above 1 so the counter does not drain to zero — this test is
+	// about the write path, not the emit path.
+	_ = counter.Init(blockHash, 2, nil)
+	counter.initCalls = 0
+
+	stumpStore := &stubStumpStore{}
+
+	subtreePayload := buildRawSubtreeBytes(t, 2)
+	server := rawSubtreeServer(subtreePayload)
+	defer server.Close()
+
+	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, 5)
+	recording := &recordingExpectedStump{}
+	svc.expectedStumps = recording
+	svc.blockCfg.EmitExpectedStumpSet = boolPtr(false)
+
+	value := makeWorkMessageBytes(t, blockHash, contentAddressOf(t, subtreePayload), server.URL, 0)
+	if err := svc.handleMessage(context.Background(), &kafka.Message{Value: value}); err != nil {
+		t.Fatalf("handleMessage with flag off: expected nil error, got: %v", err)
+	}
+
+	if got := len(recording.addCalls()); got != 0 {
+		t.Errorf("AddSubtreeIndex called %d times, want 0 when flag is off", got)
+	}
+	if got := cbMock.sentCountOfType(kafka.CallbackStump); got != 1 {
+		t.Errorf("expected 1 STUMP callback publish with flag off, got %d", got)
+	}
+	if got := counter.decrementCount(); got != 1 {
+		t.Errorf("expected counter Decrement called exactly once, got %d", got)
+	}
+	if got := retryMock.sentCount(); got != 0 {
+		t.Errorf("expected zero retry publishes, got %d", got)
+	}
+	if got := dlqMock.sentCount(); got != 0 {
+		t.Errorf("expected zero DLQ publishes, got %d", got)
+	}
+}
+
+// TestHandleMessage_FlagUnset_RecordsSubtreeIndex pins default-on semantics
+// in-path: a zero-valued BlockConfig (flag nil, as every directly-constructed
+// service has) records the subtree index for each matched callback URL —
+// exactly once, with the right block hash, index, and URL set.
+func TestHandleMessage_FlagUnset_RecordsSubtreeIndex(t *testing.T) {
+	cbMock := &callbackFailingProducer{}
+	retryMock := &callbackFailingProducer{}
+	dlqMock := &callbackFailingProducer{}
+
+	const blockHash = "block-flag-unset"
+	counter := newCountingSubtreeCounter()
+	_ = counter.Init(blockHash, 2, nil)
+	counter.initCalls = 0
+
+	stumpStore := &stubStumpStore{}
+
+	subtreePayload := buildRawSubtreeBytes(t, 2)
+	server := rawSubtreeServer(subtreePayload)
+	defer server.Close()
+
+	svc := newWorkerForHandleMessage(t, cbMock, retryMock, dlqMock, stumpStore, counter, 5)
+	recording := &recordingExpectedStump{}
+	svc.expectedStumps = recording
+	// blockCfg.EmitExpectedStumpSet deliberately left nil: unset means enabled.
+
+	value := makeWorkMessageBytes(t, blockHash, contentAddressOf(t, subtreePayload), server.URL, 0)
+	if err := svc.handleMessage(context.Background(), &kafka.Message{Value: value}); err != nil {
+		t.Fatalf("handleMessage with flag unset: expected nil error, got: %v", err)
+	}
+
+	adds := recording.addCalls()
+	if len(adds) != 1 {
+		t.Fatalf("AddSubtreeIndex called %d times, want exactly 1 with flag unset", len(adds))
+	}
+	if adds[0].blockHash != blockHash {
+		t.Errorf("recorded blockHash = %q, want %q", adds[0].blockHash, blockHash)
+	}
+	if adds[0].subtreeIndex != 0 {
+		t.Errorf("recorded subtreeIndex = %d, want 0", adds[0].subtreeIndex)
+	}
+	// The harness's staticRegStore matches every txid to this single URL.
+	if want := []string{"http://cb.example.test/hook"}; !reflect.DeepEqual(adds[0].urls, want) {
+		t.Errorf("recorded urls = %v, want %v", adds[0].urls, want)
+	}
+	if got := cbMock.sentCountOfType(kafka.CallbackStump); got != 1 {
+		t.Errorf("expected 1 STUMP callback publish, got %d", got)
+	}
+	if got := counter.decrementCount(); got != 1 {
+		t.Errorf("expected counter Decrement called exactly once, got %d", got)
+	}
+}

--- a/internal/block/subtree_worker.go
+++ b/internal/block/subtree_worker.go
@@ -400,7 +400,10 @@ func (s *SubtreeWorkerService) handleMessage(ctx context.Context, msg *kafka.Mes
 		// best-effort: an under-counted set would let arcade under-expect STUMPs
 		// and silently miss one — so a failure re-drives the (idempotent) work
 		// item, exactly like the counter decrement below.
-		if s.expectedStumps != nil {
+		// Gated by the block.emitExpectedStumpSet off-switch; the attach path in
+		// emitBlockProcessed is gated in tandem (see there for why both must
+		// switch together).
+		if s.expectedStumps != nil && s.blockCfg.EmitExpectedStumpSetEnabled() {
 			urls := make([]string, 0, len(result.CallbackGroups))
 			for callbackURL := range result.CallbackGroups {
 				urls = append(urls, callbackURL)
@@ -759,7 +762,18 @@ func (s *SubtreeWorkerService) publishSubtreeCallbacks(ctx context.Context, work
 // emit fires again; duplicate BLOCK_PROCESSED messages are deduplicated at
 // the callback delivery service (keyed by blockHash + callbackURL + type).
 func (s *SubtreeWorkerService) emitBlockProcessed(ctx context.Context, blockHash, overrideURL, overrideToken string, blockData *store.BlockProcessedData) error {
-	return emitBlockProcessedCallbacks(ctx, s.Logger, s.urlRegistry, s.expectedStumps, s.callbackProducer, blockHash, overrideURL, overrideToken, blockData)
+	// Resolve the expected-STUMP store through the block.emitExpectedStumpSet
+	// off-switch: flag off must suppress the attach entirely (nil store → no
+	// read, no expectedSubtreeIndices field), NOT ship an empty set — an empty
+	// set tells the receiver to expect zero STUMPs, silently disabling
+	// missing-STUMP detection for the block. The write path in handleMessage is
+	// gated in tandem, which is exactly why attaching-while-not-writing (or
+	// vice versa) must never happen.
+	expectedStumps := s.expectedStumps
+	if !s.blockCfg.EmitExpectedStumpSetEnabled() {
+		expectedStumps = nil
+	}
+	return emitBlockProcessedCallbacks(ctx, s.Logger, s.urlRegistry, expectedStumps, s.callbackProducer, blockHash, overrideURL, overrideToken, blockData)
 }
 
 // callbackPublisher is the narrow surface emitBlockProcessedCallbacks needs.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -467,6 +467,35 @@ type BlockConfig struct {
 	// announcement can fire one BatchGet per subtree (up to 30+) in parallel
 	// and exhaust the Aerospike connection pool.
 	BatchGetConcurrency int `yaml:"batchGetConcurrency" mapstructure:"batchgetconcurrency"`
+	// EmitExpectedStumpSet controls whether the subtree worker records the
+	// per-(block, callbackURL) set of subtree indices that produced a STUMP and
+	// attaches it to BLOCK_PROCESSED as expectedSubtreeIndices, so the receiver
+	// can detect a missing STUMP (docs/block-processed-completeness.md).
+	//
+	// Default TRUE — deliberately diverging from that doc's original "default
+	// off" rollout plan: the feature shipped unconditionally in v0.4.5 (#162)
+	// before this flag existed, so its Aerospike write load on the MINED hot
+	// path is already absorbed in production. The flag is an emergency
+	// off-switch, not a rollout gate.
+	//
+	// A *bool so that nil (unset) means enabled: zero-valued BlockConfigs built
+	// directly in tests keep production semantics; only an explicit false
+	// disables. Use EmitExpectedStumpSetEnabled to read it.
+	//
+	// Disabling turns off BOTH the recording (write) and the attach (read)
+	// together. Gating only the write while still attaching would ship an
+	// EMPTY expected set, telling the receiver to expect zero STUMPs — which
+	// reintroduces the exact silent-loss bug the feature exists to fix.
+	EmitExpectedStumpSet *bool `yaml:"emitExpectedStumpSet" mapstructure:"emitexpectedstumpset"`
+}
+
+// EmitExpectedStumpSetEnabled reports whether the expected-STUMP set is
+// recorded and attached to BLOCK_PROCESSED. nil (unset) means enabled: the
+// default is true, so a zero-valued BlockConfig behaves like production. Only
+// an explicit false disables. See BlockConfig.EmitExpectedStumpSet for the
+// default-true rationale and the write+attach-gated-together requirement.
+func (b BlockConfig) EmitExpectedStumpSetEnabled() bool {
+	return b.EmitExpectedStumpSet == nil || *b.EmitExpectedStumpSet
 }
 
 // CallbackConfig holds callback delivery configuration.
@@ -696,6 +725,8 @@ func registerDefaults(v *viper.Viper) {
 	v.SetDefault("block.notfoundmaxattempts", 3)
 	v.SetDefault("block.regcachemaxmb", 64)
 	v.SetDefault("block.batchgetconcurrency", 4)
+	// Off-switch, not a rollout gate — see BlockConfig.EmitExpectedStumpSet.
+	v.SetDefault("block.emitexpectedstumpset", true)
 
 	// Callback
 	v.SetDefault("callback.maxretries", 5)
@@ -856,14 +887,15 @@ func bindEnvVars(v *viper.Viper) {
 		"subtree.seentxidlogmax":     "SUBTREE_SEEN_TXID_LOG_MAX",
 
 		// Block
-		"block.workerpoolsize":      "BLOCK_WORKER_POOL_SIZE",
-		"block.postminettlsec":      "BLOCK_POST_MINE_TTL_SEC",
-		"block.dedupcachesize":      "BLOCK_DEDUP_CACHE_SIZE",
-		"block.maxattempts":         "BLOCK_MAX_ATTEMPTS",
-		"block.retrybackoffbasems":  "BLOCK_RETRY_BACKOFF_BASE_MS",
-		"block.notfoundmaxattempts": "BLOCK_NOT_FOUND_MAX_ATTEMPTS",
-		"block.regcachemaxmb":       "BLOCK_REG_CACHE_MAX_MB",
-		"block.batchgetconcurrency": "BLOCK_BATCH_GET_CONCURRENCY",
+		"block.workerpoolsize":       "BLOCK_WORKER_POOL_SIZE",
+		"block.postminettlsec":       "BLOCK_POST_MINE_TTL_SEC",
+		"block.dedupcachesize":       "BLOCK_DEDUP_CACHE_SIZE",
+		"block.maxattempts":          "BLOCK_MAX_ATTEMPTS",
+		"block.retrybackoffbasems":   "BLOCK_RETRY_BACKOFF_BASE_MS",
+		"block.notfoundmaxattempts":  "BLOCK_NOT_FOUND_MAX_ATTEMPTS",
+		"block.regcachemaxmb":        "BLOCK_REG_CACHE_MAX_MB",
+		"block.batchgetconcurrency":  "BLOCK_BATCH_GET_CONCURRENCY",
+		"block.emitexpectedstumpset": "BLOCK_EMIT_EXPECTED_STUMP_SET",
 
 		// Callback
 		"callback.maxretries":          "CALLBACK_MAX_RETRIES",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -317,8 +317,11 @@ type KafkaConfig struct {
 	//
 	// The 'block' and 'callback' topics are deliberately NOT configurable here and
 	// stay at 1 partition: 'block' is low-rate, and 'callback' relies on
-	// single-partition ordering to keep BLOCK_PROCESSED behind its STUMPs until a
-	// cross-partition delivery barrier exists (see docs/callback-topic-partition-design.md).
+	// single-partition ordering to keep BLOCK_PROCESSED behind its STUMPs.
+	// Widening 'callback' stays deferred until the expectedSubtreeIndices
+	// completeness check is verified end-to-end in arcade — rollout step 4 of
+	// docs/block-processed-completeness.md (which supersedes the earlier
+	// callback-topic-partition-design.md, no longer in the repo).
 	SubtreePartitions     int `yaml:"subtreePartitions"     mapstructure:"subtreepartitions"`
 	SubtreeWorkPartitions int `yaml:"subtreeWorkPartitions" mapstructure:"subtreeworkpartitions"`
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -40,6 +40,7 @@ func clearConfigEnv(t *testing.T) {
 		"SUBTREE_MAX_ATTEMPTS",
 		"BLOCK_WORKER_POOL_SIZE", "BLOCK_POST_MINE_TTL_SEC",
 		"BLOCK_RETRY_BACKOFF_BASE_MS", "BLOCK_NOT_FOUND_MAX_ATTEMPTS",
+		"BLOCK_EMIT_EXPECTED_STUMP_SET",
 		"CALLBACK_MAX_RETRIES", "CALLBACK_BACKOFF_BASE_SEC",
 		"CALLBACK_TIMEOUT_SEC", "CALLBACK_SEEN_THRESHOLD",
 		"BLOB_STORE_URL", "BLOB_STORE_SWEEP_INTERVAL_SEC", "BLOB_STORE_SWEEP_MAX_AGE_SEC",
@@ -764,5 +765,73 @@ func TestParseLogLevel(t *testing.T) {
 				t.Errorf("ParseLogLevel(%q): expected %v, got %v", tt.input, tt.expected, got)
 			}
 		})
+	}
+}
+
+// TestLoad_EmitExpectedStumpSet_DefaultTrue pins the default-on semantics of
+// the expected-STUMP set flag: a clean Load() yields a non-nil pointer (the
+// registered default) and the feature reports enabled. Default TRUE is a
+// deliberate divergence from docs/block-processed-completeness.md's original
+// "default off" rollout plan — the feature shipped always-on in v0.4.5, so the
+// flag is an emergency off-switch, not a rollout gate.
+func TestLoad_EmitExpectedStumpSet_DefaultTrue(t *testing.T) {
+	clearConfigEnv(t)
+	_ = os.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")
+	defer func() { _ = os.Unsetenv("CONFIG_FILE") }()
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	if cfg.Block.EmitExpectedStumpSet == nil {
+		t.Fatal("Block.EmitExpectedStumpSet: expected non-nil after Load() (default registered), got nil")
+	}
+	if !cfg.Block.EmitExpectedStumpSetEnabled() {
+		t.Error("Block.EmitExpectedStumpSetEnabled(): expected true by default, got false")
+	}
+}
+
+// TestLoad_EmitExpectedStumpSet_EnvOverride proves the *bool field decodes
+// from the environment through viper's WeaklyTypedInput pipeline: an explicit
+// "false" is the only way to disable, and an explicit "true" round-trips.
+func TestLoad_EmitExpectedStumpSet_EnvOverride(t *testing.T) {
+	tests := []struct {
+		name    string
+		envVal  string
+		enabled bool
+	}{
+		{"explicit false disables", "false", false},
+		{"explicit true enables", envTrue, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearConfigEnv(t)
+			_ = os.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")
+			_ = os.Setenv("BLOCK_EMIT_EXPECTED_STUMP_SET", tt.envVal)
+			defer clearConfigEnv(t)
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load() failed: %v", err)
+			}
+			if cfg.Block.EmitExpectedStumpSet == nil {
+				t.Fatal("Block.EmitExpectedStumpSet: expected non-nil when env var is set, got nil")
+			}
+			if got := cfg.Block.EmitExpectedStumpSetEnabled(); got != tt.enabled {
+				t.Errorf("EmitExpectedStumpSetEnabled() with env=%q: expected %v, got %v", tt.envVal, tt.enabled, got)
+			}
+		})
+	}
+}
+
+// TestBlockConfig_EmitExpectedStumpSetEnabled_ZeroValue locks in the
+// nil-means-enabled contract: a zero-valued BlockConfig (direct struct
+// construction, no Load()) behaves like production, so services built in
+// tests keep recording and attaching the expected-STUMP set unless a test
+// explicitly opts out with a false pointer.
+func TestBlockConfig_EmitExpectedStumpSetEnabled_ZeroValue(t *testing.T) {
+	var cfg BlockConfig
+	if !cfg.EmitExpectedStumpSetEnabled() {
+		t.Error("zero-valued BlockConfig: EmitExpectedStumpSetEnabled() expected true (nil means enabled), got false")
 	}
 }

--- a/openspec/changes/emit-expected-stump-flag/.openspec.yaml
+++ b/openspec/changes/emit-expected-stump-flag/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/emit-expected-stump-flag/design.md
+++ b/openspec/changes/emit-expected-stump-flag/design.md
@@ -1,0 +1,77 @@
+# Design: emit-expected-stump-flag
+
+## Context
+
+`internal/block/subtree_worker.go` records, per successfully processed subtree,
+the subtree's index into each matched callback URL's expected-STUMP set
+(`store.ExpectedStumpStore.AddSubtreeIndex`, one batched Aerospike operation per
+subtree) just before decrementing the per-block subtree counter. When the
+counter drains to zero, `emitBlockProcessed` reads each URL's set
+(`GetSubtreeIndices`) and attaches it to that URL's `BLOCK_PROCESSED` as
+`expectedSubtreeIndices` (JSON `omitempty`). The block-processor's
+coinbase-only path calls the shared `emitBlockProcessedCallbacks` free function
+with a nil store already — no subtrees means no STUMPs and no expected set.
+
+This shipped always-on in v0.4.5 (#162), although
+`docs/block-processed-completeness.md` had planned a default-off flag
+(`block.emitExpectedStumpSet`). Arcade v0.9.10 consumes the field. The flag is
+being added retroactively.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- An operator off-switch for the expected-STUMP hot-path write load,
+  controllable via yaml and env without a rebuild.
+- Zero behavior change at defaults, for production `Load()` configs AND for
+  zero-valued `BlockConfig` structs built directly in tests.
+- Documentation (doc, config comments, openspec) that matches shipped reality.
+
+**Non-Goals:**
+
+- Widening the `callback` topic (still deferred — rollout step 4 of the doc).
+- Changing default behavior: the set stays recorded and attached everywhere.
+- Wiring changes in `cmd/`: stores stay constructed; gating happens at the two
+  call sites.
+
+## Decisions
+
+### 1. Default TRUE, diverging from the doc's original "default off"
+
+The original plan gated a not-yet-consumed field to avoid paying write load
+before arcade could use it. That window is gone: the feature has been live and
+unconditional since v0.4.5, production has absorbed the load, and arcade
+v0.9.10 consumes the field. Defaulting off now would *regress* production
+(silent-loss detection would vanish on upgrade). So the flag ships as an
+emergency off-switch: default true, explicit false to shed the write load.
+
+### 2. `*bool` with nil-means-enabled, not a plain `bool`
+
+`TestEmitBlockProcessed_AttachesExpectedIndices` (and any directly-constructed
+`SubtreeWorkerService`) uses a zero-valued `BlockConfig` without `config.Load()`.
+A plain `bool` field would make that zero value mean *disabled*, silently
+flipping default semantics for every struct-literal construction and breaking
+existing tests, which must remain byte-identical. `EmitExpectedStumpSet *bool`
+with `EmitExpectedStumpSetEnabled()` returning `nil || *v` keeps the zero value
+on production semantics; `SetDefault("block.emitexpectedstumpset", true)` means
+`Load()` always yields a non-nil pointer, and the env binding decodes through
+viper's `WeaklyTypedInput` mapstructure pipeline (proven by the env-override
+test).
+
+### 3. Write and attach are gated together
+
+Gating only the write while still attaching would ship an **empty** expected
+set — semantically "expect zero STUMPs" — so the receiver would finalize
+immediately and silently drop any late STUMP: the exact bug the feature fixes,
+but now masquerading as a healthy signal. Conversely, writing without attaching
+just wastes the writes. Both call sites therefore consult
+`EmitExpectedStumpSetEnabled()` and switch in tandem, and the comments at both
+sites cross-reference each other.
+
+### 4. Gate the attach by resolving the store to nil in `emitBlockProcessed`
+
+`emitBlockProcessedCallbacks` already treats a nil `expectedStumps` parameter
+as "no set to attach" (the coinbase-only processor path passes nil today).
+`emitBlockProcessed` resolves `s.expectedStumps` to nil when the flag is off
+and delegates — no new function parameter, no signature churn, and the free
+function's behavior stays covered by its existing tests.

--- a/openspec/changes/emit-expected-stump-flag/proposal.md
+++ b/openspec/changes/emit-expected-stump-flag/proposal.md
@@ -1,0 +1,62 @@
+# Gate the expected-STUMP set behind `block.emitExpectedStumpSet`
+
+## Why
+
+`docs/block-processed-completeness.md` promised the expected-STUMP set (the
+per-(block, callbackURL) subtree-index set attached to `BLOCK_PROCESSED` as
+`expectedSubtreeIndices`) behind a config flag, `block.emitExpectedStumpSet`,
+default off. The feature actually shipped **always-on** in v0.4.5 (#162) — no
+flag was ever implemented, and the openspec main spec never documented the
+field. This change reconciles documentation with reality and adds the flag as
+an **emergency off-switch** for the feature's Aerospike write load on the MINED
+hot path (one batched set-add per subtree with matched URLs), should it ever
+need to be shed during an incident.
+
+## What Changes
+
+- New config key `block.emitExpectedStumpSet` (env
+  `BLOCK_EMIT_EXPECTED_STUMP_SET`), **default true** — deliberately diverging
+  from the doc's original "default off" rollout plan, because the feature has
+  been unconditionally live in production since v0.4.5 and its write load is
+  already absorbed. Off-switch semantics, not a rollout gate.
+- The flag gates **both** the write path (recording subtree indices in
+  `handleMessage`) and the attach path (reading the set in
+  `emitBlockProcessed`) together. Gating only the write while still attaching
+  would ship an empty expected set — "expect zero STUMPs" — reintroducing the
+  silent-loss bug the feature exists to fix.
+- `docs/block-processed-completeness.md` gains per-step rollout status and a
+  corrected "Cost and gating" section; stale references to the removed
+  `docs/callback-topic-partition-design.md` in `config.yaml` and
+  `internal/config/config.go` now cite `docs/block-processed-completeness.md`.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `block-processing`: `BLOCK_PROCESSED` completeness reporting
+  (`expectedSubtreeIndices`) becomes configurable via
+  `block.emitExpectedStumpSet` (default on); this change also retroactively
+  documents the field itself, which #162 shipped without a spec delta.
+
+## Impact
+
+- **`internal/config/config.go` / `config.yaml`**: `BlockConfig`
+  `EmitExpectedStumpSet *bool` (nil ⇒ enabled) +
+  `EmitExpectedStumpSetEnabled()`, default `block.emitexpectedstumpset=true`,
+  env binding `BLOCK_EMIT_EXPECTED_STUMP_SET`, refreshed kafka
+  partition-rationale comments.
+- **`internal/block/subtree_worker.go`**: write gate in `handleMessage`,
+  attach gate in `emitBlockProcessed` (resolves the store to nil when
+  disabled; `emitBlockProcessedCallbacks` signature unchanged — the
+  block-processor's coinbase-only path already passes nil).
+- **`docs/block-processed-completeness.md`**: gating and rollout-status
+  updates.
+- **Tests**: `internal/config/config_test.go` (default / env-override /
+  zero-value semantics), `internal/block/expected_stump_flag_test.go`
+  (flag-off omits the field and never reads or writes the store; flag-unset
+  records the index set — closing the write path's pre-existing coverage gap).
+  Existing tests pass unmodified.

--- a/openspec/changes/emit-expected-stump-flag/specs/block-processing/spec.md
+++ b/openspec/changes/emit-expected-stump-flag/specs/block-processing/spec.md
@@ -1,0 +1,37 @@
+# block-processing (delta)
+
+## ADDED Requirements
+
+### Requirement: Attach expected-STUMP index set to BLOCK_PROCESSED (configurable)
+
+The subtree worker SHALL record, per (block, callbackURL), the set of subtree
+indices that produced a STUMP for that URL, and SHALL attach that set to the
+URL's `BLOCK_PROCESSED` message as `expectedSubtreeIndices` (JSON `omitempty`),
+so the receiver can detect a missing STUMP (STUMPs are sparse, so a receiver
+cannot otherwise distinguish a legitimately-absent STUMP from a lost one).
+Recording MUST happen before the per-block subtree counter is decremented so
+the set is complete when the counter drains to zero and the emit path reads it.
+
+The behavior SHALL be controlled by `block.emitExpectedStumpSet` (env
+`BLOCK_EMIT_EXPECTED_STUMP_SET`), default **true**; an unset value (including a
+zero-valued config struct) MUST behave as enabled. Disabling MUST suppress both
+the recording and the attach together: emitting `BLOCK_PROCESSED` with an
+expected set that was not being recorded would ship an empty set ("expect zero
+STUMPs") and silently disable missing-STUMP detection.
+
+#### Scenario: Flag enabled or unset attaches the recorded set
+
+- **WHEN** `block.emitExpectedStumpSet` is true or unset and a block's subtrees
+  produce STUMPs for a callback URL
+- **THEN** each successful subtree records its index for that URL exactly once
+  (idempotent under re-drives), and the URL's `BLOCK_PROCESSED` message carries
+  those indices as `expectedSubtreeIndices`
+
+#### Scenario: Flag disabled records nothing and omits the field
+
+- **WHEN** `block.emitExpectedStumpSet` is explicitly false and a block is
+  processed
+- **THEN** no subtree indices are recorded, the expected-stump store is not
+  read at emit time, and `BLOCK_PROCESSED` is still emitted without an
+  `expectedSubtreeIndices` key — indistinguishable from a pre-feature payload,
+  never an empty set

--- a/openspec/changes/emit-expected-stump-flag/tasks.md
+++ b/openspec/changes/emit-expected-stump-flag/tasks.md
@@ -1,0 +1,50 @@
+# Tasks: emit-expected-stump-flag
+
+## 1. Configuration
+
+- [x] 1.1 Add `EmitExpectedStumpSet *bool` (mapstructure `emitexpectedstumpset`)
+      to `config.BlockConfig` with the default-true divergence rationale and the
+      write+attach-together correctness note; add `EmitExpectedStumpSetEnabled()`
+      (nil ⇒ enabled)
+- [x] 1.2 Default `block.emitexpectedstumpset=true`; env binding
+      `BLOCK_EMIT_EXPECTED_STUMP_SET`; document the key in `config.yaml`
+
+## 2. Gating
+
+- [x] 2.1 `handleMessage` write gate: record subtree indices only when
+      `s.expectedStumps != nil && s.blockCfg.EmitExpectedStumpSetEnabled()`
+- [x] 2.2 `emitBlockProcessed` attach gate: resolve the expected-stump store to
+      nil when disabled before delegating to `emitBlockProcessedCallbacks`
+      (suppresses the read AND the field — never an empty set)
+
+## 3. Docs and comments
+
+- [x] 3.1 `docs/block-processed-completeness.md`: rewrite "Cost and gating"
+      (flag exists, default on, off-switch semantics, both paths gated
+      together); mark per-step rollout status (1 shipped v0.4.5, 2 shipped
+      arcade v0.9.10 with skip-grace in progress, 3 overtaken by events,
+      4 still deferred)
+- [x] 3.2 Refresh the stale `docs/callback-topic-partition-design.md`
+      references in `internal/config/config.go` and `config.yaml` to cite
+      `docs/block-processed-completeness.md`
+
+## 4. Tests (TDD: red before each implementation step)
+
+- [x] 4.1 Config: `TestLoad_EmitExpectedStumpSet_DefaultTrue`,
+      `TestLoad_EmitExpectedStumpSet_EnvOverride` (false disables, true
+      enables), `TestBlockConfig_EmitExpectedStumpSetEnabled_ZeroValue`
+      (nil means enabled)
+- [x] 4.2 Block: `TestEmitBlockProcessed_FlagOff_OmitsExpectedIndices` (no
+      `expectedSubtreeIndices` key in the raw payload, zero `GetSubtreeIndices`
+      reads), `TestHandleMessage_FlagOff_SkipsAddSubtreeIndex` (zero writes,
+      STUMP still published, counter still decremented),
+      `TestHandleMessage_FlagUnset_RecordsSubtreeIndex` (default-on write path,
+      closing its pre-existing coverage gap)
+
+## 5. Validation
+
+- [x] 5.1 Existing tests pass unmodified (`expected_stump_emit_test.go`,
+      `subtree_worker_test.go`, `expected_stump_integration_test.go`
+      byte-identical to origin/main)
+- [x] 5.2 `go build ./...`, `go test ./... -count=1`, `go test -race` on
+      internal/config + internal/block, `make lint` all green


### PR DESCRIPTION
Reconciles the code with `docs/block-processed-completeness.md`: the doc specified a `block.emitExpectedStumpSet` rollout flag (default off) that was never implemented — the expected-STUMP mechanism has been unconditionally live since v0.4.5. This adds the flag as an **off-switch, default on** (deliberate divergence from the doc, which is updated with the rationale: the load cost is already absorbed in production; the rollout gate era has passed).

- `EmitExpectedStumpSet *bool` with nil-means-enabled semantics (`EmitExpectedStumpSetEnabled()`), env `BLOCK_EMIT_EXPECTED_STUMP_SET`.
- **Write and attach gate together**: flag off suppresses `AddSubtreeIndex` recording AND resolves the store to nil at emit — never shipping an *empty* `expectedSubtreeIndices` set, which would tell the receiver to expect zero STUMPs and silently disable missing-STUMP detection (the hazard is documented at both gates).
- Refreshes the stale single-partition comments (config.go/config.yaml) to reference the completeness doc instead of the superseded partition-design doc, and records per-step rollout status in the doc (data plane shipped v0.4.5; arcade detection shipped v0.9.10 with skip-grace in progress; callback-topic widening still deferred).

## Verification
- `go build ./...`; `go test ./... -count=1` 21 packages ok; `-race` clean on internal/config + internal/block; `make lint` 0 issues.
- TDD with observed behavioral RED for each gate; existing expected-stump tests byte-identical (`git diff origin/main` empty on those files).
- openspec change `emit-expected-stump-flag` scaffolded and validated.