### PR TITLE
fix(reprocess): bypass callback dedup so reprocess re-delivers BLOCK_PROCESSED

### DIFF
--- a/internal/block/subtree_worker.go
+++ b/internal/block/subtree_worker.go
@@ -723,6 +723,12 @@ func (s *SubtreeWorkerService) publishSubtreeCallbacks(ctx context.Context, work
 			SubtreeHash:   workMsg.SubtreeHash,
 			SubtreeIndex:  workMsg.SubtreeIndex,
 			StumpRef:      stumpRef,
+			// A /reprocess (OverrideCallbackURL != "") is an explicit
+			// re-emit request whose callbacks must bypass the delivery-side
+			// dedup set, or a re-run after a reorg would be silently
+			// suppressed and never reach the requesting arcade (#208). Live
+			// announcements leave this false so normal dedup is unchanged.
+			BypassDedup: workMsg.OverrideCallbackURL != "",
 		}
 		data, encErr := msg.Encode()
 		if encErr != nil {
@@ -845,6 +851,12 @@ func emitBlockProcessedCallbacks(
 			CallbackToken: entry.Token,
 			Type:          kafka.CallbackBlockProcessed,
 			BlockHash:     blockHash,
+			// A /reprocess (overrideURL != "") must force re-delivery past
+			// the delivery-side dedup set — otherwise the BLOCK_PROCESSED
+			// from a post-reorg re-run is dropped as a duplicate of the
+			// original and arcade never rebuilds the block's BUMP (#208).
+			// Live fan-out (overrideURL == "") leaves this false.
+			BypassDedup: overrideURL != "",
 		}
 		// Attach the block-level enrichment (merkle root, subtree list, coinbase
 		// BUMP) when the producer captured it. Absent for blocks processed

--- a/internal/callback/delivery.go
+++ b/internal/callback/delivery.go
@@ -413,7 +413,28 @@ func (d *DeliveryService) processDelivery(ctx context.Context, cbMsg *kafka.Call
 	)
 
 	// Check callback dedup — skip if already delivered.
-	if d.dedupStore != nil {
+	//
+	// A reprocess-originated callback (BypassDedup) is an explicit "re-emit
+	// this block's results" request, so it MUST force re-delivery past the
+	// dedup set: deduping it against the original delivery silently defeats
+	// arcade's reorg recovery (#208). We bypass only the existence *check*
+	// here — the key is still recorded on success below — so normal
+	// (non-reprocess) duplicates for the same block continue to be
+	// suppressed afterward. Reprocess is operator/arcade-driven and
+	// rate-limited at the /reprocess handler, and a forced delivery does not
+	// itself trigger another reprocess, so this cannot self-perpetuate into
+	// a callback storm.
+	if d.dedupStore != nil && cbMsg.BypassDedup {
+		d.Logger.Info(
+			"forcing callback re-delivery (reprocess): bypassing dedup",
+			"dedupKey", dedupKeyForMessage(cbMsg),
+			logfields.CallbackURL(cbMsg.CallbackURL),
+			"type", cbMsg.Type,
+			logfields.BlockHash(cbMsg.BlockHash),
+			logfields.SubtreeIndex(cbMsg.SubtreeIndex),
+		)
+	}
+	if d.dedupStore != nil && !cbMsg.BypassDedup {
 		dedupKey := dedupKeyForMessage(cbMsg)
 		if dedupKey != "" {
 			checkStart := time.Now()

--- a/internal/callback/delivery_test.go
+++ b/internal/callback/delivery_test.go
@@ -784,6 +784,69 @@ func TestProcessDelivery_DedupSkipLogsInfo(t *testing.T) {
 	}
 }
 
+// TestProcessDelivery_BypassDedupForcesReDelivery pins issue #208: a
+// /reprocess-originated callback (BypassDedup=true) must be delivered even
+// when the dedup set already holds its key — otherwise a post-reorg re-run
+// is silently suppressed and arcade never rebuilds the block's BUMP. A normal
+// duplicate (BypassDedup=false) with the same key present must still be
+// skipped. The forced delivery must also re-record the key so subsequent
+// normal duplicates stay suppressed.
+func TestProcessDelivery_BypassDedupForcesReDelivery(t *testing.T) {
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := defaultTestConfig()
+
+	// Baseline: a normal duplicate (dedup key present) is still skipped — no
+	// HTTP request, no new record.
+	dsNormal, _, _ := newTestDeliveryService(t, cfg, server.Client())
+	normalStore := &mockDedupStore{exists: true}
+	dsNormal.dedupStore = normalStore
+	normalMsg := &kafka.CallbackTopicMessage{
+		CallbackURL: server.URL + "/callback",
+		Type:        kafka.CallbackBlockProcessed,
+		BlockHash:   testBlockHash,
+	}
+	if err := dsNormal.processDelivery(context.Background(), normalMsg); err != nil {
+		t.Fatalf("processDelivery (normal) returned error: %v", err)
+	}
+	if got := requestCount.Load(); got != 0 {
+		t.Fatalf("normal duplicate: expected 0 HTTP requests (skipped), got %d", got)
+	}
+	if normalStore.recordCalls != 0 {
+		t.Errorf("normal duplicate: expected 0 Record calls, got %d", normalStore.recordCalls)
+	}
+
+	// Reprocess: same key present, but BypassDedup=true forces delivery and
+	// still records the key on success.
+	dsForce, _, _ := newTestDeliveryService(t, cfg, server.Client())
+	forceStore := &mockDedupStore{exists: true}
+	dsForce.dedupStore = forceStore
+	forceMsg := &kafka.CallbackTopicMessage{
+		CallbackURL: server.URL + "/callback",
+		Type:        kafka.CallbackBlockProcessed,
+		BlockHash:   testBlockHash,
+		BypassDedup: true,
+	}
+	before := callbackCount(metrics.OutcomeDelivered)
+	if err := dsForce.processDelivery(context.Background(), forceMsg); err != nil {
+		t.Fatalf("processDelivery (bypass) returned error: %v", err)
+	}
+	if got := requestCount.Load(); got != 1 {
+		t.Fatalf("reprocess: expected 1 HTTP request (forced delivery), got %d", got)
+	}
+	if delta := callbackCount(metrics.OutcomeDelivered) - before; delta != 1 {
+		t.Errorf("reprocess: expected delivered counter delta=1, got %d", delta)
+	}
+	if forceStore.recordCalls != 1 {
+		t.Errorf("reprocess: expected the forced delivery to re-record the dedup key (1 Record call), got %d", forceStore.recordCalls)
+	}
+}
+
 func TestBuildIdempotencyKey(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -1006,6 +1069,9 @@ func TestDeliverCallback_BlockProcessedPayload(t *testing.T) {
 // mockDedupStore implements CallbackDeduper for testing.
 type mockDedupStore struct {
 	exists bool
+	// recordCalls counts Record invocations so a test can assert that a
+	// forced (BypassDedup) delivery still records its dedup key on success.
+	recordCalls int
 }
 
 func (m *mockDedupStore) Exists(txid, callbackURL, statusType string) (bool, error) {
@@ -1013,5 +1079,6 @@ func (m *mockDedupStore) Exists(txid, callbackURL, statusType string) (bool, err
 }
 
 func (m *mockDedupStore) Record(txid, callbackURL, statusType string, ttl time.Duration) error {
+	m.recordCalls++
 	return nil
 }

--- a/internal/kafka/messages.go
+++ b/internal/kafka/messages.go
@@ -101,6 +101,23 @@ type CallbackTopicMessage struct {
 	RetryCount   int       `json:"retryCount,omitempty"`
 	NextRetryAt  time.Time `json:"nextRetryAt,omitempty"`
 
+	// BypassDedup marks a callback that must be delivered even if the
+	// delivery-side dedup set already holds its key — set only on
+	// /reprocess-originated STUMP and BLOCK_PROCESSED callbacks (see
+	// bsv-blockchain/merkle-service#208). A /reprocess is an explicit
+	// "re-emit this block's results" request, so deduping its callbacks
+	// against the original delivery silently defeats the caller's reorg
+	// recovery. When true the delivery service skips the dedup existence
+	// check but STILL records the key on success, so normal (non-reprocess)
+	// duplicates for the same block continue to be suppressed afterward.
+	//
+	// Additive + omitempty: older consumers ignore it, and live-announcement
+	// callbacks leave it false so their dedup behavior is unchanged. It is
+	// derived producer-side from OverrideCallbackURL != "" (the established
+	// "this is a reprocess" signal) and is not part of the arcade
+	// CallbackMessage contract.
+	BypassDedup bool `json:"bypassDedup,omitempty"`
+
 	// BLOCK_PROCESSED enrichment (merkle-service issues #123/#124/#125 + the
 	// coinbase path). These let a consumer build and validate a compound BUMP
 	// without fetching the block from a teranode datahub. All additive and


### PR DESCRIPTION
Fixes #208

## Problem

When arcade calls `POST /reprocess` to rebuild a block's proof (its reorg-recovery path), merkle-service re-runs the block correctly, but the resulting `BLOCK_PROCESSED` (+ `STUMP`) callbacks were **suppressed as duplicates** by the delivery-side callback dedup (`callbackDedupSet`, `dedupTTLSec = 86400`; log line `skipping duplicate callback delivery`, `dedupKey = <block_hash>`).

A reprocess therefore never re-delivered its result. arcade's reorg reconciler, unable to rebuild the block's compound BUMP ("BLOCK_PROCESSED arrived with zero STUMPs"), reverted the block's transactions to `SEEN` instead of re-anchoring them — defeating recovery.

## Fix

A `/reprocess` is an explicit "re-emit this block's results" request, so its callbacks must **force re-delivery**. This is the force-flag mechanism (issue option 1):

- Add `BypassDedup bool` (`json:"bypassDedup,omitempty"`) to `CallbackTopicMessage`.
- Set it on the reprocess-originated `STUMP` and `BLOCK_PROCESSED` callbacks, derived from `OverrideCallbackURL != ""` — the codebase's established "this is a reprocess" signal, already threaded to both emit sites. Live-announcement callbacks leave it `false`.
- In the delivery service's `processDelivery`, skip the dedup **existence check** when `BypassDedup` is set (and log an info line for observability). The key is **still recorded on success**, so normal (non-reprocess) duplicates for the same block remain suppressed afterward — normal dedup behavior is unchanged.

### Why force-flag rather than only clearing the key

The repo already had `clearReprocessDedup` (added for #122), which deletes the dedup keys at HTTP-request time. But delivery happens seconds-to-minutes later (async: publish → block-processor → subtree fetch → emit → deliver). In that window a concurrent live announcement, or a retry of the original callback, can **re-record** the key and re-suppress the reprocess result — a TOCTOU race consistent with #208's evidence (1,895 dedup-skips for blocks actively being reprocessed). The force-flag travels *with* the message, so the decision is made at delivery time and the race is closed. `clearReprocessDedup` is retained as complementary best-effort cleanup.

### Storm safety

Reprocess is operator/arcade-driven and rate-limited at the `/reprocess` handler, and a forced delivery does not itself trigger another reprocess, so the bypass cannot self-perpetuate into a callback storm.

## Test

`TestProcessDelivery_BypassDedupForcesReDelivery` (internal/callback): with a dedup key already present, a `BypassDedup` callback **is** delivered (one HTTP POST, `delivered` metric +1) and **re-records** the key, whereas a normal duplicate with the same key present is **still skipped** (no HTTP POST, no record).

## Verification

- `go build ./...` — clean
- `go vet` (touched pkgs) — clean
- `go test ./internal/callback/... ./internal/block/... ./internal/kafka/... ./internal/api/...` — pass
- `make lint` (logfields canon + `golangci-lint run`) — 0 issues
- Full `go test ./...` passes except `internal/store` (pre-existing: requires a live Aerospike `merkle` namespace; fails identically on `origin/main`, and this PR does not touch that package).

## Files changed

- `internal/kafka/messages.go` — new `BypassDedup` field + doc
- `internal/block/subtree_worker.go` — set `BypassDedup` on reprocess STUMP + BLOCK_PROCESSED callbacks
- `internal/callback/delivery.go` — skip dedup existence check when `BypassDedup` is set (still records on success)
- `internal/callback/delivery_test.go` — new test + `mockDedupStore.recordCalls`

https://claude.ai/code/session_01BvyMDBbGFAD2RDQAYhRdP3
