### PR TITLE
Peer-weighted SEEN_MULTIPLE_NODES from first-seen mining nodes

### DIFF
--- a/cmd/block-processor/main.go
+++ b/cmd/block-processor/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bsv-blockchain/merkle-service/internal/block"
 	"github.com/bsv-blockchain/merkle-service/internal/config"
 	"github.com/bsv-blockchain/merkle-service/internal/metrics"
+	"github.com/bsv-blockchain/merkle-service/internal/nodes"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
 	_ "github.com/bsv-blockchain/merkle-service/internal/store/sql" // register SQL backend
@@ -45,9 +46,15 @@ func main() {
 	stopSweeper := store.StartAgeSweeperFromConfig(registry.Blob, cfg.BlobStore, logger)
 	defer stopSweeper()
 
+	nodeRegistry, err := nodes.NewRegistry(registry.BlockAttribution, cfg.Callback.SeenWindowBlocks, logger)
+	if err != nil {
+		log.Fatal("failed to create node registry: ", err)
+	}
+
 	processor := block.NewProcessor(
 		cfg.Kafka, cfg.Block, cfg.DataHub,
 		registry.Registration, registry.Subtree, registry.CallbackURLRegistry, registry.DataHubRegistry, registry.SubtreeCounter,
+		nodeRegistry,
 		logger,
 	)
 

--- a/cmd/merkle-service/main.go
+++ b/cmd/merkle-service/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bsv-blockchain/merkle-service/internal/datahub"
 	"github.com/bsv-blockchain/merkle-service/internal/kafka"
 	"github.com/bsv-blockchain/merkle-service/internal/metrics"
+	"github.com/bsv-blockchain/merkle-service/internal/nodes"
 	"github.com/bsv-blockchain/merkle-service/internal/p2p"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
@@ -84,8 +85,15 @@ func main() {
 		cfg.DataHub.AllowPrivateIPs,
 		logger,
 	)
-	subtreeFetcher := subtree.NewProcessor(cfg, registry.Registration, registry.SeenCounter, registry.Subtree, logger)
-	blockProcessor := block.NewProcessor(cfg.Kafka, cfg.Block, cfg.DataHub, registry.Registration, registry.Subtree, registry.CallbackURLRegistry, registry.DataHubRegistry, registry.SubtreeCounter, logger)
+	nodeRegistry, err := nodes.NewRegistry(registry.BlockAttribution, cfg.Callback.SeenWindowBlocks, logger)
+	if err != nil {
+		log.Fatal("failed to create node registry: ", err)
+	}
+	nodeRegistry.StartBackgroundRefresh(0)
+	defer nodeRegistry.StopBackgroundRefresh()
+
+	subtreeFetcher := subtree.NewProcessor(cfg, registry.Registration, registry.SeenCounter, registry.Subtree, nodeRegistry, registry.SubtreeAttribution, logger)
+	blockProcessor := block.NewProcessor(cfg.Kafka, cfg.Block, cfg.DataHub, registry.Registration, registry.Subtree, registry.CallbackURLRegistry, registry.DataHubRegistry, registry.SubtreeCounter, nodeRegistry, logger)
 	subtreeWorker := block.NewSubtreeWorkerService(cfg.Kafka, cfg.Block, cfg.DataHub, registry.Registration, registry.Subtree, registry.Stump, registry.CallbackURLRegistry, registry.SubtreeCounter, registry.ExpectedStump, registry.SeenCounter, logger)
 	callbackDelivery := callback.NewDeliveryService(cfg, registry.CallbackDedup, registry.Stump, registry.CallbackURLRegistry, logger)
 

--- a/cmd/subtree-fetcher/main.go
+++ b/cmd/subtree-fetcher/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bsv-blockchain/merkle-service/internal/config"
 	"github.com/bsv-blockchain/merkle-service/internal/metrics"
+	"github.com/bsv-blockchain/merkle-service/internal/nodes"
 	"github.com/bsv-blockchain/merkle-service/internal/service"
 	"github.com/bsv-blockchain/merkle-service/internal/store"
 	_ "github.com/bsv-blockchain/merkle-service/internal/store/sql" // register SQL backend
@@ -35,7 +36,15 @@ func main() {
 	}
 	defer func() { _ = registry.Close() }()
 
-	processor := subtree.NewProcessor(cfg, registry.Registration, registry.SeenCounter, registry.Subtree, logger)
+	nodeRegistry, err := nodes.NewRegistry(registry.BlockAttribution, cfg.Callback.SeenWindowBlocks, logger)
+	if err != nil {
+		log.Fatal("failed to create node registry: ", err)
+	}
+	// Fetcher replicas do not process blocks; refresh tip weights from the shared store.
+	nodeRegistry.StartBackgroundRefresh(0)
+	defer nodeRegistry.StopBackgroundRefresh()
+
+	processor := subtree.NewProcessor(cfg, registry.Registration, registry.SeenCounter, registry.Subtree, nodeRegistry, registry.SubtreeAttribution, logger)
 
 	var metricsSrv *metrics.Server
 	if cfg.Metrics.Enabled {

--- a/config.yaml
+++ b/config.yaml
@@ -410,10 +410,17 @@ callback:
   # Env: CALLBACK_TIMEOUT_SEC
   timeoutSec: 10
 
-  # Number of unique subtrees a txid must appear in before emitting
-  # a SEEN_MULTIPLE_NODES callback. Tracks network propagation confidence.
+  # Deprecated unique-subtree count (ignored). Prefer seenScoreThreshold.
   # Env: CALLBACK_SEEN_THRESHOLD
   seenThreshold: 3
+
+  # Tip-path window size for mining-node weights (last W blocks).
+  # Env: CALLBACK_SEEN_WINDOW_BLOCKS
+  seenWindowBlocks: 100
+
+  # Weighted score threshold (sum of node block-counts) for SEEN_MULTIPLE_NODES.
+  # Env: CALLBACK_SEEN_SCORE_THRESHOLD
+  seenScoreThreshold: 51
 
   # TTL in seconds for callback delivery deduplication records in Aerospike.
   # After expiry, a very late duplicate could be redelivered. Default: 86400 (24 hours).

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -68,7 +68,9 @@ data:
       maxRetries: 5
       backoffBaseSec: 30
       timeoutSec: 10
-      seenThreshold: 3
+      seenThreshold: 3  # deprecated; use seenScoreThreshold
+      seenWindowBlocks: 100
+      seenScoreThreshold: 51
       dedupTTLSec: 86400
       maxConnsPerHost: 32
       maxIdleConnsPerHost: 16

--- a/internal/block/processor.go
+++ b/internal/block/processor.go
@@ -22,6 +22,11 @@ import (
 // longer than the per-attempt HTTP timeout plus a single backoff.
 const blockFetchPerPeerTimeout = 12 * time.Second
 
+// NodeRecorder attributes first-seen block announcements for the node registry.
+type NodeRecorder interface {
+	RecordBlock(hash string, height uint32, headerHex, peerID string) (ready bool, err error)
+}
+
 // Processor implements the block processor service.
 type Processor struct {
 	service.BaseService
@@ -44,6 +49,7 @@ type Processor struct {
 	urlRegistry      store.CallbackURLRegistry
 	dataHubRegistry  store.DataHubRegistry
 	subtreeCounter   store.SubtreeCounterStore
+	nodeRegistry     NodeRecorder
 	dataHubClient    *datahub.Client
 	dedupCache       *cache.DedupCache
 }
@@ -57,6 +63,7 @@ func NewProcessor(
 	urlRegistry store.CallbackURLRegistry,
 	dataHubRegistry store.DataHubRegistry,
 	subtreeCounter store.SubtreeCounterStore,
+	nodeRegistry NodeRecorder,
 	logger *slog.Logger,
 ) *Processor {
 	p := &Processor{
@@ -68,6 +75,7 @@ func NewProcessor(
 		urlRegistry:     urlRegistry,
 		dataHubRegistry: dataHubRegistry,
 		subtreeCounter:  subtreeCounter,
+		nodeRegistry:    nodeRegistry,
 	}
 	p.InitBase("block-processor")
 	if logger != nil {
@@ -194,8 +202,18 @@ func (p *Processor) handleMessage(ctx context.Context, msg *kafka.Message) error
 		logfields.BlockHash(blockMsg.Hash),
 		logfields.BlockHeight(blockMsg.Height),
 		logfields.DataHubURL(blockMsg.DataHubURL),
+		"peerId", blockMsg.PeerID,
 		"reprocess", blockMsg.OverrideCallbackURL != "",
 	)
+
+	// First-seen peer attribution for the node registry (shared store).
+	// Run before work-path dedup so the first announce always wins.
+	if p.nodeRegistry != nil && blockMsg.PeerID != "" && blockMsg.Hash != "" {
+		if _, err := p.nodeRegistry.RecordBlock(blockMsg.Hash, blockMsg.Height, blockMsg.Header, blockMsg.PeerID); err != nil {
+			p.Logger.Warn("failed to record block peer for node registry",
+				logfields.BlockHash(blockMsg.Hash), "peerId", blockMsg.PeerID, "error", err)
+		}
+	}
 
 	// Check dedup cache — skip if already successfully processed. Reprocess
 	// requests (BypassDedup) intentionally skip both the lookup and the later

--- a/internal/block/reprocess_test.go
+++ b/internal/block/reprocess_test.go
@@ -313,7 +313,8 @@ func TestProcessor_NewProcessor_WithDataHubRegistry_NoCrashOnNil(t *testing.T) {
 		config.BlockConfig{},
 		config.DataHubConfig{},
 		nil, nil, nil, nil, nil,
-		nil,
+		nil, // nodeRegistry
+		nil, // logger
 	)
 	if p == nil {
 		t.Fatal("NewProcessor returned nil")

--- a/internal/block/seen_counter_cleanup_test.go
+++ b/internal/block/seen_counter_cleanup_test.go
@@ -18,12 +18,14 @@ func (f *fakeSeenCounter) Increment(string, string) (*store.IncrementResult, err
 	return &store.IncrementResult{}, nil
 }
 
-func (f *fakeSeenCounter) BatchIncrement([]string, string) (map[string]*store.IncrementResult, error) {
-	return nil, nil
-}
-
 func (f *fakeSeenCounter) Threshold() int { return 3 }
 
+func (f *fakeSeenCounter) AddPeer(txid, peerID string, weight int) (*store.IncrementResult, error) {
+	return &store.IncrementResult{}, nil
+}
+func (f *fakeSeenCounter) BatchAddPeer(txids []string, peerID string, weight int) (map[string]*store.IncrementResult, error) {
+	return map[string]*store.IncrementResult{}, nil
+}
 func (f *fakeSeenCounter) BatchDelete(txids []string) error {
 	cp := make([]string, len(txids))
 	copy(cp, txids)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -184,7 +184,12 @@ type AerospikeConfig struct {
 	// than this are evicted by the per-record TTL. Default 7 days; tune down
 	// for clusters where DataHub fleet membership rotates more aggressively.
 	DataHubRegistryTTLSec int `yaml:"dataHubRegistryTTLSec" mapstructure:"datahubregistryttlsec"`
-	MaxRetries            int `yaml:"maxRetries"  mapstructure:"maxretries"`
+	// BlockAttributionSet stores first-seen peer attributions for block hashes
+	// (node registry cold start / multi-replica).
+	BlockAttributionSet string `yaml:"blockAttributionSet" mapstructure:"blockattributionset"`
+	// SubtreeAttributionSet stores first-seen peer per subtree hash.
+	SubtreeAttributionSet string `yaml:"subtreeAttributionSet" mapstructure:"subtreeattributionset"`
+	MaxRetries            int    `yaml:"maxRetries"  mapstructure:"maxretries"`
 	RetryBaseMs           int `yaml:"retryBaseMs" mapstructure:"retrybasems"`
 	// ConnectionQueueSize is the per-node connection pool size. The Aerospike
 	// Go client default is 100; under bursty BatchGet load (e.g. 14+ subtrees
@@ -503,10 +508,17 @@ func (b BlockConfig) EmitExpectedStumpSetEnabled() bool {
 
 // CallbackConfig holds callback delivery configuration.
 type CallbackConfig struct {
-	MaxRetries          int `yaml:"maxRetries"          mapstructure:"maxretries"`
-	BackoffBaseSec      int `yaml:"backoffBaseSec"      mapstructure:"backoffbasesec"`
-	TimeoutSec          int `yaml:"timeoutSec"          mapstructure:"timeoutsec"`
-	SeenThreshold       int `yaml:"seenThreshold"       mapstructure:"seenthreshold"`
+	MaxRetries     int `yaml:"maxRetries"     mapstructure:"maxretries"`
+	BackoffBaseSec int `yaml:"backoffBaseSec" mapstructure:"backoffbasesec"`
+	TimeoutSec     int `yaml:"timeoutSec"     mapstructure:"timeoutsec"`
+	// SeenThreshold is deprecated. Prefer SeenScoreThreshold (weighted peer score).
+	// Kept for backward-compatible config parsing; ignored at runtime.
+	SeenThreshold int `yaml:"seenThreshold" mapstructure:"seenthreshold"`
+	// SeenWindowBlocks is W: tip-path blocks used for node weights (default 100).
+	SeenWindowBlocks int `yaml:"seenWindowBlocks" mapstructure:"seenwindowblocks"`
+	// SeenScoreThreshold is the minimum weighted score (out of SeenWindowBlocks)
+	// to emit SEEN_MULTIPLE_NODES (default 51).
+	SeenScoreThreshold  int `yaml:"seenScoreThreshold"  mapstructure:"seenscorethreshold"`
 	DedupTTLSec         int `yaml:"dedupTTLSec"         mapstructure:"dedupttlsec"`
 	MaxConnsPerHost     int `yaml:"maxConnsPerHost"     mapstructure:"maxconnsperhost"`
 	MaxIdleConnsPerHost int `yaml:"maxIdleConnsPerHost" mapstructure:"maxidleconnsperhost"`
@@ -736,7 +748,11 @@ func registerDefaults(v *viper.Viper) {
 	v.SetDefault("callback.breakerthreshold", 20)
 	v.SetDefault("callback.backoffbasesec", 30)
 	v.SetDefault("callback.timeoutsec", 10)
-	v.SetDefault("callback.seenthreshold", 3)
+	v.SetDefault("callback.seenthreshold", 3) // deprecated
+	v.SetDefault("callback.seenwindowblocks", 100)
+	v.SetDefault("callback.seenscorethreshold", 51)
+	v.SetDefault("aerospike.blockattributionset", "merkle_block_attributions")
+	v.SetDefault("aerospike.subtreeattributionset", "merkle_subtree_attributions")
 	v.SetDefault("callback.dedupttlsec", 86400)
 	v.SetDefault("callback.maxconnsperhost", 32)
 	v.SetDefault("callback.maxidleconnsperhost", 16)
@@ -904,7 +920,11 @@ func bindEnvVars(v *viper.Viper) {
 		"callback.maxretries":          "CALLBACK_MAX_RETRIES",
 		"callback.backoffbasesec":      "CALLBACK_BACKOFF_BASE_SEC",
 		"callback.timeoutsec":          "CALLBACK_TIMEOUT_SEC",
-		"callback.seenthreshold":       "CALLBACK_SEEN_THRESHOLD",
+		"callback.seenthreshold":            "CALLBACK_SEEN_THRESHOLD", // deprecated
+		"callback.seenwindowblocks":         "CALLBACK_SEEN_WINDOW_BLOCKS",
+		"callback.seenscorethreshold":       "CALLBACK_SEEN_SCORE_THRESHOLD",
+		"aerospike.blockattributionset":     "AEROSPIKE_BLOCK_ATTRIBUTION_SET",
+		"aerospike.subtreeattributionset":   "AEROSPIKE_SUBTREE_ATTRIBUTION_SET",
 		"callback.dedupttlsec":         "CALLBACK_DEDUP_TTL_SEC",
 		"callback.maxconnsperhost":     "CALLBACK_MAX_CONNS_PER_HOST",
 		"callback.maxidleconnsperhost": "CALLBACK_MAX_IDLE_CONNS_PER_HOST",

--- a/internal/nodes/chain.go
+++ b/internal/nodes/chain.go
@@ -1,0 +1,244 @@
+// Package nodes maintains the set of "mining nodes" used for SEEN_MULTIPLE_NODES
+// confidence scoring. A node is a peer that first-announced at least one of the
+// last W blocks on our lightweight tip path derived from P2P block announcements.
+package nodes
+
+import (
+	"sort"
+)
+
+// BlockAttr is a first-seen attribution of a block hash to a peer.
+type BlockAttr struct {
+	Hash     string
+	PrevHash string
+	Height   uint32
+	PeerID   string
+}
+
+// Chain is a pure in-memory model of attributed blocks, a tip chosen by
+// maximum height, and a sliding window of the last W blocks on the tip path.
+//
+// Performance: tip path and weight map are recomputed only on mutation
+// (Record/Load/Prune), never on Weight/Ready reads — those are O(1) map lookups
+// against the cached snapshot. This matters because Weight is called on every
+// subtree that reaches scoring at multi-million-tx scale.
+type Chain struct {
+	window int
+	blocks map[string]BlockAttr // hash → attr
+	tip    string
+
+	// Cached after each mutation. windowPath is tip-first, capped at window.
+	windowPath []string
+	weights    map[string]int
+	ready      bool
+}
+
+// NewChain creates an empty chain with the given window size W.
+// W <= 0 defaults to 100.
+func NewChain(window int) *Chain {
+	if window <= 0 {
+		window = 100
+	}
+	return &Chain{
+		window:  window,
+		blocks:  make(map[string]BlockAttr),
+		weights: make(map[string]int),
+	}
+}
+
+// Load replaces chain state from a full set of attributions (e.g. after
+// loading from a shared store). Tip is recomputed as the max-height block.
+func (c *Chain) Load(attrs []BlockAttr) {
+	c.blocks = make(map[string]BlockAttr, len(attrs))
+	for _, a := range attrs {
+		if a.Hash == "" {
+			continue
+		}
+		c.blocks[a.Hash] = a
+	}
+	c.recomputeTip()
+	c.rebuildCaches()
+}
+
+// Record adds a first-seen block attribution. If hash is already known, the
+// existing attribution is kept and FirstSeen is false. Otherwise the block is
+// stored, the tip may move, and Orphaned lists hashes that left the tip path
+// (informational; attributions are retained for side-branch reconnection).
+func (c *Chain) Record(attr BlockAttr) (firstSeen bool, orphaned []string) {
+	if attr.Hash == "" {
+		return false, nil
+	}
+	if _, exists := c.blocks[attr.Hash]; exists {
+		return false, nil
+	}
+
+	oldPath := c.windowPathSet()
+	c.blocks[attr.Hash] = attr
+	c.recomputeTip()
+	c.rebuildCaches()
+	newPath := c.windowPathSet()
+
+	for h := range oldPath {
+		if !newPath[h] {
+			orphaned = append(orphaned, h)
+		}
+	}
+	sort.Strings(orphaned)
+	return true, orphaned
+}
+
+// Window returns up to W block attributions on the current tip path,
+// tip-first order (index 0 is the tip).
+func (c *Chain) Window() []BlockAttr {
+	out := make([]BlockAttr, 0, len(c.windowPath))
+	for _, h := range c.windowPath {
+		out = append(out, c.blocks[h])
+	}
+	return out
+}
+
+// Weights returns peerID → number of blocks in the current window.
+// The returned map must not be mutated by the caller (shared cache).
+func (c *Chain) Weights() map[string]int {
+	return c.weights
+}
+
+// Weight returns the window count for peerID (0 if unknown / not in window).
+// O(1) after cache rebuild.
+func (c *Chain) Weight(peerID string) int {
+	if peerID == "" {
+		return 0
+	}
+	return c.weights[peerID]
+}
+
+// Ready is true when the tip path has at least W known blocks. O(1).
+func (c *Chain) Ready() bool {
+	return c.ready
+}
+
+// TipHash returns the current tip block hash, or empty if none.
+func (c *Chain) TipHash() string { return c.tip }
+
+// WindowSize returns W.
+func (c *Chain) WindowSize() int { return c.window }
+
+// Len returns the number of attributed blocks retained.
+func (c *Chain) Len() int { return len(c.blocks) }
+
+// All returns a copy of every attributed block (for persistence snapshots).
+func (c *Chain) All() []BlockAttr {
+	out := make([]BlockAttr, 0, len(c.blocks))
+	for _, a := range c.blocks {
+		out = append(out, a)
+	}
+	return out
+}
+
+// PruneBelow removes attributions with height strictly less than
+// tipHeight - retainDepth, keeping enough history for short reorgs.
+// retainDepth defaults to 2*window when <= 0.
+func (c *Chain) PruneBelow(retainDepth int) int {
+	if c.tip == "" {
+		return 0
+	}
+	if retainDepth <= 0 {
+		retainDepth = 2 * c.window
+	}
+	tip := c.blocks[c.tip]
+	if tip.Height < uint32(retainDepth) {
+		return 0
+	}
+	minHeight := tip.Height - uint32(retainDepth)
+	keep := c.windowPathSet()
+	// Also keep full tip path beyond window for parent walks.
+	for _, h := range c.tipPathUncapped() {
+		keep[h] = true
+	}
+	removed := 0
+	for h, a := range c.blocks {
+		if keep[h] {
+			continue
+		}
+		if a.Height < minHeight {
+			delete(c.blocks, h)
+			removed++
+		}
+	}
+	if removed > 0 {
+		c.rebuildCaches()
+	}
+	return removed
+}
+
+func (c *Chain) recomputeTip() {
+	if len(c.blocks) == 0 {
+		c.tip = ""
+		return
+	}
+	var best BlockAttr
+	found := false
+	for _, a := range c.blocks {
+		if !found || a.Height > best.Height || (a.Height == best.Height && a.Hash < best.Hash) {
+			best = a
+			found = true
+		}
+	}
+	c.tip = best.Hash
+}
+
+// rebuildCaches refreshes windowPath, weights, ready. Call after any mutation.
+func (c *Chain) rebuildCaches() {
+	path := c.tipPathUncapped()
+	if len(path) > c.window {
+		path = path[:c.window]
+	}
+	// Own the slice so later walks don't share backing arrays unexpectedly.
+	c.windowPath = append([]string(nil), path...)
+
+	w := make(map[string]int, 8)
+	for _, h := range c.windowPath {
+		a := c.blocks[h]
+		if a.PeerID == "" {
+			continue
+		}
+		w[a.PeerID]++
+	}
+	c.weights = w
+	c.ready = len(c.windowPath) >= c.window
+}
+
+// tipPathUncapped walks prevHash links from tip, returning hashes tip-first.
+func (c *Chain) tipPathUncapped() []string {
+	if c.tip == "" {
+		return nil
+	}
+	max := c.window * 4
+	if max < 256 {
+		max = 256
+	}
+	seen := make(map[string]struct{}, max)
+	path := make([]string, 0, c.window)
+	h := c.tip
+	for i := 0; i < max && h != ""; i++ {
+		if _, ok := seen[h]; ok {
+			break
+		}
+		a, ok := c.blocks[h]
+		if !ok {
+			break
+		}
+		seen[h] = struct{}{}
+		path = append(path, h)
+		h = a.PrevHash
+	}
+	return path
+}
+
+func (c *Chain) windowPathSet() map[string]bool {
+	set := make(map[string]bool, len(c.windowPath))
+	for _, h := range c.windowPath {
+		set[h] = true
+	}
+	return set
+}

--- a/internal/nodes/chain_test.go
+++ b/internal/nodes/chain_test.go
@@ -1,0 +1,149 @@
+package nodes
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestChain_FirstSeenWins(t *testing.T) {
+	c := NewChain(100)
+	first, _ := c.Record(BlockAttr{Hash: "h1", PrevHash: "h0", Height: 1, PeerID: "alice"})
+	if !first {
+		t.Fatal("expected first seen")
+	}
+	second, _ := c.Record(BlockAttr{Hash: "h1", PrevHash: "h0", Height: 1, PeerID: "bob"})
+	if second {
+		t.Fatal("duplicate hash must not re-attribute")
+	}
+	if c.Weight("alice") != 1 {
+		t.Fatalf("alice weight=%d", c.Weight("alice"))
+	}
+	if c.Weight("bob") != 0 {
+		t.Fatalf("bob should not own h1, weight=%d", c.Weight("bob"))
+	}
+}
+
+func TestChain_ExtendsTipAndWeights(t *testing.T) {
+	c := NewChain(100)
+	c.Record(BlockAttr{Hash: "h1", PrevHash: "genesis", Height: 1, PeerID: "a"})
+	c.Record(BlockAttr{Hash: "h2", PrevHash: "h1", Height: 2, PeerID: "b"})
+	c.Record(BlockAttr{Hash: "h3", PrevHash: "h2", Height: 3, PeerID: "a"})
+
+	if c.TipHash() != "h3" {
+		t.Fatalf("tip=%s want h3", c.TipHash())
+	}
+	w := c.Weights()
+	if w["a"] != 2 || w["b"] != 1 {
+		t.Fatalf("weights=%v", w)
+	}
+	if c.Ready() {
+		t.Fatal("window of 3 should not be ready for W=100")
+	}
+}
+
+func TestChain_ReadyWhenWindowFull(t *testing.T) {
+	const W = 5
+	c := NewChain(W)
+	prev := "genesis"
+	for i := 1; i <= W; i++ {
+		h := fmt.Sprintf("h%d", i)
+		c.Record(BlockAttr{Hash: h, PrevHash: prev, Height: uint32(i), PeerID: "miner"})
+		prev = h
+	}
+	if !c.Ready() {
+		t.Fatal("expected ready after W continuous blocks")
+	}
+	if c.Weight("miner") != W {
+		t.Fatalf("weight=%d want %d", c.Weight("miner"), W)
+	}
+}
+
+func TestChain_ReorgDropsOrphansFromWindow(t *testing.T) {
+	// Build main chain: g -> a1 -> a2 -> a3
+	c := NewChain(10)
+	c.Record(BlockAttr{Hash: "a1", PrevHash: "g", Height: 1, PeerID: "alice"})
+	c.Record(BlockAttr{Hash: "a2", PrevHash: "a1", Height: 2, PeerID: "alice"})
+	c.Record(BlockAttr{Hash: "a3", PrevHash: "a2", Height: 3, PeerID: "alice"})
+
+	// Side branch from a1: b2 (height 2) then b3, b4 (height 4 wins tip)
+	c.Record(BlockAttr{Hash: "b2", PrevHash: "a1", Height: 2, PeerID: "bob"})
+	c.Record(BlockAttr{Hash: "b3", PrevHash: "b2", Height: 3, PeerID: "bob"})
+	first, orphaned := c.Record(BlockAttr{Hash: "b4", PrevHash: "b3", Height: 4, PeerID: "bob"})
+	if !first {
+		t.Fatal("b4 should be first seen")
+	}
+	if c.TipHash() != "b4" {
+		t.Fatalf("tip=%s want b4", c.TipHash())
+	}
+
+	// a2 and a3 should be off the tip path window.
+	orphanedSet := map[string]bool{}
+	for _, h := range orphaned {
+		orphanedSet[h] = true
+	}
+	if !orphanedSet["a2"] || !orphanedSet["a3"] {
+		t.Fatalf("expected a2,a3 orphaned from tip path, got %v", orphaned)
+	}
+
+	w := c.Weights()
+	// Window tip path: b4,b3,b2,a1 → bob=3, alice=1
+	if w["bob"] != 3 {
+		t.Fatalf("bob weight=%d want 3, weights=%v", w["bob"], w)
+	}
+	if w["alice"] != 1 {
+		t.Fatalf("alice weight=%d want 1, weights=%v", w["alice"], w)
+	}
+}
+
+func TestChain_GapStopsWindow(t *testing.T) {
+	c := NewChain(5)
+	// Missing parent of h2: walk stops, window len=1
+	c.Record(BlockAttr{Hash: "h2", PrevHash: "missing", Height: 2, PeerID: "a"})
+	if len(c.Window()) != 1 {
+		t.Fatalf("window len=%d want 1", len(c.Window()))
+	}
+	if c.Ready() {
+		t.Fatal("should not be ready with a gap")
+	}
+}
+
+func TestChain_LoadRestoresTip(t *testing.T) {
+	attrs := []BlockAttr{
+		{Hash: "h1", PrevHash: "g", Height: 1, PeerID: "a"},
+		{Hash: "h2", PrevHash: "h1", Height: 2, PeerID: "b"},
+	}
+	c := NewChain(100)
+	c.Load(attrs)
+	if c.TipHash() != "h2" {
+		t.Fatalf("tip=%s", c.TipHash())
+	}
+	if c.Weight("b") != 1 || c.Weight("a") != 1 {
+		t.Fatalf("weights=%v", c.Weights())
+	}
+}
+
+func TestChain_PruneBelowKeepsTipPath(t *testing.T) {
+	c := NewChain(3)
+	prev := "g"
+	for i := 1; i <= 10; i++ {
+		h := fmt.Sprintf("h%d", i)
+		c.Record(BlockAttr{Hash: h, PrevHash: prev, Height: uint32(i), PeerID: "m"})
+		prev = h
+	}
+	// Side old orphan far below tip
+	c.Record(BlockAttr{Hash: "old", PrevHash: "x", Height: 1, PeerID: "other"})
+	removed := c.PruneBelow(4)
+	if removed < 1 {
+		t.Fatalf("expected prune of old block, removed=%d", removed)
+	}
+	if _, ok := c.blocks["old"]; ok {
+		t.Fatal("old should be pruned")
+	}
+	// Tip path blocks within retain depth stay
+	if c.TipHash() != "h10" {
+		t.Fatalf("tip=%s", c.TipHash())
+	}
+	if len(c.Window()) != 3 {
+		t.Fatalf("window=%d", len(c.Window()))
+	}
+}

--- a/internal/nodes/header.go
+++ b/internal/nodes/header.go
@@ -1,0 +1,24 @@
+package nodes
+
+import (
+	"fmt"
+
+	"github.com/bsv-blockchain/teranode/model"
+)
+
+// ParsePrevHash extracts the previous-block hash from a hex-encoded 80-byte
+// block header as carried on kafka.BlockMessage.Header. Returns empty string
+// when headerHex is empty (caller may still attribute by height alone).
+func ParsePrevHash(headerHex string) (string, error) {
+	if headerHex == "" {
+		return "", nil
+	}
+	h, err := model.NewBlockHeaderFromString(headerHex)
+	if err != nil {
+		return "", fmt.Errorf("parse block header: %w", err)
+	}
+	if h.HashPrevBlock == nil {
+		return "", nil
+	}
+	return h.HashPrevBlock.String(), nil
+}

--- a/internal/nodes/memory_store.go
+++ b/internal/nodes/memory_store.go
@@ -1,0 +1,71 @@
+package nodes
+
+import (
+	"sync"
+
+	"github.com/bsv-blockchain/merkle-service/internal/store"
+)
+
+// MemoryBlockAttributionStore is an in-process BlockAttributionStore for tests.
+type MemoryBlockAttributionStore struct {
+	mu   sync.Mutex
+	data map[string]store.BlockAttribution
+}
+
+func NewMemoryBlockAttributionStore() *MemoryBlockAttributionStore {
+	return &MemoryBlockAttributionStore{data: make(map[string]store.BlockAttribution)}
+}
+
+func (s *MemoryBlockAttributionStore) TryAttribute(hash, prevHash, peerID string, height uint32) (string, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, ok := s.data[hash]; ok {
+		return existing.PeerID, false, nil
+	}
+	s.data[hash] = store.BlockAttribution{
+		Hash:     hash,
+		PrevHash: prevHash,
+		Height:   height,
+		PeerID:   peerID,
+	}
+	return peerID, true, nil
+}
+
+func (s *MemoryBlockAttributionStore) ListAll() ([]store.BlockAttribution, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]store.BlockAttribution, 0, len(s.data))
+	for _, a := range s.data {
+		out = append(out, a)
+	}
+	return out, nil
+}
+
+func (s *MemoryBlockAttributionStore) DeleteHashes(hashes []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, h := range hashes {
+		delete(s.data, h)
+	}
+	return nil
+}
+
+// MemorySubtreeAttributionStore is an in-process SubtreeAttributionStore for tests.
+type MemorySubtreeAttributionStore struct {
+	mu   sync.Mutex
+	data map[string]string // hash → peerID
+}
+
+func NewMemorySubtreeAttributionStore() *MemorySubtreeAttributionStore {
+	return &MemorySubtreeAttributionStore{data: make(map[string]string)}
+}
+
+func (s *MemorySubtreeAttributionStore) TryAttribute(subtreeHash, peerID string) (string, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, ok := s.data[subtreeHash]; ok {
+		return existing, false, nil
+	}
+	s.data[subtreeHash] = peerID
+	return peerID, true, nil
+}

--- a/internal/nodes/registry.go
+++ b/internal/nodes/registry.go
@@ -1,0 +1,259 @@
+package nodes
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/bsv-blockchain/merkle-service/internal/store"
+)
+
+// weightView is an immutable snapshot published for lock-free hot-path reads.
+// Weight/Ready are on the multi-million-tx scoring path; they must not take
+// mutexes or rebuild maps.
+type weightView struct {
+	ready   bool
+	weights map[string]int // peerID → count; never mutated after publish
+}
+
+// Registry is the shared-store-backed node weight map used by subtree scoring.
+//
+// Hot path (Weight/Ready): atomic.Value load only — no I/O, no locks.
+// Cold path (RecordBlock): shared store first-seen insert + local chain update
+// + publish new weightView. Block rate is ~O(1/min), so cost is irrelevant.
+//
+// Multi-replica: block-processor mutates the store; subtree-fetchers refresh
+// from the store on a ticker so their weightView stays current without
+// consuming the block topic on every fetcher.
+type Registry struct {
+	store  store.BlockAttributionStore
+	window int
+	logger *slog.Logger
+
+	mu    sync.Mutex // protects chain mutations only
+	chain *Chain
+
+	view atomic.Value // *weightView
+
+	// Optional background refresh for replicas that do not see RecordBlock.
+	refreshStop chan struct{}
+	refreshOnce sync.Once
+}
+
+// NewRegistry loads existing attributions from store and builds the chain.
+// store may be nil only for pure unit tests that never call RecordBlock.
+func NewRegistry(attrStore store.BlockAttributionStore, window int, logger *slog.Logger) (*Registry, error) {
+	if window <= 0 {
+		window = 100
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	r := &Registry{
+		store:  attrStore,
+		window: window,
+		logger: logger,
+		chain:  NewChain(window),
+	}
+	r.publishView() // empty view
+	if attrStore != nil {
+		attrs, err := attrStore.ListAll()
+		if err != nil {
+			return nil, fmt.Errorf("load block attributions: %w", err)
+		}
+		r.chain.Load(fromStoreAttrs(attrs))
+		r.publishView()
+		r.logger.Info("node registry loaded",
+			"blocks", r.chain.Len(),
+			"tip", r.chain.TipHash(),
+			"ready", r.chain.Ready(),
+			"window", window,
+		)
+	}
+	return r, nil
+}
+
+// NewMemoryRegistry returns a registry backed by an in-process store (tests / single process).
+func NewMemoryRegistry(window int, logger *slog.Logger) (*Registry, error) {
+	return NewRegistry(NewMemoryBlockAttributionStore(), window, logger)
+}
+
+// StartBackgroundRefresh periodically reloads attributions from the shared
+// store. Call from subtree-fetcher replicas that do not process block messages
+// so Weight/Ready track tip changes. interval <= 0 defaults to 5s.
+// Block rate is low; a multi-second lag on weight updates is acceptable.
+func (r *Registry) StartBackgroundRefresh(interval time.Duration) {
+	if r.store == nil {
+		return
+	}
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	r.refreshOnce.Do(func() {
+		r.refreshStop = make(chan struct{})
+		go func() {
+			t := time.NewTicker(interval)
+			defer t.Stop()
+			for {
+				select {
+				case <-r.refreshStop:
+					return
+				case <-t.C:
+					if err := r.Reload(); err != nil {
+						r.logger.Warn("node registry refresh failed", "error", err)
+					}
+				}
+			}
+		}()
+	})
+}
+
+// StopBackgroundRefresh stops the refresh goroutine if running.
+func (r *Registry) StopBackgroundRefresh() {
+	if r.refreshStop != nil {
+		select {
+		case <-r.refreshStop:
+		default:
+			close(r.refreshStop)
+		}
+	}
+}
+
+// RecordBlock attributes the first peer to announce this block hash, updates
+// the tip path using header prevHash (approach C), and returns whether the
+// registry is ready for scoring after this update.
+func (r *Registry) RecordBlock(hash string, height uint32, headerHex, peerID string) (ready bool, err error) {
+	if hash == "" || peerID == "" {
+		return r.Ready(), nil
+	}
+	if r.store == nil {
+		return false, fmt.Errorf("node registry has no attribution store")
+	}
+
+	prevHash, err := ParsePrevHash(headerHex)
+	if err != nil {
+		r.logger.Warn("failed to parse block header for node registry; recording without prevHash",
+			"hash", hash,
+			"error", err,
+		)
+		prevHash = ""
+	}
+
+	_, inserted, err := r.store.TryAttribute(hash, prevHash, peerID, height)
+	if err != nil {
+		return r.Ready(), fmt.Errorf("attribute block: %w", err)
+	}
+	if !inserted {
+		return r.Ready(), nil
+	}
+
+	attr := BlockAttr{
+		Hash:     hash,
+		PrevHash: prevHash,
+		Height:   height,
+		PeerID:   peerID,
+	}
+
+	r.mu.Lock()
+	first, orphaned := r.chain.Record(attr)
+	if first {
+		if len(orphaned) > 0 {
+			r.logger.Info("node registry tip path changed (reorg or extension)",
+				"tip", r.chain.TipHash(),
+				"orphanedFromWindow", len(orphaned),
+			)
+		}
+		if removed := r.chain.PruneBelow(0); removed > 0 {
+			r.logger.Debug("pruned off-path block attributions from memory", "count", removed)
+		}
+		r.publishViewLocked()
+	}
+	ready = r.chain.Ready()
+	r.mu.Unlock()
+	return ready, nil
+}
+
+// Weight returns the number of tip-window blocks first-announced by peerID.
+// Lock-free; safe on the per-txid scoring hot path.
+func (r *Registry) Weight(peerID string) int {
+	v := r.loadView()
+	if v == nil || peerID == "" {
+		return 0
+	}
+	return v.weights[peerID]
+}
+
+// Ready reports whether the tip path has at least W known blocks. Lock-free.
+func (r *Registry) Ready() bool {
+	v := r.loadView()
+	return v != nil && v.ready
+}
+
+// Snapshot returns a copy of peerID → weight for the current window.
+func (r *Registry) Snapshot() map[string]int {
+	v := r.loadView()
+	if v == nil {
+		return map[string]int{}
+	}
+	out := make(map[string]int, len(v.weights))
+	for k, n := range v.weights {
+		out[k] = n
+	}
+	return out
+}
+
+// Reload refreshes chain state from the store (background refresh / startup).
+func (r *Registry) Reload() error {
+	if r.store == nil {
+		return nil
+	}
+	attrs, err := r.store.ListAll()
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	r.chain.Load(fromStoreAttrs(attrs))
+	r.publishViewLocked()
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *Registry) loadView() *weightView {
+	v, _ := r.view.Load().(*weightView)
+	return v
+}
+
+func (r *Registry) publishView() {
+	r.mu.Lock()
+	r.publishViewLocked()
+	r.mu.Unlock()
+}
+
+// publishViewLocked copies chain caches into an immutable weightView.
+// Caller must hold r.mu.
+func (r *Registry) publishViewLocked() {
+	src := r.chain.Weights()
+	cp := make(map[string]int, len(src))
+	for k, n := range src {
+		cp[k] = n
+	}
+	r.view.Store(&weightView{
+		ready:   r.chain.Ready(),
+		weights: cp,
+	})
+}
+
+func fromStoreAttrs(attrs []store.BlockAttribution) []BlockAttr {
+	out := make([]BlockAttr, 0, len(attrs))
+	for _, a := range attrs {
+		out = append(out, BlockAttr{
+			Hash:     a.Hash,
+			PrevHash: a.PrevHash,
+			Height:   a.Height,
+			PeerID:   a.PeerID,
+		})
+	}
+	return out
+}

--- a/internal/store/block_attribution.go
+++ b/internal/store/block_attribution.go
@@ -1,0 +1,171 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+
+	as "github.com/aerospike/aerospike-client-go/v8"
+	astypes "github.com/aerospike/aerospike-client-go/v8/types"
+)
+
+const (
+	blockAttrPrevBin   = "prev"
+	blockAttrHeightBin = "height"
+	blockAttrPeerBin   = "peer"
+	blockAttrIndexKey  = "_index"
+	blockAttrHashesBin = "hashes"
+)
+
+type aerospikeBlockAttributionStore struct {
+	client      *AerospikeClient
+	setName     string
+	logger      *slog.Logger
+	maxRetries  int
+	retryBaseMs int
+}
+
+var _ BlockAttributionStore = (*aerospikeBlockAttributionStore)(nil)
+
+func NewBlockAttributionStore(client *AerospikeClient, setName string, maxRetries, retryBaseMs int, logger *slog.Logger) BlockAttributionStore {
+	return &aerospikeBlockAttributionStore{
+		client: client, setName: setName, logger: logger,
+		maxRetries: maxRetries, retryBaseMs: retryBaseMs,
+	}
+}
+
+func (s *aerospikeBlockAttributionStore) TryAttribute(hash, prevHash, peerID string, height uint32) (string, bool, error) {
+	key, err := as.NewKey(s.client.Namespace(), s.setName, hash)
+	if err != nil {
+		return "", false, err
+	}
+	wp := s.client.WritePolicy(s.maxRetries, s.retryBaseMs)
+	wp.RecordExistsAction = as.CREATE_ONLY
+	bins := as.BinMap{
+		blockAttrPrevBin:   prevHash,
+		blockAttrHeightBin: int(height),
+		blockAttrPeerBin:   peerID,
+	}
+	err = s.client.Client().Put(wp, key, bins)
+	if err == nil {
+		_ = s.addToIndex(hash)
+		return peerID, true, nil
+	}
+	if !isKeyExistsError(err) {
+		return "", false, fmt.Errorf("create block attribution: %w", err)
+	}
+	rp := s.client.ReadPolicy()
+	rec, err := s.client.Client().Get(rp, key, blockAttrPeerBin)
+	if err != nil {
+		return "", false, fmt.Errorf("read block attribution: %w", err)
+	}
+	stored, _ := rec.Bins[blockAttrPeerBin].(string)
+	return stored, false, nil
+}
+
+func (s *aerospikeBlockAttributionStore) ListAll() ([]BlockAttribution, error) {
+	hashes, err := s.listIndex()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]BlockAttribution, 0, len(hashes))
+	rp := s.client.ReadPolicy()
+	for _, h := range hashes {
+		key, err := as.NewKey(s.client.Namespace(), s.setName, h)
+		if err != nil {
+			continue
+		}
+		rec, err := s.client.Client().Get(rp, key)
+		if err != nil {
+			var asErr as.Error
+			if errors.As(err, &asErr) && asErr.Matches(astypes.KEY_NOT_FOUND_ERROR) {
+				continue
+			}
+			return nil, err
+		}
+		if rec == nil {
+			continue
+		}
+		attr := BlockAttribution{Hash: h}
+		if v, ok := rec.Bins[blockAttrPrevBin].(string); ok {
+			attr.PrevHash = v
+		}
+		if v, ok := rec.Bins[blockAttrPeerBin].(string); ok {
+			attr.PeerID = v
+		}
+		attr.Height = uint32(asInt(rec.Bins[blockAttrHeightBin])) //nolint:gosec
+		out = append(out, attr)
+	}
+	return out, nil
+}
+
+func (s *aerospikeBlockAttributionStore) DeleteHashes(hashes []string) error {
+	for _, h := range hashes {
+		key, err := as.NewKey(s.client.Namespace(), s.setName, h)
+		if err != nil {
+			continue
+		}
+		_, _ = s.client.Client().Delete(s.client.WritePolicy(s.maxRetries, s.retryBaseMs), key)
+		_ = s.removeFromIndex(h)
+	}
+	return nil
+}
+
+func (s *aerospikeBlockAttributionStore) addToIndex(hash string) error {
+	key, err := as.NewKey(s.client.Namespace(), s.setName, blockAttrIndexKey)
+	if err != nil {
+		return err
+	}
+	wp := s.client.WritePolicy(s.maxRetries, s.retryBaseMs)
+	wp.RecordExistsAction = as.UPDATE
+	listPolicy := as.NewListPolicy(as.ListOrderUnordered, as.ListWriteFlagsAddUnique|as.ListWriteFlagsNoFail)
+	_, err = s.client.Client().Operate(wp, key, as.ListAppendWithPolicyOp(listPolicy, blockAttrHashesBin, hash))
+	return err
+}
+
+func (s *aerospikeBlockAttributionStore) removeFromIndex(hash string) error {
+	key, err := as.NewKey(s.client.Namespace(), s.setName, blockAttrIndexKey)
+	if err != nil {
+		return err
+	}
+	wp := s.client.WritePolicy(s.maxRetries, s.retryBaseMs)
+	_, err = s.client.Client().Operate(wp, key, as.ListRemoveByValueOp(blockAttrHashesBin, hash, as.ListReturnTypeNone))
+	return err
+}
+
+func (s *aerospikeBlockAttributionStore) listIndex() ([]string, error) {
+	key, err := as.NewKey(s.client.Namespace(), s.setName, blockAttrIndexKey)
+	if err != nil {
+		return nil, err
+	}
+	rec, err := s.client.Client().Get(s.client.ReadPolicy(), key, blockAttrHashesBin)
+	if err != nil {
+		var asErr as.Error
+		if errors.As(err, &asErr) && asErr.Matches(astypes.KEY_NOT_FOUND_ERROR) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if rec == nil || rec.Bins[blockAttrHashesBin] == nil {
+		return nil, nil
+	}
+	raw, ok := rec.Bins[blockAttrHashesBin].([]interface{})
+	if !ok {
+		return nil, nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out, nil
+}
+
+func isKeyExistsError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var asErr as.Error
+	return errors.As(err, &asErr) && asErr.Matches(astypes.KEY_EXISTS_ERROR)
+}

--- a/internal/store/factory.go
+++ b/internal/store/factory.go
@@ -148,7 +148,7 @@ func newAerospikeRegistry(_ context.Context, cfg *config.Config, logger *slog.Lo
 			cfg.Aerospike.MaxRetries, cfg.Aerospike.RetryBaseMs, logger,
 		),
 		SeenCounter: NewSeenCounterStore(
-			asClient, cfg.Aerospike.SeenSet, cfg.Callback.SeenThreshold,
+			asClient, cfg.Aerospike.SeenSet, cfg.Callback.SeenScoreThreshold,
 			cfg.Aerospike.MaxRetries, cfg.Aerospike.RetryBaseMs, logger,
 		),
 		SubtreeCounter: NewSubtreeCounterStore(
@@ -157,6 +157,14 @@ func newAerospikeRegistry(_ context.Context, cfg *config.Config, logger *slog.Lo
 		),
 		ExpectedStump: NewExpectedStumpStore(
 			asClient, cfg.Aerospike.ExpectedStumpSet, cfg.Aerospike.SubtreeCounterTTLSec,
+			cfg.Aerospike.MaxRetries, cfg.Aerospike.RetryBaseMs, logger,
+		),
+		BlockAttribution: NewBlockAttributionStore(
+			asClient, cfg.Aerospike.BlockAttributionSet,
+			cfg.Aerospike.MaxRetries, cfg.Aerospike.RetryBaseMs, logger,
+		),
+		SubtreeAttribution: NewSubtreeAttributionStore(
+			asClient, cfg.Aerospike.SubtreeAttributionSet, cfg.Callback.DedupTTLSec,
 			cfg.Aerospike.MaxRetries, cfg.Aerospike.RetryBaseMs, logger,
 		),
 		Health: asClient,

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -94,19 +94,22 @@ type CallbackAccumulatorStore interface {
 	ReadAndDelete(blockHash string) (map[string]*AccumulatedCallback, error)
 }
 
-// SeenCounterStore tracks how many distinct subtrees have reported a txid.
-// Increment fires ThresholdReached exactly once — when the unique count first
-// reaches the configured threshold.
+// SeenCounterStore tracks weighted confidence that mining nodes have seen a
+// txid. Each peerID is recorded at most once per txid, contributing its
+// current node weight (blocks in the last-W tip window) to the score.
+// ThresholdReached fires exactly once when the score first reaches the
+// configured threshold (F-045).
 //
-// BatchIncrement applies Increment semantics to many txids of ONE subtree in
-// bulk (the subtree-fetcher hot path). It returns a result per txid that
-// succeeded plus the first error encountered; callers emit callbacks for the
-// returned results and surface the error for redelivery (F-058) — increments
-// are idempotent, so re-running the whole batch is safe. The exactly-once
-// ThresholdReached guarantee (F-045) is identical to Increment's.
+// BatchAddPeer is the subtree-fetcher hot path: one peer observation applied
+// to many registered txids. It returns a result per txid that succeeded plus
+// the first error (F-058 partial-success: emit callbacks for successes,
+// redeliver on error; operations are idempotent under re-runs).
+//
+// The former unique-subtree Increment/BatchIncrement API is replaced by this
+// peer-weighted model.
 type SeenCounterStore interface {
-	Increment(txid, subtreeID string) (*IncrementResult, error)
-	BatchIncrement(txids []string, subtreeID string) (map[string]*IncrementResult, error)
+	AddPeer(txid, peerID string, weight int) (*IncrementResult, error)
+	BatchAddPeer(txids []string, peerID string, weight int) (map[string]*IncrementResult, error)
 	// BatchDelete removes the counters for txids. Called at mine time: a
 	// counter tracks pre-mine propagation, so once its txid is in a block
 	// the record is dead weight — this is the event-driven cleanup that
@@ -114,6 +117,29 @@ type SeenCounterStore interface {
 	// (idempotent, safe on work-item redelivery).
 	BatchDelete(txids []string) error
 	Threshold() int
+}
+
+// SubtreeAttributionStore records the first peer to announce each subtree hash.
+type SubtreeAttributionStore interface {
+	// TryAttribute returns the stored peer for subtreeHash. first is true only
+	// when this call won the first-seen race and inserted peerID.
+	TryAttribute(subtreeHash, peerID string) (attributedPeer string, first bool, err error)
+}
+
+// BlockAttributionStore persists first-seen block→peer attributions for the
+// node registry (shared across k8s replicas).
+type BlockAttributionStore interface {
+	TryAttribute(hash, prevHash, peerID string, height uint32) (attributedPeer string, first bool, err error)
+	ListAll() ([]BlockAttribution, error)
+	DeleteHashes(hashes []string) error
+}
+
+// BlockAttribution is a persisted first-seen block announcement.
+type BlockAttribution struct {
+	Hash     string
+	PrevHash string
+	Height   uint32
+	PeerID   string
 }
 
 // BlockProcessedData is the canonical block-level data the producer attaches

--- a/internal/store/registry.go
+++ b/internal/store/registry.go
@@ -12,9 +12,11 @@ type Registry struct {
 	CallbackURLRegistry CallbackURLRegistry
 	DataHubRegistry     DataHubRegistry
 	CallbackAccumulator CallbackAccumulatorStore
-	SeenCounter         SeenCounterStore
-	SubtreeCounter      SubtreeCounterStore
-	ExpectedStump       ExpectedStumpStore
+	SeenCounter          SeenCounterStore
+	SubtreeCounter       SubtreeCounterStore
+	ExpectedStump        ExpectedStumpStore
+	BlockAttribution     BlockAttributionStore
+	SubtreeAttribution   SubtreeAttributionStore
 
 	// Blob is the raw blob store backing Stump and Subtree. Exposed so the
 	// block-processor — the single replica that already executes DAH prunes

--- a/internal/store/seen_counter.go
+++ b/internal/store/seen_counter.go
@@ -5,23 +5,26 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
-	"time"
 
 	as "github.com/aerospike/aerospike-client-go/v8"
 	astypes "github.com/aerospike/aerospike-client-go/v8/types"
 )
 
 const (
-	seenSubtreesBin    = "subtrees"
+	seenPeersBin       = "peers" // CDT map peerID → weight
 	seenThresholdFired = "tfired"
 
-	// seenCASMaxAttempts caps the generation-checked retry loop. Real-world
-	// contention is bounded by the number of concurrent subtree workers per
-	// txid; 32 is generous and keeps a runaway loop from holding a connection.
+	// seenCASMaxAttempts caps the generation-checked retry loop for the
+	// exactly-once threshold transition (F-045).
 	seenCASMaxAttempts = 32
 )
 
-// aerospikeSeenCounter is the Aerospike-backed SeenCounterStore implementation.
+// aerospikeSeenCounter is the Aerospike-backed peer-weighted SeenCounterStore.
+//
+// Hot path (BatchAddPeer): one BatchOperate per chunk that MapPut(create-only)
+// the peer and reads back the peers map + tfired. Score is summed client-side
+// from the tiny peer map (≈5 miners). Phase-2 generation-CAS only runs for
+// candidates that just crossed the score threshold (F-045).
 type aerospikeSeenCounter struct {
 	client      *AerospikeClient
 	setName     string
@@ -44,30 +47,23 @@ func NewSeenCounterStore(client *AerospikeClient, setName string, threshold, max
 	}
 }
 
-// Increment idempotently records that a txid was seen in a specific subtree
-// and atomically transitions the threshold-fired flag from false to true the
-// first time the unique-subtree count reaches the threshold. ThresholdReached
-// is true only on the single call that observes that 0->1 transition.
-//
-// The atomic transition is implemented as a generation-checked
-// read-modify-write: each attempt reads the record (capturing generation),
-// computes the next state locally, and issues an Operate with
-// GenerationPolicy=EXPECT_GEN_EQUAL so a concurrent writer that bumped the
-// generation in between forces a retry. F-045: previously the threshold check
-// and the marker write were two unrelated operations, so two concurrent
-// observations could both pass `alreadyFired == false` and emit duplicate
-// SEEN_MULTIPLE_NODES callbacks.
-func (s *aerospikeSeenCounter) Increment(txid, subtreeID string) (*IncrementResult, error) {
+func (s *aerospikeSeenCounter) Threshold() int { return s.threshold }
+
+// AddPeer records peerID with weight if not already present, with generation-CAS
+// for the exactly-once threshold transition.
+func (s *aerospikeSeenCounter) AddPeer(txid, peerID string, weight int) (*IncrementResult, error) {
+	if weight <= 0 || peerID == "" {
+		return &IncrementResult{NewCount: 0, ThresholdReached: false}, nil
+	}
+
 	key, err := as.NewKey(s.client.Namespace(), s.setName, txid)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create key: %w", err)
 	}
 
 	for attempt := 0; attempt < seenCASMaxAttempts; attempt++ {
-		// Step 1: read current state + generation. Treat KEY_NOT_FOUND as a
-		// brand-new record (generation 0, empty subtree list, fired=0).
 		readPolicy := s.client.ReadPolicy()
-		current, err := s.client.Client().Get(readPolicy, key, seenSubtreesBin, seenThresholdFired)
+		current, err := s.client.Client().Get(readPolicy, key, seenPeersBin, seenThresholdFired)
 		if err != nil {
 			var asErr as.Error
 			if errors.As(err, &asErr) && asErr.Matches(astypes.KEY_NOT_FOUND_ERROR) {
@@ -78,40 +74,26 @@ func (s *aerospikeSeenCounter) Increment(txid, subtreeID string) (*IncrementResu
 		}
 
 		var (
-			gen           uint32
-			priorFired    bool
-			currentMember bool
-			currentSize   int
+			gen        uint32
+			priorFired bool
+			peers      map[string]int
 		)
 		if current != nil {
 			gen = current.Generation
 			if firedVal, ok := current.Bins[seenThresholdFired].(int); ok && firedVal == 1 {
 				priorFired = true
 			}
-			if list, ok := current.Bins[seenSubtreesBin].([]interface{}); ok {
-				currentSize = len(list)
-				for _, v := range list {
-					if str, ok := v.(string); ok && str == subtreeID {
-						currentMember = true
-						break
-					}
-				}
-			}
+			peers = peersMapFromBin(current.Bins[seenPeersBin])
 		}
-
-		// Step 2: compute next state locally. AddUnique semantics: only count
-		// distinct subtreeIDs.
-		newSize := currentSize
-		if !currentMember {
-			newSize++
+		if peers == nil {
+			peers = make(map[string]int, 4)
 		}
-		shouldFire := !priorFired && newSize >= s.threshold
+		if _, ok := peers[peerID]; !ok {
+			peers[peerID] = weight
+		}
+		score := sumPeerWeights(peers)
+		shouldFire := !priorFired && score >= s.threshold
 
-		// Step 3: write next state with EXPECT_GEN_EQUAL. We always update the
-		// subtree list (idempotent ListAppend with AddUnique|NoFail handles
-		// re-runs) and only set tfired=1 when this attempt observed the
-		// 0->threshold transition. New records skip the generation check via
-		// CREATE_ONLY so two concurrent first-writers also resolve cleanly.
 		wp := s.client.WritePolicy(s.maxRetries, s.retryBaseMs)
 		if current == nil {
 			wp.RecordExistsAction = as.CREATE_ONLY
@@ -121,85 +103,39 @@ func (s *aerospikeSeenCounter) Increment(txid, subtreeID string) (*IncrementResu
 			wp.Generation = gen
 		}
 
-		listPolicy := as.NewListPolicy(as.ListOrderUnordered, as.ListWriteFlagsAddUnique|as.ListWriteFlagsNoFail)
-		ops := []*as.Operation{
-			as.ListAppendWithPolicyOp(listPolicy, seenSubtreesBin, subtreeID),
-		}
+		bins := as.BinMap{seenPeersBin: peersToASMap(peers)}
 		if shouldFire {
-			ops = append(ops, as.PutOp(as.NewBin(seenThresholdFired, 1)))
+			bins[seenThresholdFired] = 1
+		} else if priorFired {
+			bins[seenThresholdFired] = 1
 		}
 
-		_, err = s.client.Client().Operate(wp, key, ops...)
+		err = s.client.Client().Put(wp, key, bins)
 		if err != nil {
 			var asErr as.Error
-			if errors.As(err, &asErr) {
-				// Generation mismatch (concurrent writer beat us) or
-				// CREATE_ONLY collision (two concurrent first-writers): retry
-				// with the now-current state.
-				if asErr.Matches(astypes.GENERATION_ERROR) || asErr.Matches(astypes.KEY_EXISTS_ERROR) {
-					// Tiny backoff to avoid hot-spinning on pathological contention.
-					if s.retryBaseMs > 0 {
-						time.Sleep(time.Duration(s.retryBaseMs) * time.Millisecond)
-					}
-					continue
-				}
+			if errors.As(err, &asErr) &&
+				(asErr.Matches(astypes.GENERATION_ERROR) || asErr.Matches(astypes.KEY_EXISTS_ERROR)) {
+				continue // retry
 			}
 			return nil, fmt.Errorf("failed to write seen counter: %w", err)
 		}
-
-		return &IncrementResult{
-			NewCount:         newSize,
-			ThresholdReached: shouldFire,
-		}, nil
+		return &IncrementResult{NewCount: score, ThresholdReached: shouldFire}, nil
 	}
-
-	return nil, fmt.Errorf("seen counter CAS exhausted after %d attempts (txid=%s)", seenCASMaxAttempts, txid)
+	return nil, fmt.Errorf("seen counter CAS exhausted for %s after %d attempts", txid, seenCASMaxAttempts)
 }
 
-// Threshold returns the configured threshold.
-func (s *aerospikeSeenCounter) Threshold() int {
-	return s.threshold
-}
-
-// BatchIncrement records that every txid in txids was seen in subtreeID,
-// replacing the sequential 2-RTT-per-txid Increment loop that capped the SEEN
-// path at ~500-1000 txids/s per instance (throughput review F-4).
-//
-// txids are split into <=aerospikeBatchChunkSize chunks, and up to
-// batchChunkConcurrency chunks are processed concurrently. Each chunk
-// (batchIncrementChunk) is a SINGLE batch round-trip that both appends
-// subtreeID to every txid's unique-subtree list AND reads back the count and
-// threshold-fired flag (the list-append op returns the new size, so no separate
-// read-back is needed). Any txid that has just reached the threshold without the
-// fired flag set then goes through the generation-CAS Increment, preserving the
-// F-045 exactly-once guarantee: when several workers race, exactly one observes
-// ThresholdReached=true. That fire path is empty in steady state.
-//
-// Chunks cover disjoint txids, so each accumulates into its own local result map
-// (and its own CAS calls on distinct keys) merged under a mutex;
-// batchChunkConcurrency<=1 keeps the whole thing serial.
-//
-// Returns a result for every txid that succeeded plus the first error
-// encountered (F-058 partial-success contract: the caller emits callbacks for
-// returned results and surfaces the error so the subtree is redelivered; all
-// operations here are idempotent under re-runs).
-func (s *aerospikeSeenCounter) BatchIncrement(txids []string, subtreeID string) (map[string]*IncrementResult, error) {
+// BatchAddPeer applies peer/weight to many txids (subtree-fetcher hot path).
+func (s *aerospikeSeenCounter) BatchAddPeer(txids []string, peerID string, weight int) (map[string]*IncrementResult, error) {
 	results := make(map[string]*IncrementResult, len(txids))
-	if len(txids) == 0 {
+	if weight <= 0 || peerID == "" || len(txids) == 0 {
 		return results, nil
 	}
 
-	// Chunks carry disjoint txid sets, so each runs into its own local result map
-	// (and its own phase-2 generation-CAS calls on distinct keys) and is merged
-	// under a mutex. batchChunkConcurrency<=1 keeps this fully serial.
 	var mu sync.Mutex
 	err := forEachChunkConcurrent(txids, s.client.batchChunkConcurrency,
 		func(chunk []string) error {
 			local := make(map[string]*IncrementResult, len(chunk))
-			chunkErr := s.batchIncrementChunk(chunk, subtreeID, local)
-			// Merge partial results even on error: batchIncrementChunk follows the
-			// F-058 partial-success contract (populate what succeeded, surface the
-			// first error for redelivery).
+			chunkErr := s.batchAddPeerChunk(chunk, peerID, weight, local)
 			mu.Lock()
 			for k, v := range local {
 				results[k] = v
@@ -210,43 +146,27 @@ func (s *aerospikeSeenCounter) BatchIncrement(txids []string, subtreeID string) 
 	return results, err
 }
 
-// batchIncrementChunk processes one <=aerospikeBatchChunkSize chunk in a SINGLE
-// batch round-trip. Per txid it issues a BatchOperate that both (a) idempotently
-// appends subtreeID to the unique-subtree list and (b) reads the threshold-fired
-// flag. The list-append operation itself returns the resulting list size
-// ("Server returns list size on bin name"), so the post-count is known without a
-// second read-back BatchGet — halving the per-chunk RTTs versus the prior
-// append-then-BatchGet pair.
-//
-// Phase 2 (the exactly-once 0->threshold transition) is unchanged: any txid that
-// has just reached the threshold without the fired flag set is delegated to the
-// generation-CAS Increment, preserving the F-045 guarantee that exactly one
-// concurrent observer reports ThresholdReached=true.
-func (s *aerospikeSeenCounter) batchIncrementChunk(txids []string, subtreeID string, results map[string]*IncrementResult) error {
-	listPolicy := as.NewListPolicy(as.ListOrderUnordered, as.ListWriteFlagsAddUnique|as.ListWriteFlagsNoFail)
+func (s *aerospikeSeenCounter) batchAddPeerChunk(txids []string, peerID string, weight int, results map[string]*IncrementResult) error {
+	mapPolicy := as.NewMapPolicyWithFlags(as.MapOrder.UNORDERED, as.MapWriteFlagsCreateOnly|as.MapWriteFlagsNoFail)
 	batchRecs := make([]as.BatchRecordIfc, len(txids))
 	for i, txid := range txids {
 		key, err := as.NewKey(s.client.Namespace(), s.setName, txid)
 		if err != nil {
 			return fmt.Errorf("failed to create key for %s: %w", txid, err)
 		}
-		// Two ops in one record transaction: the append returns the new
-		// unique-subtree count on seenSubtreesBin; GetBinOp reads only the fired
-		// flag (a different bin, so its result never collides with the append's).
 		batchRecs[i] = as.NewBatchWrite(
 			nil, key,
-			as.ListAppendWithPolicyOp(listPolicy, seenSubtreesBin, subtreeID),
+			as.MapPutOp(mapPolicy, seenPeersBin, peerID, weight),
+			as.GetBinOp(seenPeersBin),
 			as.GetBinOp(seenThresholdFired),
 		)
 	}
 
 	bp := s.client.BatchPolicy(s.maxRetries, s.retryBaseMs)
 	if err := s.client.Client().BatchOperate(bp, batchRecs); err != nil {
-		return fmt.Errorf("batch append/read seen counters: %w", err)
+		return fmt.Errorf("batch add peer seen counters: %w", err)
 	}
 
-	// Per-key failures: skip those txids (no result entry) and surface the first
-	// error; the caller's redelivery re-runs the whole idempotent batch.
 	var firstErr error
 	for i, br := range batchRecs {
 		rec := br.BatchRec()
@@ -263,26 +183,18 @@ func (s *aerospikeSeenCounter) batchIncrementChunk(txids []string, subtreeID str
 			continue
 		}
 
-		// AddUnique|NoFail: a duplicate subtreeID leaves the count unchanged, so
-		// the returned size is the current unique-subtree count either way.
-		size := 0
-		if v, ok := rec.Record.Bins[seenSubtreesBin].(int); ok {
-			size = v
-		}
+		score := sumPeerWeights(peersMapFromBin(extractPeersBin(rec.Record.Bins[seenPeersBin])))
 		fired := false
 		if firedVal, ok := rec.Record.Bins[seenThresholdFired].(int); ok && firedVal == 1 {
 			fired = true
 		}
 
-		if size >= s.threshold && !fired {
-			// Phase 2: candidate for the exactly-once threshold transition.
-			// Delegate to the generation-CAS Increment (idempotent re-append +
-			// atomic 0->1 flip); if a concurrent worker fires first, this call
-			// returns ThresholdReached=false (F-045).
-			res, incErr := s.Increment(txids[i], subtreeID)
-			if incErr != nil {
+		if score >= s.threshold && !fired {
+			// Phase 2: generation-CAS fire (F-045).
+			res, err := s.AddPeer(txids[i], peerID, weight)
+			if err != nil {
 				if firstErr == nil {
-					firstErr = fmt.Errorf("firing threshold for %s: %w", txids[i], incErr)
+					firstErr = fmt.Errorf("firing threshold for %s: %w", txids[i], err)
 				}
 				continue
 			}
@@ -290,23 +202,16 @@ func (s *aerospikeSeenCounter) batchIncrementChunk(txids []string, subtreeID str
 			continue
 		}
 
-		results[txids[i]] = &IncrementResult{NewCount: size, ThresholdReached: false}
+		results[txids[i]] = &IncrementResult{NewCount: score, ThresholdReached: false}
 	}
-
 	return firstErr
 }
 
-// BatchDelete removes the counters for txids in chunked batch round-trips —
-// the mine-time cleanup: a counter tracks pre-mine propagation, so once its
-// txid is in a block the record is dead weight. Missing keys are not an
-// error (idempotent, safe on work-item redelivery); per-key failures surface
-// as the first error so the caller can log, while the rest of the batch
-// still deletes.
+// BatchDelete removes seen counters at mine time (unchanged contract).
 func (s *aerospikeSeenCounter) BatchDelete(txids []string) error {
 	if len(txids) == 0 {
 		return nil
 	}
-
 	return forEachChunkConcurrent(txids, s.client.batchChunkConcurrency,
 		func(chunk []string) error {
 			batchRecs := make([]as.BatchRecordIfc, 0, len(chunk))
@@ -317,12 +222,10 @@ func (s *aerospikeSeenCounter) BatchDelete(txids []string) error {
 				}
 				batchRecs = append(batchRecs, as.NewBatchDelete(nil, key))
 			}
-
 			bp := s.client.BatchPolicy(s.maxRetries, s.retryBaseMs)
 			if err := s.client.Client().BatchOperate(bp, batchRecs); err != nil {
 				return fmt.Errorf("batch delete seen counters: %w", err)
 			}
-
 			var firstErr error
 			for i, br := range batchRecs {
 				rec := br.BatchRec()
@@ -332,4 +235,71 @@ func (s *aerospikeSeenCounter) BatchDelete(txids []string) error {
 			}
 			return firstErr
 		})
+}
+
+func extractPeersBin(v interface{}) interface{} {
+	switch t := v.(type) {
+	case []interface{}:
+		for i := len(t) - 1; i >= 0; i-- {
+			switch t[i].(type) {
+			case map[interface{}]interface{}, map[string]interface{}:
+				return t[i]
+			}
+		}
+		return nil
+	default:
+		return v
+	}
+}
+
+func peersMapFromBin(v interface{}) map[string]int {
+	out := make(map[string]int)
+	switch m := v.(type) {
+	case map[interface{}]interface{}:
+		for k, val := range m {
+			ks, ok := k.(string)
+			if !ok {
+				continue
+			}
+			out[ks] = asInt(val)
+		}
+	case map[string]interface{}:
+		for k, val := range m {
+			out[k] = asInt(val)
+		}
+	case map[string]int:
+		for k, val := range m {
+			out[k] = val
+		}
+	}
+	return out
+}
+
+func peersToASMap(peers map[string]int) map[interface{}]interface{} {
+	m := make(map[interface{}]interface{}, len(peers))
+	for k, v := range peers {
+		m[k] = v
+	}
+	return m
+}
+
+func sumPeerWeights(peers map[string]int) int {
+	score := 0
+	for _, w := range peers {
+		score += w
+	}
+	return score
+}
+
+func asInt(v interface{}) int {
+	switch n := v.(type) {
+	case int:
+		return n
+	case int64:
+		return int(n)
+	case uint64:
+		return int(n)
+	default:
+		return 0
+	}
 }

--- a/internal/store/seen_counter_test.go
+++ b/internal/store/seen_counter_test.go
@@ -28,7 +28,7 @@ func TestSeenCounter_BasicIncrement(t *testing.T) {
 
 	txid := fmt.Sprintf("tx-basic-%d", os.Getpid())
 	for i := 1; i <= 5; i++ {
-		res, err := store.Increment(txid, fmt.Sprintf("subtree-%d", i))
+		res, err := store.AddPeer(txid, fmt.Sprintf("subtree-%d", i), 1)
 		if err != nil {
 			t.Fatalf("Increment %d: %v", i, err)
 		}
@@ -43,7 +43,7 @@ func TestSeenCounter_DuplicateSubtreeIsIdempotent(t *testing.T) {
 
 	txid := fmt.Sprintf("tx-dup-%d", os.Getpid())
 	for i := 0; i < 4; i++ {
-		res, err := store.Increment(txid, "subtree-A")
+		res, err := store.AddPeer(txid, "subtree-A", 1)
 		if err != nil {
 			t.Fatalf("Increment %d: %v", i, err)
 		}
@@ -62,7 +62,7 @@ func TestSeenCounter_ThresholdFiresExactlyOnce(t *testing.T) {
 	txid := fmt.Sprintf("tx-thresh-%d", os.Getpid())
 	fired := 0
 	for i := 0; i < 8; i++ {
-		res, err := store.Increment(txid, fmt.Sprintf("subtree-%d", i))
+		res, err := store.AddPeer(txid, fmt.Sprintf("subtree-%d", i), 1)
 		if err != nil {
 			t.Fatalf("Increment %d: %v", i, err)
 		}
@@ -100,7 +100,7 @@ func TestSeenCounter_ConcurrentThresholdFiresOnce(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			<-start
-			res, err := store.Increment(txid, fmt.Sprintf("subtree-%d", i))
+			res, err := store.AddPeer(txid, fmt.Sprintf("subtree-%d", i), 1)
 			if err != nil {
 				t.Errorf("Increment %d: %v", i, err)
 				return
@@ -139,7 +139,7 @@ func TestSeenCounter_ConcurrentDistinctTxidsAllFire(t *testing.T) {
 			go func(i, j int) {
 				defer wg.Done()
 				txid := fmt.Sprintf("tx-multi-%d-%d", pid, i)
-				res, err := store.Increment(txid, fmt.Sprintf("subtree-%d", j))
+				res, err := store.AddPeer(txid, fmt.Sprintf("subtree-%d", j), 1)
 				if err != nil {
 					t.Errorf("Increment(%s,%d): %v", txid, j, err)
 					return

--- a/internal/store/sql/block_attribution.go
+++ b/internal/store/sql/block_attribution.go
@@ -1,0 +1,84 @@
+package sql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	storepkg "github.com/bsv-blockchain/merkle-service/internal/store"
+)
+
+type blockAttributionStore struct {
+	db *sql.DB
+	d  *dialect
+}
+
+var _ storepkg.BlockAttributionStore = (*blockAttributionStore)(nil)
+
+func newBlockAttributionStore(db *sql.DB, d *dialect) *blockAttributionStore {
+	return &blockAttributionStore{db: db, d: d}
+}
+
+func (s *blockAttributionStore) TryAttribute(hash, prevHash, peerID string, height uint32) (string, bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	qIns := fmt.Sprintf( //nolint:gosec
+		"INSERT INTO block_attributions (block_hash, prev_hash, height, peer_id, created_at) VALUES (%s, %s, %s, %s, %s)%s",
+		s.d.placeholder(1), s.d.placeholder(2), s.d.placeholder(3), s.d.placeholder(4), s.d.now, s.d.onConflictDoNothing,
+	)
+	res, err := s.db.ExecContext(ctx, qIns, hash, prevHash, height, peerID)
+	if err != nil {
+		return "", false, fmt.Errorf("insert block attribution: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n > 0 {
+		return peerID, true, nil
+	}
+
+	qGet := fmt.Sprintf("SELECT peer_id FROM block_attributions WHERE block_hash = %s", s.d.placeholder(1)) //nolint:gosec
+	var stored string
+	if err := s.db.QueryRowContext(ctx, qGet, hash).Scan(&stored); err != nil {
+		return "", false, fmt.Errorf("read block attribution: %w", err)
+	}
+	return stored, false, nil
+}
+
+func (s *blockAttributionStore) ListAll() ([]storepkg.BlockAttribution, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	rows, err := s.db.QueryContext(ctx, `SELECT block_hash, prev_hash, height, peer_id FROM block_attributions`)
+	if err != nil {
+		return nil, fmt.Errorf("list block attributions: %w", err)
+	}
+	defer rows.Close()
+
+	var out []storepkg.BlockAttribution
+	for rows.Next() {
+		var a storepkg.BlockAttribution
+		var height int64
+		if err := rows.Scan(&a.Hash, &a.PrevHash, &height, &a.PeerID); err != nil {
+			return nil, err
+		}
+		a.Height = uint32(height) //nolint:gosec
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+func (s *blockAttributionStore) DeleteHashes(hashes []string) error {
+	if len(hashes) == 0 {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	for _, h := range hashes {
+		q := fmt.Sprintf("DELETE FROM block_attributions WHERE block_hash = %s", s.d.placeholder(1)) //nolint:gosec
+		if _, err := s.db.ExecContext(ctx, q, h); err != nil {
+			return fmt.Errorf("delete block attribution %s: %w", h, err)
+		}
+	}
+	return nil
+}

--- a/internal/store/sql/migrations/0009_peer_weighted_seen.sql
+++ b/internal/store/sql/migrations/0009_peer_weighted_seen.sql
@@ -1,0 +1,32 @@
+-- Peer-weighted SEEN_MULTIPLE_NODES scoring + first-seen block/subtree attributions.
+
+CREATE TABLE IF NOT EXISTS block_attributions (
+    block_hash  TEXT PRIMARY KEY,
+    prev_hash   TEXT NOT NULL DEFAULT '',
+    height      INTEGER NOT NULL,
+    peer_id     TEXT NOT NULL,
+    created_at  ${TIMESTAMPTZ} NOT NULL
+);
+
+CREATE INDEX ${IF_NOT_EXISTS_INDEX} idx_block_attributions_height ON block_attributions (height);
+
+CREATE TABLE IF NOT EXISTS subtree_attributions (
+    subtree_hash TEXT PRIMARY KEY,
+    peer_id      TEXT NOT NULL,
+    created_at   ${TIMESTAMPTZ} NOT NULL,
+    expires_at   ${TIMESTAMPTZ}
+);
+
+CREATE INDEX ${IF_NOT_EXISTS_INDEX} idx_subtree_attributions_expires_at ON subtree_attributions (expires_at);
+
+CREATE TABLE IF NOT EXISTS seen_counter_peers (
+    txid    TEXT NOT NULL,
+    peer_id TEXT NOT NULL,
+    weight  INTEGER NOT NULL,
+    PRIMARY KEY (txid, peer_id)
+);
+
+CREATE INDEX ${IF_NOT_EXISTS_INDEX} idx_seen_counter_peers_txid ON seen_counter_peers (txid);
+
+-- Incremental score for O(1) updates when a new peer is observed.
+ALTER TABLE seen_counters ADD COLUMN score INTEGER NOT NULL DEFAULT 0;

--- a/internal/store/sql/seen_counter.go
+++ b/internal/store/sql/seen_counter.go
@@ -23,19 +23,15 @@ func newSeenCounter(db *sql.DB, d *dialect, threshold int) *seenCounter {
 
 func (s *seenCounter) Threshold() int { return s.threshold }
 
-// BatchIncrement applies Increment to each txid in turn. The SQL backend
-// serves tests and small single-node deployments, so per-txid transactions
-// are acceptable here; the Aerospike backend is the one with the true batched
-// implementation (throughput review F-4). Same partial-success contract:
-// results for every txid that succeeded, plus the first error (F-058).
-func (s *seenCounter) BatchIncrement(txids []string, subtreeID string) (map[string]*storepkg.IncrementResult, error) {
+// BatchAddPeer applies AddPeer to each txid (SQL is tests/small deploys).
+func (s *seenCounter) BatchAddPeer(txids []string, peerID string, weight int) (map[string]*storepkg.IncrementResult, error) {
 	results := make(map[string]*storepkg.IncrementResult, len(txids))
 	var firstErr error
 	for _, txid := range txids {
-		res, err := s.Increment(txid, subtreeID)
+		res, err := s.AddPeer(txid, peerID, weight)
 		if err != nil {
 			if firstErr == nil {
-				firstErr = fmt.Errorf("batch increment %s: %w", txid, err)
+				firstErr = fmt.Errorf("batch add peer %s: %w", txid, err)
 			}
 			continue
 		}
@@ -44,19 +40,13 @@ func (s *seenCounter) BatchIncrement(txids []string, subtreeID string) (map[stri
 	return results, firstErr
 }
 
-// Increment inserts (txid, subtreeID) into seen_counter_subtrees (idempotent
-// via the compound PK), counts distinct subtrees for the txid, and atomically
-// transitions threshold_fired from 0 to 1 on the first call that reaches the
-// threshold. Exactly one caller observes ThresholdReached=true.
-//
-// F-045: previously the read-then-update of threshold_fired could race when
-// two concurrent callers both saw fired=0 with count >= threshold and each
-// independently set fired=1, both reporting ThresholdReached=true. The fix
-// flips the flag with a single conditional `UPDATE … RETURNING`-style
-// statement (or, on SQLite, an UPDATE that filters on the prior value and
-// then inspects RowsAffected) so the transition is observed by exactly one
-// caller.
-func (s *seenCounter) Increment(txid, subtreeID string) (*storepkg.IncrementResult, error) {
+// AddPeer records peerID once per txid with observation-time weight; fires
+// threshold via conditional UPDATE (F-045).
+func (s *seenCounter) AddPeer(txid, peerID string, weight int) (*storepkg.IncrementResult, error) {
+	if weight <= 0 || peerID == "" {
+		return &storepkg.IncrementResult{NewCount: 0, ThresholdReached: false}, nil
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -66,8 +56,7 @@ func (s *seenCounter) Increment(txid, subtreeID string) (*storepkg.IncrementResu
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// Ensure the parent counter row exists (no-op if already there).
-	qIns := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
+	qIns := fmt.Sprintf( //nolint:gosec // placeholders internal
 		"INSERT INTO seen_counters (txid) VALUES (%s)%s",
 		s.d.placeholder(1), s.d.onConflictDoNothing,
 	)
@@ -75,27 +64,32 @@ func (s *seenCounter) Increment(txid, subtreeID string) (*storepkg.IncrementResu
 		return nil, fmt.Errorf("insert seen_counters: %w", err)
 	}
 
-	// Idempotent append of subtreeID.
-	qSub := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
-		"INSERT INTO seen_counter_subtrees (txid, subtree_id) VALUES (%s, %s)%s",
-		s.d.placeholder(1), s.d.placeholder(2), s.d.onConflictDoNothing,
+	qPeer := fmt.Sprintf( //nolint:gosec
+		"INSERT INTO seen_counter_peers (txid, peer_id, weight) VALUES (%s, %s, %s)%s",
+		s.d.placeholder(1), s.d.placeholder(2), s.d.placeholder(3), s.d.onConflictDoNothing,
 	)
-	if _, err = tx.ExecContext(ctx, qSub, txid, subtreeID); err != nil {
-		return nil, fmt.Errorf("insert seen_counter_subtrees: %w", err)
+	res, err := tx.ExecContext(ctx, qPeer, txid, peerID, weight)
+	if err != nil {
+		return nil, fmt.Errorf("insert seen_counter_peers: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n > 0 {
+		qBump := fmt.Sprintf( //nolint:gosec
+			"UPDATE seen_counters SET score = score + %s WHERE txid = %s",
+			s.d.placeholder(1), s.d.placeholder(2),
+		)
+		if _, err = tx.ExecContext(ctx, qBump, weight, txid); err != nil {
+			return nil, fmt.Errorf("bump score: %w", err)
+		}
 	}
 
-	// Count distinct subtrees for this txid.
-	qCount := fmt.Sprintf("SELECT COUNT(*) FROM seen_counter_subtrees WHERE txid = %s", s.d.placeholder(1)) //nolint:gosec // placeholder from internal function
-	var count int
-	if err = tx.QueryRowContext(ctx, qCount, txid).Scan(&count); err != nil {
-		return nil, fmt.Errorf("count subtrees: %w", err)
+	qScore := fmt.Sprintf("SELECT score FROM seen_counters WHERE txid = %s", s.d.placeholder(1)) //nolint:gosec
+	var score int
+	if err = tx.QueryRowContext(ctx, qScore, txid).Scan(&score); err != nil {
+		return nil, fmt.Errorf("read score: %w", err)
 	}
 
-	// Atomically attempt the 0 -> 1 transition. The WHERE clause guarantees
-	// only one writer succeeds: any concurrent attempt sees threshold_fired
-	// already set to 1 and matches zero rows.
 	thresholdReached := false
-	if count >= s.threshold {
+	if score >= s.threshold {
 		thresholdReached, err = s.tryFireThreshold(ctx, tx, txid)
 		if err != nil {
 			return nil, err
@@ -105,20 +99,12 @@ func (s *seenCounter) Increment(txid, subtreeID string) (*storepkg.IncrementResu
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("commit seen counter tx: %w", err)
 	}
-	return &storepkg.IncrementResult{NewCount: count, ThresholdReached: thresholdReached}, nil
+	return &storepkg.IncrementResult{NewCount: score, ThresholdReached: thresholdReached}, nil
 }
 
-// tryFireThreshold flips threshold_fired from 0 to 1 atomically. Returns true
-// if THIS caller performed the transition; false if a concurrent caller had
-// already fired (the row's prior value was already 1). Errors are surfaced —
-// the previous implementation swallowed marker-write failures, masking real
-// faults like a row-level lock timeout.
 func (s *seenCounter) tryFireThreshold(ctx context.Context, tx *sql.Tx, txid string) (bool, error) {
 	if isPostgres(s.d) {
-		// Postgres: UPDATE … RETURNING. RETURNING emits a row only when the
-		// WHERE matches, so the presence of a result row IS the false->true
-		// transition signal.
-		q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
+		q := fmt.Sprintf( //nolint:gosec
 			`UPDATE seen_counters
             SET threshold_fired = 1
             WHERE txid = %s AND threshold_fired = 0
@@ -135,11 +121,7 @@ func (s *seenCounter) tryFireThreshold(ctx context.Context, tx *sql.Tx, txid str
 		return true, nil
 	}
 
-	// SQLite path. Modern SQLite (>= 3.35) supports RETURNING, but we keep
-	// portability with older builds by inspecting RowsAffected: the WHERE
-	// filter on threshold_fired = 0 makes the UPDATE itself the CAS, and
-	// RowsAffected > 0 means we won the race.
-	q := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
+	q := fmt.Sprintf( //nolint:gosec
 		`UPDATE seen_counters
         SET threshold_fired = 1
         WHERE txid = %s AND threshold_fired = 0`, s.d.placeholder(1),
@@ -155,11 +137,7 @@ func (s *seenCounter) tryFireThreshold(ctx context.Context, tx *sql.Tx, txid str
 	return n > 0, nil
 }
 
-// BatchDelete removes the counters (and their per-subtree child rows) for
-// txids — the mine-time cleanup: once a txid is in a block its propagation
-// counter is dead weight. Missing txids are silently skipped (idempotent, so
-// work-item redelivery is safe). Per-txid statements match this backend's
-// tests-and-small-deployments posture (see BatchIncrement).
+// BatchDelete removes peer-weighted counters at mine time.
 func (s *seenCounter) BatchDelete(txids []string) error {
 	if len(txids) == 0 {
 		return nil
@@ -167,25 +145,21 @@ func (s *seenCounter) BatchDelete(txids []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	qChildren := fmt.Sprintf("DELETE FROM seen_counter_subtrees WHERE txid = %s", s.d.placeholder(1))
+	qChildren := fmt.Sprintf("DELETE FROM seen_counter_peers WHERE txid = %s", s.d.placeholder(1))
+	// Also clean legacy subtree table if present (pre-migration rows).
+	qLegacy := fmt.Sprintf("DELETE FROM seen_counter_subtrees WHERE txid = %s", s.d.placeholder(1))
 	qParent := fmt.Sprintf("DELETE FROM seen_counters WHERE txid = %s", s.d.placeholder(1))
 
-	// Children + parent go in ONE transaction per txid (no FK cascade in the
-	// schema): unpaired deletes could interleave with a concurrent Increment
-	// and leave orphan child rows that a recreated parent later counts as
-	// phantom subtrees. Per-txid transactions (not one big one) preserve the
-	// best-effort contract — a failure on one txid doesn't roll back the rest.
 	var firstErr error
 	for _, txid := range txids {
-		if err := s.deleteOne(ctx, qChildren, qParent, txid); err != nil && firstErr == nil {
+		if err := s.deleteOne(ctx, qChildren, qLegacy, qParent, txid); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
 	return firstErr
 }
 
-// deleteOne atomically removes one txid's child rows and parent counter row.
-func (s *seenCounter) deleteOne(ctx context.Context, qChildren, qParent, txid string) error {
+func (s *seenCounter) deleteOne(ctx context.Context, qChildren, qLegacy, qParent, txid string) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin delete seen counter tx for %s: %w", txid, err)
@@ -193,8 +167,10 @@ func (s *seenCounter) deleteOne(ctx context.Context, qChildren, qParent, txid st
 	defer func() { _ = tx.Rollback() }()
 
 	if _, err := tx.ExecContext(ctx, qChildren, txid); err != nil {
-		return fmt.Errorf("delete seen counter subtrees for %s: %w", txid, err)
+		return fmt.Errorf("delete seen counter peers for %s: %w", txid, err)
 	}
+	// Best-effort legacy cleanup (table may not exist on fresh installs after 0009).
+	_, _ = tx.ExecContext(ctx, qLegacy, txid)
 	if _, err := tx.ExecContext(ctx, qParent, txid); err != nil {
 		return fmt.Errorf("delete seen counter for %s: %w", txid, err)
 	}

--- a/internal/store/sql/sql.go
+++ b/internal/store/sql/sql.go
@@ -85,9 +85,11 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger) (*storepk
 		CallbackURLRegistry: newCallbackURLRegistry(db, d, urlRetention),
 		DataHubRegistry:     newDataHubRegistry(db, d, urlRetention),
 		CallbackAccumulator: newCallbackAccumulator(db, d, cfg.Aerospike.CallbackAccumulatorTTLSec),
-		SeenCounter:         newSeenCounter(db, d, cfg.Callback.SeenThreshold),
+		SeenCounter:         newSeenCounter(db, d, cfg.Callback.SeenScoreThreshold),
 		SubtreeCounter:      newSubtreeCounter(db, d, cfg.Aerospike.SubtreeCounterTTLSec),
 		ExpectedStump:       newExpectedStump(db, d, cfg.Aerospike.SubtreeCounterTTLSec),
+		BlockAttribution:    newBlockAttributionStore(db, d),
+		SubtreeAttribution:  newSubtreeAttributionStore(db, d, cfg.Callback.DedupTTLSec),
 		Blob:                blob,
 		Health:              &pingHealth{db: db},
 	}

--- a/internal/store/sql/sql_test.go
+++ b/internal/store/sql/sql_test.go
@@ -536,7 +536,7 @@ func TestSeenCounter_ThresholdFiresOnce(t *testing.T) {
 	var firedCount int
 	// Increment with 5 distinct subtreeIDs.
 	for i := 0; i < 5; i++ {
-		res, err := s.Increment("tx", fmt.Sprintf("st%d", i))
+		res, err := s.AddPeer("tx", fmt.Sprintf("st%d", i), 1)
 		if err != nil {
 			t.Fatalf("Increment %d: %v", i, err)
 		}
@@ -549,7 +549,7 @@ func TestSeenCounter_ThresholdFiresOnce(t *testing.T) {
 	}
 
 	// Duplicate subtreeID shouldn't bump count further.
-	res, err := s.Increment("tx", "st0")
+	res, err := s.AddPeer("tx", "st0", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -598,7 +598,7 @@ func TestSeenCounter_ConcurrentThresholdFiresOnce(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			<-start
-			res, err := s.Increment("tx-race", fmt.Sprintf("st%d", i))
+			res, err := s.AddPeer("tx-race", fmt.Sprintf("st%d", i), 1)
 			if err != nil {
 				t.Errorf("Increment %d: %v", i, err)
 				return
@@ -1000,7 +1000,7 @@ func TestSeenCounter_BatchIncrement(t *testing.T) {
 	txids := []string{"tx-a", "tx-b", "tx-c"}
 
 	// First subtree: every txid at count 1, none fired.
-	results, err := s.BatchIncrement(txids, "st1")
+	results, err := s.BatchAddPeer(txids, "st1", 1)
 	if err != nil {
 		t.Fatalf("BatchIncrement st1: %v", err)
 	}
@@ -1014,7 +1014,7 @@ func TestSeenCounter_BatchIncrement(t *testing.T) {
 	}
 
 	// Second distinct subtree: every txid crosses threshold=2 exactly once.
-	results, err = s.BatchIncrement(txids, "st2")
+	results, err = s.BatchAddPeer(txids, "st2", 1)
 	if err != nil {
 		t.Fatalf("BatchIncrement st2: %v", err)
 	}
@@ -1025,7 +1025,7 @@ func TestSeenCounter_BatchIncrement(t *testing.T) {
 	}
 
 	// Idempotent re-run of the same batch: counts unchanged, no re-fire.
-	results, err = s.BatchIncrement(txids, "st2")
+	results, err = s.BatchAddPeer(txids, "st2", 1)
 	if err != nil {
 		t.Fatalf("BatchIncrement st2 rerun: %v", err)
 	}
@@ -1047,7 +1047,7 @@ func TestSeenCounter_BatchDelete(t *testing.T) {
 
 	for _, txid := range []string{"tx-a", "tx-b", "tx-keep"} {
 		for i := 0; i < 2; i++ {
-			if _, err := s.Increment(txid, fmt.Sprintf("st%d", i)); err != nil {
+			if _, err := s.AddPeer(txid, fmt.Sprintf("st%d", i), 1); err != nil {
 				t.Fatalf("Increment(%s): %v", txid, err)
 			}
 		}
@@ -1058,7 +1058,7 @@ func TestSeenCounter_BatchDelete(t *testing.T) {
 	}
 
 	// Deleted txids restart from a clean slate.
-	res, err := s.Increment("tx-a", "st-new")
+	res, err := s.AddPeer("tx-a", "st-new", 1)
 	if err != nil {
 		t.Fatalf("Increment after delete: %v", err)
 	}
@@ -1067,7 +1067,7 @@ func TestSeenCounter_BatchDelete(t *testing.T) {
 	}
 
 	// Untouched txid keeps its history.
-	res, err = s.Increment("tx-keep", "st2")
+	res, err = s.AddPeer("tx-keep", "st2", 1)
 	if err != nil {
 		t.Fatalf("Increment(tx-keep): %v", err)
 	}

--- a/internal/store/sql/subtree_attribution.go
+++ b/internal/store/sql/subtree_attribution.go
@@ -1,0 +1,50 @@
+package sql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	storepkg "github.com/bsv-blockchain/merkle-service/internal/store"
+)
+
+type subtreeAttributionStore struct {
+	db     *sql.DB
+	d      *dialect
+	ttlSec int
+}
+
+var _ storepkg.SubtreeAttributionStore = (*subtreeAttributionStore)(nil)
+
+func newSubtreeAttributionStore(db *sql.DB, d *dialect, ttlSec int) *subtreeAttributionStore {
+	if ttlSec <= 0 {
+		ttlSec = 86400
+	}
+	return &subtreeAttributionStore{db: db, d: d, ttlSec: ttlSec}
+}
+
+func (s *subtreeAttributionStore) TryAttribute(subtreeHash, peerID string) (string, bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	qIns := fmt.Sprintf( //nolint:gosec
+		"INSERT INTO subtree_attributions (subtree_hash, peer_id, created_at, expires_at) VALUES (%s, %s, %s, %s)%s",
+		s.d.placeholder(1), s.d.placeholder(2), s.d.now, s.d.intervalSeconds(s.ttlSec), s.d.onConflictDoNothing,
+	)
+	res, err := s.db.ExecContext(ctx, qIns, subtreeHash, peerID)
+	if err != nil {
+		return "", false, fmt.Errorf("insert subtree attribution: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n > 0 {
+		return peerID, true, nil
+	}
+
+	qGet := fmt.Sprintf("SELECT peer_id FROM subtree_attributions WHERE subtree_hash = %s", s.d.placeholder(1)) //nolint:gosec
+	var stored string
+	if err := s.db.QueryRowContext(ctx, qGet, subtreeHash).Scan(&stored); err != nil {
+		return "", false, fmt.Errorf("read subtree attribution: %w", err)
+	}
+	return stored, false, nil
+}

--- a/internal/store/sql/sweeper.go
+++ b/internal/store/sql/sweeper.go
@@ -45,6 +45,7 @@ var ttlTables = []ttlTable{
 	{parent: "callback_dedup"},
 	{parent: "subtree_counters"},
 	{parent: "expected_stumps"},
+	{parent: "subtree_attributions"},
 	{
 		parent:    "callback_accumulator",
 		parentKey: "block_hash",

--- a/internal/store/subtree_attribution.go
+++ b/internal/store/subtree_attribution.go
@@ -1,0 +1,54 @@
+package store
+
+import (
+	"fmt"
+	"log/slog"
+
+	as "github.com/aerospike/aerospike-client-go/v8"
+)
+
+const subtreeAttrPeerBin = "peer"
+
+type aerospikeSubtreeAttributionStore struct {
+	client      *AerospikeClient
+	setName     string
+	ttlSec      int
+	logger      *slog.Logger
+	maxRetries  int
+	retryBaseMs int
+}
+
+var _ SubtreeAttributionStore = (*aerospikeSubtreeAttributionStore)(nil)
+
+func NewSubtreeAttributionStore(client *AerospikeClient, setName string, ttlSec, maxRetries, retryBaseMs int, logger *slog.Logger) SubtreeAttributionStore {
+	if ttlSec <= 0 {
+		ttlSec = 86400
+	}
+	return &aerospikeSubtreeAttributionStore{
+		client: client, setName: setName, ttlSec: ttlSec, logger: logger,
+		maxRetries: maxRetries, retryBaseMs: retryBaseMs,
+	}
+}
+
+func (s *aerospikeSubtreeAttributionStore) TryAttribute(subtreeHash, peerID string) (string, bool, error) {
+	key, err := as.NewKey(s.client.Namespace(), s.setName, subtreeHash)
+	if err != nil {
+		return "", false, err
+	}
+	wp := s.client.WritePolicy(s.maxRetries, s.retryBaseMs)
+	wp.RecordExistsAction = as.CREATE_ONLY
+	wp.Expiration = uint32(s.ttlSec) //nolint:gosec
+	err = s.client.Client().Put(wp, key, as.BinMap{subtreeAttrPeerBin: peerID})
+	if err == nil {
+		return peerID, true, nil
+	}
+	if !isKeyExistsError(err) {
+		return "", false, fmt.Errorf("create subtree attribution: %w", err)
+	}
+	rec, err := s.client.Client().Get(s.client.ReadPolicy(), key, subtreeAttrPeerBin)
+	if err != nil {
+		return "", false, fmt.Errorf("read subtree attribution: %w", err)
+	}
+	stored, _ := rec.Bins[subtreeAttrPeerBin].(string)
+	return stored, false, nil
+}

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -1,9 +1,10 @@
 package store
 
-// IncrementResult is returned by SeenCounterStore.Increment.
+// IncrementResult is returned by SeenCounterStore.AddPeer / BatchAddPeer.
+// NewCount is the weighted seen score after the call (sum of peer weights).
 type IncrementResult struct {
 	NewCount         int
-	ThresholdReached bool // true only when count first equals threshold (not above)
+	ThresholdReached bool // true only when score first reaches threshold (not above)
 }
 
 // AccumulatedCallbackEntry holds data for one subtree's contribution to a

--- a/internal/subtree/processor.go
+++ b/internal/subtree/processor.go
@@ -32,12 +32,23 @@ type RegistrationGetter interface {
 	Get(txid string) ([]store.CallbackEntry, error)
 }
 
-// SeenCounter abstracts seen-count tracking for testability. BatchIncrement
-// carries the store.SeenCounterStore partial-success contract: results for
-// every txid that succeeded plus the first error (F-058).
+// SeenCounter abstracts peer-weighted seen scoring for testability.
+// BatchAddPeer carries the store.SeenCounterStore partial-success contract:
+// results for every txid that succeeded plus the first error (F-058).
 type SeenCounter interface {
-	Increment(txid, subtreeID string) (*store.IncrementResult, error)
-	BatchIncrement(txids []string, subtreeID string) (map[string]*store.IncrementResult, error)
+	AddPeer(txid, peerID string, weight int) (*store.IncrementResult, error)
+	BatchAddPeer(txids []string, peerID string, weight int) (map[string]*store.IncrementResult, error)
+}
+
+// NodeWeights provides mining-node weights for SEEN_MULTIPLE_NODES scoring.
+type NodeWeights interface {
+	Ready() bool
+	Weight(peerID string) int
+}
+
+// SubtreeAttributor records first-seen peer per subtree hash.
+type SubtreeAttributor interface {
+	TryAttribute(subtreeHash, peerID string) (attributedPeer string, first bool, err error)
 }
 
 // RegCache abstracts the registration deduplication cache for testability.
@@ -60,12 +71,14 @@ type Processor struct {
 	callbackProducer  *kafka.Producer
 	retryProducer     *kafka.Producer // re-publishes to the subtree topic on transient failure
 	dlqProducer       *kafka.Producer // publishes to subtree-dlq when MaxAttempts is exceeded
-	registrationStore RegistrationGetter
-	seenCounterStore  SeenCounter
-	subtreeStore      store.SubtreeStore
-	regCache          RegCache
-	dedupCache        *cache.DedupCache
-	dataHubClient     *datahub.Client
+	registrationStore  RegistrationGetter
+	seenCounterStore   SeenCounter
+	subtreeStore       store.SubtreeStore
+	nodeRegistry       NodeWeights
+	subtreeAttribution SubtreeAttributor
+	regCache           RegCache
+	dedupCache         *cache.DedupCache
+	dataHubClient      *datahub.Client
 }
 
 // NewProcessor creates a new subtree Processor. logger, when non-nil,
@@ -77,13 +90,17 @@ func NewProcessor(
 	registrationStore RegistrationGetter,
 	seenCounterStore SeenCounter,
 	subtreeStore store.SubtreeStore,
+	nodeRegistry NodeWeights,
+	subtreeAttribution SubtreeAttributor,
 	logger *slog.Logger,
 ) *Processor {
 	p := &Processor{
-		cfg:               cfg,
-		registrationStore: registrationStore,
-		seenCounterStore:  seenCounterStore,
-		subtreeStore:      subtreeStore,
+		cfg:                cfg,
+		registrationStore:  registrationStore,
+		seenCounterStore:   seenCounterStore,
+		subtreeStore:       subtreeStore,
+		nodeRegistry:       nodeRegistry,
+		subtreeAttribution: subtreeAttribution,
 	}
 	p.InitBase("subtree-fetcher")
 	if logger != nil {
@@ -324,15 +341,40 @@ func (p *Processor) handleMessage(ctx context.Context, msg *kafka.Message) error
 		"processing subtree announcement",
 		logfields.SubtreeHash(subtreeMsg.Hash),
 		logfields.DataHubURL(subtreeMsg.DataHubURL),
+		"peerId", subtreeMsg.PeerID,
 		"attemptCount", subtreeMsg.AttemptCount,
 	)
 
-	// Check dedup cache — skip if already successfully processed.
+	// Local dedup FIRST — O(1) memory, no shared-store RTT (high-TPS path).
 	if p.dedupCache != nil && p.dedupCache.Contains(subtreeMsg.Hash) {
 		p.Logger.Debug("skipping duplicate subtree message", logfields.SubtreeHash(subtreeMsg.Hash))
 		metrics.ObserveSubtreeProcessing(metrics.OutcomeDedupHit, time.Since(start))
 		return nil
 	}
+
+	// First-seen peer attribution (shared store). Losers skip heavy work.
+	attributedPeer := subtreeMsg.PeerID
+	if p.subtreeAttribution != nil && subtreeMsg.Hash != "" && subtreeMsg.PeerID != "" {
+		peer, first, attrErr := p.subtreeAttribution.TryAttribute(subtreeMsg.Hash, subtreeMsg.PeerID)
+		if attrErr != nil {
+			p.Logger.Warn("subtree attribution failed; continuing with message peer",
+				logfields.SubtreeHash(subtreeMsg.Hash), "error", attrErr)
+		} else {
+			attributedPeer = peer
+			if !first {
+				p.Logger.Debug("skipping subtree hash owned by first-seen peer",
+					logfields.SubtreeHash(subtreeMsg.Hash), "peerId", peer)
+				if p.dedupCache != nil {
+					p.dedupCache.Add(subtreeMsg.Hash)
+				}
+				metrics.ObserveSubtreeProcessing(metrics.OutcomeDedupHit, time.Since(start))
+				return nil
+			}
+		}
+	}
+	// Stash for emitBatchedSeenCallbacks via message field reuse — re-set PeerID
+	// so downstream scoring uses the attributed peer.
+	subtreeMsg.PeerID = attributedPeer
 
 	// Peer-health gate: if the announcing peer has been failing recently,
 	// skip the fetch and ack-and-drop. SEEN_ON_NETWORK detection is
@@ -426,7 +468,7 @@ func (p *Processor) handleMessage(ctx context.Context, msg *kafka.Message) error
 	// either retried or terminally DLQ'd. Otherwise downstream callback
 	// consumers permanently lose SEEN notifications during a Kafka
 	// callback-topic outage (F-057).
-	if err := p.emitBatchedSeenCallbacks(ctx, registeredTxids, subtreeMsg.Hash); err != nil {
+	if err := p.emitBatchedSeenCallbacks(ctx, registeredTxids, subtreeMsg.Hash, subtreeMsg.PeerID); err != nil {
 		return p.handleTransientFailure(ctx, subtreeMsg, "publishing batched SEEN callbacks", err, start)
 	}
 
@@ -762,7 +804,7 @@ func (p *Processor) findRegisteredTxids(txids []string) (map[string][]store.Call
 // callbacks for the affected txids. Returning the error keeps the dedup
 // cache untouched (handleMessage gates that add on success) and routes the
 // work through handleTransientFailure for redelivery.
-func (p *Processor) emitBatchedSeenCallbacks(ctx context.Context, registeredTxids map[string][]store.CallbackEntry, subtreeID string) error {
+func (p *Processor) emitBatchedSeenCallbacks(ctx context.Context, registeredTxids map[string][]store.CallbackEntry, subtreeID, peerID string) error {
 	if len(registeredTxids) == 0 {
 		return nil
 	}
@@ -796,46 +838,39 @@ func (p *Processor) emitBatchedSeenCallbacks(ctx context.Context, registeredTxid
 		firstErr = err
 	}
 
-	// 4.6: Increment seen counters and collect threshold-reached txids.
-	//
-	// A failure here MUST surface as an error (F-058). Pre-fix this path
-	// logged a warning and continued, while handleMessage still added the
-	// subtree hash to the dedup cache — permanently dropping
-	// SEEN_MULTIPLE_NODES callbacks for the affected txids on redelivery.
-	// BatchIncrement has the same partial-success contract the old per-txid
-	// loop had: results for every txid that succeeded plus the first error;
-	// surface the error so handleMessage re-drives via handleTransientFailure
-	// (which leaves the dedup cache untouched) while threshold callbacks for
-	// the successes still go out on this attempt.
-	//
-	// Batched (throughput review F-4): the previous per-txid Increment loop
-	// cost 2 serial Aerospike RTTs per registered txid (~500-1000 txids/s per
-	// instance); BatchIncrement is 2 batch RTTs per 5000 txids, with the
-	// exactly-once threshold CAS (F-045) run only for the rare crossers.
+	// 4.6: Peer-weighted SEEN_MULTIPLE_NODES scoring.
+	// Warm-up: do not score until the node registry has a full tip window.
+	// Unknown peers (weight 0) do not contribute.
 	thresholdGroups := make(map[string][]string) // callbackURL → threshold-reached txids
-	if len(registeredTxids) > 0 {
-		txids := make([]string, 0, len(registeredTxids))
-		for txid := range registeredTxids {
-			txids = append(txids, txid)
-		}
-		metrics.ObserveDBBatchSize(metrics.StoreSeenCounter, metrics.OpIncrement, len(txids))
-		incStart := time.Now()
-		results, incErr := p.seenCounterStore.BatchIncrement(txids, subtreeID)
-		metrics.ObserveDB(p.backendLabel(), metrics.StoreSeenCounter, metrics.OpIncrement, incStart, incErr)
-		if incErr != nil {
-			p.Logger.Error("failed to batch-increment seen counters",
-				logfields.SubtreeHash(subtreeID), logfields.TxIDCount(len(txids)), "succeeded", len(results), "error", incErr)
-			if firstErr == nil {
-				firstErr = fmt.Errorf("incrementing seen counters for subtree %s: %w", subtreeID, incErr)
+	if p.nodeRegistry != nil && p.nodeRegistry.Ready() {
+		weight := p.nodeRegistry.Weight(peerID)
+		if weight > 0 && len(registeredTxids) > 0 {
+			txids := make([]string, 0, len(registeredTxids))
+			for txid := range registeredTxids {
+				txids = append(txids, txid)
 			}
-		}
-		for txid, result := range results {
-			if result.ThresholdReached {
-				for _, e := range registeredTxids[txid] {
-					thresholdGroups[e.URL] = append(thresholdGroups[e.URL], txid)
+			metrics.ObserveDBBatchSize(metrics.StoreSeenCounter, metrics.OpIncrement, len(txids))
+			incStart := time.Now()
+			results, incErr := p.seenCounterStore.BatchAddPeer(txids, peerID, weight)
+			metrics.ObserveDB(p.backendLabel(), metrics.StoreSeenCounter, metrics.OpIncrement, incStart, incErr)
+			if incErr != nil {
+				p.Logger.Error("failed to batch-add peer to seen counters",
+					logfields.SubtreeHash(subtreeID), "peerId", peerID, logfields.TxIDCount(len(txids)), "succeeded", len(results), "error", incErr)
+				if firstErr == nil {
+					firstErr = fmt.Errorf("adding peer to seen counters for subtree %s: %w", subtreeID, incErr)
+				}
+			}
+			for txid, result := range results {
+				if result.ThresholdReached {
+					for _, e := range registeredTxids[txid] {
+						thresholdGroups[e.URL] = append(thresholdGroups[e.URL], txid)
+					}
 				}
 			}
 		}
+	} else {
+		p.Logger.Debug("skipping SEEN_MULTIPLE_NODES scoring: node registry not ready or peer unknown",
+			"peerId", peerID)
 	}
 
 	// Emit one batched SEEN_MULTIPLE_NODES per callbackURL, chunked to fit

--- a/internal/subtree/processor_test.go
+++ b/internal/subtree/processor_test.go
@@ -98,26 +98,40 @@ func (m *mockRegStore) Get(txid string) ([]store.CallbackEntry, error) {
 
 type mockSeenCounter struct{}
 
-func (m *mockSeenCounter) Increment(txid, subtreeID string) (*store.IncrementResult, error) {
-	return &store.IncrementResult{NewCount: 1, ThresholdReached: false}, nil
+func (m *mockSeenCounter) AddPeer(txid, peerID string, weight int) (*store.IncrementResult, error) {
+	return &store.IncrementResult{NewCount: weight, ThresholdReached: false}, nil
 }
 
-func (m *mockSeenCounter) BatchIncrement(txids []string, subtreeID string) (map[string]*store.IncrementResult, error) {
-	return batchViaIncrement(m.Increment, txids, subtreeID)
+func (m *mockSeenCounter) BatchAddPeer(txids []string, peerID string, weight int) (map[string]*store.IncrementResult, error) {
+	return batchViaAddPeer(m.AddPeer, txids, peerID, weight)
 }
 
-// batchViaIncrement implements the BatchIncrement partial-success contract on
-// top of a mock's Increment so each fake's behavior (failure injection,
-// idempotency tracking) carries over to the batched path unchanged.
-func batchViaIncrement(
-	inc func(txid, subtreeID string) (*store.IncrementResult, error),
+// mockReadyNodes always reports ready with fixed weight so multi-node scoring runs in tests.
+type mockReadyNodes struct{ weight int }
+
+func (m *mockReadyNodes) Ready() bool { return true }
+func (m *mockReadyNodes) Weight(peerID string) int {
+	if peerID == "" {
+		return 0
+	}
+	if m.weight > 0 {
+		return m.weight
+	}
+	return 1
+}
+
+// batchViaAddPeer implements the BatchAddPeer partial-success contract on
+// top of a mock's AddPeer so each fake's behavior carries over to the batched path.
+func batchViaAddPeer(
+	inc func(txid, peerID string, weight int) (*store.IncrementResult, error),
 	txids []string,
-	subtreeID string,
+	peerID string,
+	weight int,
 ) (map[string]*store.IncrementResult, error) {
 	results := make(map[string]*store.IncrementResult, len(txids))
 	var firstErr error
 	for _, txid := range txids {
-		res, err := inc(txid, subtreeID)
+		res, err := inc(txid, peerID, weight)
 		if err != nil {
 			if firstErr == nil {
 				firstErr = err
@@ -684,7 +698,13 @@ func newMockIdempotentSeenCounter(threshold int) *mockIdempotentSeenCounter {
 	}
 }
 
-func (m *mockIdempotentSeenCounter) Increment(txid, subtreeID string) (*store.IncrementResult, error) {
+func (m *mockIdempotentSeenCounter) AddPeer(txid, peerID string, weight int) (*store.IncrementResult, error) {
+	_ = weight
+	subtreeID := peerID
+	return m.incrementLegacy(txid, subtreeID)
+}
+
+func (m *mockIdempotentSeenCounter) incrementLegacy(txid, subtreeID string) (*store.IncrementResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -708,14 +728,14 @@ func (m *mockIdempotentSeenCounter) Increment(txid, subtreeID string) (*store.In
 	}, nil
 }
 
-func (m *mockIdempotentSeenCounter) BatchIncrement(txids []string, subtreeID string) (map[string]*store.IncrementResult, error) {
-	return batchViaIncrement(m.Increment, txids, subtreeID)
+func (m *mockIdempotentSeenCounter) BatchAddPeer(txids []string, peerID string, weight int) (map[string]*store.IncrementResult, error) {
+	return batchViaAddPeer(m.AddPeer, txids, peerID, weight)
 }
 
 func TestIdempotentSeenCounter_FirstSubtreeIncrements(t *testing.T) {
 	sc := newMockIdempotentSeenCounter(3)
 
-	result, err := sc.Increment("txid-1", "subtree-A")
+	result, err := sc.AddPeer("txid-1", "subtree-A", 1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -731,10 +751,10 @@ func TestIdempotentSeenCounter_DuplicateSubtreeDoesNotIncrement(t *testing.T) {
 	sc := newMockIdempotentSeenCounter(3)
 
 	// First call with subtree-A.
-	_, _ = sc.Increment("txid-1", "subtree-A")
+	_, _ = sc.AddPeer("txid-1", "subtree-A", 1)
 
 	// Duplicate call with same subtree-A.
-	result, _ := sc.Increment("txid-1", "subtree-A")
+	result, _ := sc.AddPeer("txid-1", "subtree-A", 1)
 	if result.NewCount != 1 {
 		t.Errorf("expected count=1 after duplicate, got %d", result.NewCount)
 	}
@@ -746,11 +766,11 @@ func TestIdempotentSeenCounter_DuplicateSubtreeDoesNotIncrement(t *testing.T) {
 func TestIdempotentSeenCounter_ThresholdFiresOnce(t *testing.T) {
 	sc := newMockIdempotentSeenCounter(3)
 
-	_, _ = sc.Increment("txid-1", "subtree-A")
-	_, _ = sc.Increment("txid-1", "subtree-B")
+	_, _ = sc.AddPeer("txid-1", "subtree-A", 1)
+	_, _ = sc.AddPeer("txid-1", "subtree-B", 1)
 
 	// Third unique subtree should trigger threshold.
-	result, _ := sc.Increment("txid-1", "subtree-C")
+	result, _ := sc.AddPeer("txid-1", "subtree-C", 1)
 	if result.NewCount != 3 {
 		t.Errorf("expected count=3, got %d", result.NewCount)
 	}
@@ -759,7 +779,7 @@ func TestIdempotentSeenCounter_ThresholdFiresOnce(t *testing.T) {
 	}
 
 	// Fourth unique subtree — threshold should NOT fire again.
-	result, _ = sc.Increment("txid-1", "subtree-D")
+	result, _ = sc.AddPeer("txid-1", "subtree-D", 1)
 	if result.NewCount != 4 {
 		t.Errorf("expected count=4, got %d", result.NewCount)
 	}
@@ -771,10 +791,10 @@ func TestIdempotentSeenCounter_ThresholdFiresOnce(t *testing.T) {
 func TestIdempotentSeenCounter_ThresholdDoesNotFireOnDuplicates(t *testing.T) {
 	sc := newMockIdempotentSeenCounter(2)
 
-	_, _ = sc.Increment("txid-1", "subtree-A")
+	_, _ = sc.AddPeer("txid-1", "subtree-A", 1)
 
 	// Duplicate of subtree-A — count stays 1, no threshold.
-	result, _ := sc.Increment("txid-1", "subtree-A")
+	result, _ := sc.AddPeer("txid-1", "subtree-A", 1)
 	if result.NewCount != 1 {
 		t.Errorf("expected count=1, got %d", result.NewCount)
 	}
@@ -783,7 +803,7 @@ func TestIdempotentSeenCounter_ThresholdDoesNotFireOnDuplicates(t *testing.T) {
 	}
 
 	// Now a truly new subtree triggers threshold.
-	result, _ = sc.Increment("txid-1", "subtree-B")
+	result, _ = sc.AddPeer("txid-1", "subtree-B", 1)
 	if result.NewCount != 2 {
 		t.Errorf("expected count=2, got %d", result.NewCount)
 	}
@@ -792,7 +812,7 @@ func TestIdempotentSeenCounter_ThresholdDoesNotFireOnDuplicates(t *testing.T) {
 	}
 
 	// Re-send subtree-A — should NOT fire threshold.
-	result, _ = sc.Increment("txid-1", "subtree-A")
+	result, _ = sc.AddPeer("txid-1", "subtree-A", 1)
 	if result.ThresholdReached {
 		t.Error("threshold should not fire again on re-sent subtree")
 	}
@@ -801,12 +821,12 @@ func TestIdempotentSeenCounter_ThresholdDoesNotFireOnDuplicates(t *testing.T) {
 func TestIdempotentSeenCounter_IndependentPerTxid(t *testing.T) {
 	sc := newMockIdempotentSeenCounter(2)
 
-	_, _ = sc.Increment("txid-1", "subtree-A")
-	_, _ = sc.Increment("txid-2", "subtree-A")
+	_, _ = sc.AddPeer("txid-1", "subtree-A", 1)
+	_, _ = sc.AddPeer("txid-2", "subtree-A", 1)
 
 	// Same subtreeID for different txids should be independent.
-	result1, _ := sc.Increment("txid-1", "subtree-B")
-	result2, _ := sc.Increment("txid-2", "subtree-B")
+	result1, _ := sc.AddPeer("txid-1", "subtree-B", 1)
+	result2, _ := sc.AddPeer("txid-2", "subtree-B", 1)
 
 	if !result1.ThresholdReached {
 		t.Error("txid-1 threshold should fire")
@@ -880,7 +900,7 @@ func TestIntegration_SeenCounterIdempotency(t *testing.T) {
 	var thresholdCount int
 
 	for _, st := range subtrees {
-		result, err := sc.Increment("txid-1", st)
+		result, err := sc.AddPeer("txid-1", st, 1)
 		if err != nil {
 			t.Fatalf("Increment error: %v", err)
 		}
@@ -895,7 +915,7 @@ func TestIntegration_SeenCounterIdempotency(t *testing.T) {
 
 	// Now replay all subtrees (duplicates).
 	for _, st := range subtrees {
-		result, _ := sc.Increment("txid-1", st)
+		result, _ := sc.AddPeer("txid-1", st, 1)
 		if result.ThresholdReached {
 			t.Errorf("threshold should not fire on duplicate subtree %s", st)
 		}
@@ -1027,6 +1047,7 @@ func newTestProcessor(t *testing.T, regStore RegistrationGetter, seenCounter See
 	p := &Processor{
 		registrationStore: regStore,
 		seenCounterStore:  seenCounter,
+		nodeRegistry:      &mockReadyNodes{weight: 51},
 		callbackProducer:  kafka.NewTestProducer(mockProducer, "callback-test", logger),
 	}
 	p.InitBase("subtree-test")
@@ -1046,7 +1067,7 @@ func TestBatchedSeenCallbacks_SingleCallbackURL(t *testing.T) {
 		"tx3":   {"http://arcade.example.com/cb"},
 	}
 
-	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-A"); err != nil {
+	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-A", "peer-A"); err != nil {
 		t.Fatalf("emitBatchedSeenCallbacks: %v", err)
 	}
 
@@ -1086,7 +1107,7 @@ func TestBatchedSeenCallbacks_MultipleCallbackURLs(t *testing.T) {
 		"tx3":   {"http://url-A/cb"},
 	}
 
-	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-A"); err != nil {
+	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-A", "peer-A"); err != nil {
 		t.Fatalf("emitBatchedSeenCallbacks: %v", err)
 	}
 
@@ -1125,7 +1146,7 @@ func TestBatchedSeenCallbacks_PropagatesCallbackToken(t *testing.T) {
 		testTx1: {url},
 		testTx2: {url},
 	}
-	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, map[string]string{url: token}), "subtree-A"); err != nil {
+	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, map[string]string{url: token}), "subtree-A", "peer-A"); err != nil {
 		t.Fatalf("emitBatchedSeenCallbacks: %v", err)
 	}
 
@@ -1144,7 +1165,7 @@ func TestBatchedSeenCallbacks_NoRegistered(t *testing.T) {
 	regStore := &mockRegStore{registrations: map[string][]string{}}
 	p, mockProd := newTestProcessor(t, regStore, &mockSeenCounter{})
 
-	if err := p.emitBatchedSeenCallbacks(context.Background(), map[string][]store.CallbackEntry{}, "subtree-A"); err != nil {
+	if err := p.emitBatchedSeenCallbacks(context.Background(), map[string][]store.CallbackEntry{}, "subtree-A", "peer-A"); err != nil {
 		t.Fatalf("emitBatchedSeenCallbacks: %v", err)
 	}
 
@@ -1165,7 +1186,7 @@ func TestBatchedSeenCallbacks_SeenMultipleNodesThreshold(t *testing.T) {
 		testTx2: {"http://arcade/cb"},
 	}
 
-	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-A"); err != nil {
+	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-A", "peer-A"); err != nil {
 		t.Fatalf("emitBatchedSeenCallbacks: %v", err)
 	}
 
@@ -1196,7 +1217,7 @@ func TestBatchedSeenCallbacks_SeenMultipleNodesThreshold(t *testing.T) {
 func TestBatchedSeenCallbacks_PartialThreshold(t *testing.T) {
 	// Threshold=2: tx1 has already been seen once (will reach threshold), tx2 hasn't.
 	sc := newMockIdempotentSeenCounter(2)
-	_, _ = sc.Increment(testTx1, "subtree-PREV") // pre-seen once
+	_, _ = sc.AddPeer(testTx1, "subtree-PREV", 1) // pre-seen once
 
 	regStore := &mockRegStore{registrations: map[string][]string{}}
 	p, mockProd := newTestProcessor(t, regStore, sc)
@@ -1206,7 +1227,7 @@ func TestBatchedSeenCallbacks_PartialThreshold(t *testing.T) {
 		testTx2: {"http://arcade/cb"},
 	}
 
-	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-A"); err != nil {
+	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-A", "peer-A"); err != nil {
 		t.Fatalf("emitBatchedSeenCallbacks: %v", err)
 	}
 
@@ -1239,7 +1260,7 @@ func TestBatchedSeenCallbacks_ChunksLargeBatch(t *testing.T) {
 		registered[fmt.Sprintf("tx%05d", i)] = []string{"http://arcade/cb"}
 	}
 
-	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-A"); err != nil {
+	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-A", "peer-A"); err != nil {
 		t.Fatalf("emitBatchedSeenCallbacks: %v", err)
 	}
 
@@ -1288,6 +1309,7 @@ func newTestProcessorWithCfg(t *testing.T, regStore RegistrationGetter, seenCoun
 		cfg:               cfg,
 		registrationStore: regStore,
 		seenCounterStore:  seenCounter,
+		nodeRegistry:      &mockReadyNodes{weight: 51},
 		callbackProducer:  kafka.NewTestProducer(mockProducer, "callback-test", logger),
 	}
 	p.InitBase("subtree-test")
@@ -1333,7 +1355,7 @@ func TestEmitSeenBatch_LogsTxidsCappedAtConfig(t *testing.T) {
 		"tx4": {testSeenBatchCallbackURL},
 		"tx5": {testSeenBatchCallbackURL},
 	}
-	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-cap"); err != nil {
+	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-cap", "peer-A"); err != nil {
 		t.Fatalf("emitBatchedSeenCallbacks: %v", err)
 	}
 
@@ -1379,7 +1401,7 @@ func TestEmitSeenBatch_LogsAllTxidsWhenUnderCap(t *testing.T) {
 		"tx1": {testSeenBatchCallbackURL},
 		"tx2": {testSeenBatchCallbackURL},
 	}
-	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-under-cap"); err != nil {
+	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-under-cap", "peer-A"); err != nil {
 		t.Fatalf("emitBatchedSeenCallbacks: %v", err)
 	}
 
@@ -1416,7 +1438,7 @@ func TestEmitSeenBatch_CountsOnlyWhenLogMaxZero(t *testing.T) {
 		"tx2": {testSeenBatchCallbackURL},
 		"tx3": {testSeenBatchCallbackURL},
 	}
-	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-counts-only"); err != nil {
+	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-counts-only", "peer-A"); err != nil {
 		t.Fatalf("emitBatchedSeenCallbacks: %v", err)
 	}
 
@@ -1450,7 +1472,7 @@ func TestEmitSeenBatch_NilCfgLogsCountsOnly(t *testing.T) {
 	registered := map[string][]string{
 		"tx1": {testSeenBatchCallbackURL},
 	}
-	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-nil-cfg"); err != nil {
+	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-nil-cfg", "peer-A"); err != nil {
 		t.Fatalf("emitBatchedSeenCallbacks: %v", err)
 	}
 
@@ -1479,7 +1501,7 @@ func TestEmitSeenBatch_LogsAllTxidsAtExactCap(t *testing.T) {
 		"tx2": {testSeenBatchCallbackURL},
 		"tx3": {testSeenBatchCallbackURL},
 	}
-	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-exact-cap"); err != nil {
+	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-exact-cap", "peer-A"); err != nil {
 		t.Fatalf("emitBatchedSeenCallbacks: %v", err)
 	}
 
@@ -1521,7 +1543,7 @@ func TestEmitSeenBatch_NoSuccessLogOnPublishFailure(t *testing.T) {
 		"tx1": {testSeenBatchCallbackURL},
 		"tx2": {testSeenBatchCallbackURL},
 	}
-	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-pubfail"); err == nil {
+	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-pubfail", "peer-A"); err == nil {
 		t.Fatal("expected an error from emitBatchedSeenCallbacks with a failing producer")
 	}
 
@@ -1720,7 +1742,7 @@ func TestEmitBatchedSeenCallbacks_HappyPathReturnsNil(t *testing.T) {
 		testTx2: {"http://url-B/cb"},
 	}
 
-	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-happy"); err != nil {
+	if err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-happy", "peer-A"); err != nil {
 		t.Fatalf("expected nil error on happy path, got: %v", err)
 	}
 	if got := len(mockProd.getMessages()); got != 2 {
@@ -1747,7 +1769,7 @@ func TestEmitBatchedSeenCallbacks_PublishFailureReturnsError(t *testing.T) {
 		testTx2: {"http://url-B/cb"},
 	}
 
-	err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-fail")
+	err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-fail", "peer-A")
 	if err == nil {
 		t.Fatalf("expected non-nil error when callback publish fails")
 	}
@@ -1782,7 +1804,7 @@ func TestEmitBatchedSeenCallbacks_PartialFailureStillAttemptsOtherURLs(t *testin
 		testTx2: {okURL},
 	}
 
-	err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-partial")
+	err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-partial", "peer-A")
 	if err == nil {
 		t.Fatalf("expected non-nil error when one callback URL publish fails")
 	}
@@ -2038,7 +2060,7 @@ type failingSeenCounter struct {
 	attempts []string // txids passed to Increment, in call order
 }
 
-func (f *failingSeenCounter) Increment(txid, subtreeID string) (*store.IncrementResult, error) {
+func (f *failingSeenCounter) AddPeer(txid, peerID string, weight int) (*store.IncrementResult, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.attempts = append(f.attempts, txid)
@@ -2046,8 +2068,8 @@ func (f *failingSeenCounter) Increment(txid, subtreeID string) (*store.Increment
 	return nil, f.err
 }
 
-func (f *failingSeenCounter) BatchIncrement(txids []string, subtreeID string) (map[string]*store.IncrementResult, error) {
-	return batchViaIncrement(f.Increment, txids, subtreeID)
+func (f *failingSeenCounter) BatchAddPeer(txids []string, peerID string, weight int) (map[string]*store.IncrementResult, error) {
+	return batchViaAddPeer(f.AddPeer, txids, peerID, weight)
 }
 
 // TestEmitBatchedSeenCallbacks_IncrementFailureReturnsError verifies that a
@@ -2065,12 +2087,12 @@ func TestEmitBatchedSeenCallbacks_IncrementFailureReturnsError(t *testing.T) {
 		testTx2: {"http://url-B/cb"},
 	}
 
-	err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-counter-fail")
+	err := p.emitBatchedSeenCallbacks(context.Background(), toEntries(registered, nil), "subtree-counter-fail", "peer-A")
 	if err == nil {
 		t.Fatalf("expected non-nil error when seen-counter Increment fails")
 	}
-	if !strings.Contains(err.Error(), "incrementing seen counter") {
-		t.Errorf("expected error to wrap increment context, got: %v", err)
+	if !strings.Contains(err.Error(), "seen counter") {
+		t.Errorf("expected error to wrap seen counter context, got: %v", err)
 	}
 
 	// Both txids should have been attempted (best-effort iteration past
@@ -2128,13 +2150,14 @@ func TestHandleMessage_SeenCounterIncrementFailure_RoutesToRetryAndSkipsDedup(t 
 				StorageMode: "stream", // skip blob store
 			},
 		},
-		registrationStore: regStore,
-		seenCounterStore:  sc,
-		callbackProducer:  kafka.NewTestProducer(cbMock, "callback-test", logger),
-		retryProducer:     kafka.NewTestProducer(retryMock, "subtree-test", logger),
-		dlqProducer:       kafka.NewTestProducer(dlqMock, "subtree-dlq-test", logger),
-		dataHubClient:     datahub.NewClient(5, 0, logger),
-		dedupCache:        dedup,
+		registrationStore:  regStore,
+		seenCounterStore:   sc,
+		nodeRegistry:       &mockReadyNodes{weight: 51},
+		callbackProducer:   kafka.NewTestProducer(cbMock, "callback-test", logger),
+		retryProducer:      kafka.NewTestProducer(retryMock, "subtree-test", logger),
+		dlqProducer:        kafka.NewTestProducer(dlqMock, "subtree-dlq-test", logger),
+		dataHubClient:      datahub.NewClient(5, 0, logger),
+		dedupCache:         dedup,
 	}
 	p.InitBase("subtree-counter-fail-test")
 	p.Logger = logger
@@ -2142,6 +2165,7 @@ func TestHandleMessage_SeenCounterIncrementFailure_RoutesToRetryAndSkipsDedup(t 
 	subtreeMsg := &kafka.SubtreeMessage{
 		Hash:         "subtree-counter-fail",
 		DataHubURL:   dataHubServer.URL,
+		PeerID:       "peer-A",
 		AttemptCount: 0,
 	}
 	value, err := subtreeMsg.Encode()


### PR DESCRIPTION
## Summary

- Replace unique-subtree `seenThreshold` counting with **peer-weighted confidence**: a node is a peer that first-announced at least one of the last 100 tip-path blocks; `SEEN_MULTIPLE_NODES` fires when the sum of those peers' block counts for a txid reaches **51** (out of 100).
- Attribute **blocks and subtrees** to the **first peer** to announce each hash (shared store for k8s); discard later duplicates for attribution/scoring.
- Lightweight reorg handling (**approach C**): parse `BlockMessage.Header` → `prevHash`, walk tip path, drop orphans from the window — no chaintracks dependency.
- Hot-path oriented for multi-million-tx scale: local dedup before shared-store attribution, lock-free weight snapshots, `BatchAddPeer` (Aerospike batch + generation-CAS fire / SQL incremental score). Preserves F-045 exactly-once threshold and F-058 partial-success redelivery.

## Motivation

`SEEN_MULTIPLE_NODES` currently means “appeared in N distinct subtree hashes,” which can include non-mining relays. We want confidence that **mining nodes** (recent block producers) have seen the tx, weighted by recent hashrate (blocks in last 100).

## Design

| Concern | Approach |
|---|---|
| Who mined a block? | First `PeerID` on `BlockMessage` for that hash (heuristic; not PoW-proven) |
| Who owns a subtree? | First `PeerID` on `SubtreeMessage` for that hash |
| Node set | Peers with ≥1 block on last **W=100** tip-path attributions |
| Score | Sum of window block-counts of unique peers that saw the txid |
| Fire | Score ≥ **T=51**, once per txid (F-045 CAS) |
| Warm-up | No multi-node scoring until tip path has ≥ W blocks |
| Reorgs | Tip = max height; walk `prevHash` from header; off-path blocks leave window |
| k8s | Shared Aerospike/SQL for attributions + seen scores |
| Scale | Local dedup first; batch seen updates; O(1) `Weight`/`Ready` |

### Config

| Key | Default | Notes |
|---|---|---|
| `callback.seenWindowBlocks` | 100 | W |
| `callback.seenScoreThreshold` | 51 | Fire threshold |
| `callback.seenThreshold` | 3 | **Deprecated**, ignored |

Env: `CALLBACK_SEEN_WINDOW_BLOCKS`, `CALLBACK_SEEN_SCORE_THRESHOLD`.

### Out of scope / known caveats

- First announcer ≈ miner is a network heuristic (matches Teranode’s “provider peer” practice).
- Max-height tip is not full chainwork selection; fine for short reorgs.
- Cold start needs ~W live tip-path blocks (persisted attributions survive restarts).
- Subtree-fetcher refreshes node weights from the shared store on a short interval.

## Changes

- **`internal/nodes`**: tip chain, first-seen registry, lock-free weight view, background refresh for fetcher replicas
- **Stores**: `BlockAttributionStore`, `SubtreeAttributionStore`; peer-weighted `SeenCounterStore` with `BatchAddPeer` (replaces unique-subtree `Increment`/`BatchIncrement`; keeps `BatchDelete`)
- **SQL migration**: `0009_peer_weighted_seen`
- **block-processor**: record first-seen block peer from announcements
- **subtree-fetcher**: first-seen subtree peer + batched weighted scoring; skip unknown peers / warm-up
- Config + k8s configmap + tests

## Test plan

- [x] `go test ./internal/nodes/ ./internal/store/ ./internal/store/sql/ ./internal/subtree/ ./internal/block/ ./internal/config/`
- [x] `go build ./...`
- [ ] Review warm-up: no `SEEN_MULTIPLE_NODES` until 100 tip-path blocks attributed
- [ ] Review reorg: competing fork with higher tip drops orphans from weights
- [ ] Load sanity: many registered txids in one subtree → batch path, not N store RTTs
- [ ] Multi-replica: first-seen block/subtree peer consistent via shared store

## Notes for maintainer

Draft for design feedback. Built on latest `bsv-blockchain/merkle-service` `main` (not the stale galt-tr fork). Happy to adjust thresholds, warm-up policy, or thin the first cut.