### PR TITLE
fix(callback): stop stranding blocks when a STUMP callback is rejected as too large

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -478,6 +478,30 @@ callback:
   # Env: CALLBACK_MAX_IDLE_CONNS_PER_HOST
   maxIdleConnsPerHost: 16
 
+  # Mirror of the RECEIVER's inbound body cap, in bytes. When > 0, a built
+  # callback body larger than this is never POSTed: delivery fails fast with an
+  # oversize error naming the block hash, subtree index and exact byte count,
+  # instead of spending a multi-MiB upload on a request the receiver is certain
+  # to reject with 413.
+  #
+  # 0 (the default) disables the pre-flight check and relies on the receiver's
+  # 413. That is safe — a 413 is retried, not DLQ'd — but it is strictly less
+  # diagnosable, so operators SHOULD set this to whatever their receiver
+  # enforces. For arcade that is `callback.max_body_bytes` (env
+  # ARCADE_CALLBACK_MAX_BODY_BYTES); its default is 16 MiB (16777216) and
+  # dev-ovh-1 runs 128 MiB (134217728) since teranode-argocd-deployments#211.
+  #
+  # Background: STUMP bodies are hex-encoded, which DOUBLES the blob, so the
+  # effective raw-STUMP ceiling is half this number. On 2026-08-11 at 1000 TPS
+  # a single subtree's STUMP crossed arcade's 16 MiB default; the 413 was
+  # classified as a permanent 4xx and DLQ'd with ZERO retries, arcade's
+  # bump-builder logged `expected_stumps:1, received_stumps:0` forever, and
+  # every transaction in that block was stranded short of MINED. Deliveries
+  # now also log a WARN above 8 MiB regardless of this setting, so payload
+  # growth is visible before it becomes an outage.
+  # Env: CALLBACK_MAX_BODY_BYTES
+  maxBodyBytes: 0
+
   # SSRF guard escape hatch. When false (the default), callback URLs that
   # resolve to loopback (127.0.0.0/8, ::1), link-local (169.254.0.0/16,
   # fe80::/10), or RFC1918 (10/8, 172.16/12, 192.168/16) addresses are

--- a/internal/callback/delivery.go
+++ b/internal/callback/delivery.go
@@ -64,6 +64,74 @@ func isPermanentDeliveryError(err error) bool {
 	return errors.As(err, &p)
 }
 
+// oversizeDeliveryError marks a delivery that failed purely because the
+// request body was bigger than the receiver is willing to accept — either the
+// receiver answered 413 Request Entity Too Large, or our own pre-flight check
+// (callback.maxBodyBytes) refused to send it.
+//
+// This is deliberately a DIFFERENT class from permanentDeliveryError even
+// though 413 is a 4xx. Every other non-retryable 4xx (400/401/403/404/405/410
+// /415/422) says "this request is wrong and always will be" — a bad URL, a bad
+// token, a payload the receiver cannot parse. 413 says something categorically
+// different: "this request is too big *for my current configuration*". That is
+// an operational condition, curable without changing anything about the
+// message, by raising the receiver's cap.
+//
+// The distinction is not academic. Live on dev-ovh-1 at 1000 TPS on
+// 2026-08-11, one subtree's STUMP exceeded arcade's then-default 16 MiB
+// `callback.max_body_bytes` after hex inflation (hex doubles the blob).
+// arcade answered 413, we classified it as `permanent`, logged
+//
+//	"callback permanently failed, publishing to DLQ" type:"STUMP" reason:"permanent"
+//
+// and published it to `callback-dlq` after ZERO retry attempts. arcade's
+// bump-builder then logged, forever:
+//
+//	"BLOCK_PROCESSED is missing expected STUMPs — deferring finalization"
+//	expected_stumps:1 received_stumps:0 missing_subtree_indices:[0]
+//
+// It never built a BUMP for that block, so EVERY transaction in it never
+// reached MINED. Because arcade's completeness gate leaves `processed_at`
+// NULL, its watchdog re-drives the block via /reprocess indefinitely — so the
+// block IS recoverable, but only if merkle is still willing to attempt the
+// delivery. Sending it straight to the DLQ with no retries threw away the one
+// window in which an operator could raise the cap and have the block heal
+// itself.
+//
+// Routing: an oversize failure takes the normal retry ladder (5 attempts,
+// linear 30s backoff ≈ 7.5 minutes of durable, Kafka-parked retries) instead
+// of the DLQ, and it never trips the per-URL circuit breaker — see
+// scheduleRetryOrDLQ.
+type oversizeDeliveryError struct {
+	err error
+	// bodyBytes is the size of the body we built (and either sent or
+	// refused to send). Carried on the error so the retry/DLQ decision point
+	// can name it in the operator-facing log without rebuilding the payload.
+	bodyBytes int
+	// limitBytes is the cap that was violated: the receiver's, when we know
+	// it (pre-flight), or 0 when we only learned about it from a 413.
+	limitBytes int64
+	// statusCode is the HTTP status the receiver returned, or 0 when the
+	// request was never sent because the pre-flight check refused it.
+	statusCode int
+}
+
+func (e *oversizeDeliveryError) Error() string { return e.err.Error() }
+func (e *oversizeDeliveryError) Unwrap() error { return e.err }
+
+func errOversizeDelivery(err error, bodyBytes int, limitBytes int64, statusCode int) error {
+	return &oversizeDeliveryError{err: err, bodyBytes: bodyBytes, limitBytes: limitBytes, statusCode: statusCode}
+}
+
+// asOversizeDeliveryError returns the oversize error in err's chain, or nil.
+func asOversizeDeliveryError(err error) *oversizeDeliveryError {
+	var o *oversizeDeliveryError
+	if errors.As(err, &o) {
+		return o
+	}
+	return nil
+}
+
 // callbackPayload is the JSON body sent to the callback URL, matching Arcade's CallbackMessage.
 type callbackPayload struct {
 	Type         string   `json:"type"`
@@ -154,6 +222,30 @@ type DeliveryService struct {
 // the cache at ~35 MB while comfortably covering the distinct subtrees in
 // flight during one block's delivery fan-out.
 const bodyCacheMaxEntries = 64
+
+// bodyWarnBytes is the built-body size above which a delivery logs a WARN
+// naming the block, subtree and exact byte count — even when the POST then
+// succeeds.
+//
+// 8 MiB is half of arcade's original `callback.max_body_bytes` default
+// (16 MiB, `config.DefaultCallbackMaxBodyBytes`). A body at this size means
+// the deployment is one subtree-growth step away from the 2026-08-11
+// dev-ovh-1 incident, in which a STUMP crossed that cap and the block it
+// belonged to was stranded (see oversizeDeliveryError). This is the
+// early-warning signal that the receiver's cap is about to be reached.
+//
+// It is a constant rather than config on purpose — its job is "tell me the
+// payloads are growing", which needs no tuning, while the *enforcing* knob
+// (callback.maxBodyBytes) is configurable because only the operator knows the
+// receiver's real cap.
+//
+// The warning fires per DELIVERY, not per built body: it sits after the
+// bodyCache lookup, so one subtree fanned out to N subscribers logs N lines.
+// Deliberate — the body is memoized but the risk is per-request, and any one
+// of those N POSTs can be the one that 413s. A normal STUMP body is ~545 KB,
+// so crossing 8 MiB at all already means the deployment is close to an
+// outage, which is exactly when the volume is worth paying.
+const bodyWarnBytes = 8 << 20
 
 // NewDeliveryService creates a new callback DeliveryService. stumpStore is
 // required whenever STUMP-type messages are delivered — it is the claim-check
@@ -323,6 +415,11 @@ func (d *DeliveryService) Init(_ interface{}) error {
 		"futureRetryWaitCap", futureRetryWaitCap,
 		"maxConnsPerHost", maxConnsPerHostOrDefault(d.cfg.Callback.MaxConnsPerHost),
 		"maxIdleConnsPerHost", maxIdleConnsPerHostOrDefault(d.cfg.Callback.MaxIdleConnsPerHost),
+		// 0 means "no local pre-flight cap; discover the receiver's limit from
+		// its 413". Surfaced at startup because whether this is set is the
+		// difference between a diagnosable oversize failure and an opaque one.
+		"maxBodyBytes", d.cfg.Callback.MaxBodyBytes,
+		"bodyWarnBytes", bodyWarnBytes,
 		"allowPrivateIPs", d.cfg.Callback.AllowPrivateIPs,
 	)
 
@@ -648,6 +745,64 @@ func (d *DeliveryService) processDelivery(ctx context.Context, sourceTopic strin
 // returns nil iff the durable side-effect succeeded; otherwise the caller
 // must propagate the error up so the Kafka offset is not committed.
 func (d *DeliveryService) scheduleRetryOrDLQ(ctx context.Context, sourceTopic string, cbMsg *kafka.CallbackTopicMessage, cause error) error {
+	// Oversize is checked BEFORE the permanent check and before the retry
+	// budget, because it needs the opposite treatment from both.
+	//
+	// It must not be permanent: 413 is curable by raising the receiver's cap,
+	// and DLQ-on-first-413 is exactly what stranded a block on 2026-08-11
+	// (see oversizeDeliveryError). So it falls through to the normal retry
+	// ladder below — 5 attempts on a 30s linear backoff is ~7.5 minutes of
+	// durable, Kafka-parked retrying, during which an operator raising the cap
+	// heals the block with no further action. Beyond that window arcade's own
+	// watchdog keeps the block recoverable: its completeness gate leaves
+	// `processed_at` NULL and re-drives /reprocess, which re-emits this STUMP.
+	//
+	// It must also not trip the per-URL circuit breaker on the way out. The
+	// breaker's premise is "this endpoint is dead, stop fanning out to it" —
+	// but a receiver rejecting one oversize STUMP is emphatically alive, and
+	// a block full of oversize STUMPs would cross the default threshold of 20
+	// in a single block and auto-disable arcade's callback URL, killing SEEN
+	// and BLOCK_PROCESSED delivery for every transaction, not just the
+	// stranded block's. That is a strictly worse outage than the one we are
+	// fixing.
+	if o := asOversizeDeliveryError(cause); o != nil {
+		if cbMsg.RetryCount < d.cfg.Callback.MaxRetries {
+			// Retry budget left: fall through to the normal republish path,
+			// which logs the scheduled retry. The loud ERROR naming the block
+			// was already emitted at detection time by logOversize.
+			return d.scheduleRetry(ctx, sourceTopic, cbMsg, cause)
+		}
+		// Budget exhausted. This is the "a block is stranded" moment — say so
+		// in those words, with the block identity and the exact size, so an
+		// operator reading logs or alerting on the metric knows immediately
+		// which block is stuck and why. Distinct outcome label from the
+		// generic DLQ counter precisely so it can be alerted on separately.
+		d.Logger.Error(
+			"BLOCK STRANDED: oversize callback exhausted its retries and is going to the DLQ — "+
+				"the receiver never got this subtree's STUMP, so it cannot finalize the block and none of the "+
+				"block's transactions can reach MINED. Raise the receiver's inbound body cap "+
+				"(arcade: callback.max_body_bytes / ARCADE_CALLBACK_MAX_BODY_BYTES), then re-drive the block "+
+				"with POST /reprocess",
+			logfields.CallbackURL(cbMsg.CallbackURL),
+			logfields.TxID(cbMsg.TxID),
+			"type", cbMsg.Type,
+			logfields.BlockHash(cbMsg.BlockHash),
+			logfields.SubtreeIndex(cbMsg.SubtreeIndex),
+			"bodyBytes", o.bodyBytes,
+			"limitBytes", o.limitBytes,
+			"status", o.statusCode,
+			"retryCount", cbMsg.RetryCount,
+			"reason", "oversize",
+			"cause", cause,
+		)
+		metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeOversizeStranded).Inc()
+		if err := d.publishToDLQDurably(ctx, cbMsg); err != nil {
+			return err
+		}
+		// Deliberately NO recordCallbackURLFailure here — see above.
+		return nil
+	}
+
 	// Permanent failures (e.g. STUMP blob expired) skip the retry budget and
 	// go straight to the DLQ — retrying cannot recover them.
 	if isPermanentDeliveryError(cause) {
@@ -686,9 +841,21 @@ func (d *DeliveryService) scheduleRetryOrDLQ(ctx context.Context, sourceTopic st
 		return nil
 	}
 
-	// Bump retry count + compute next NextRetryAt using linear backoff, then
-	// republish back to the callback topic. The republish is the durable
-	// side-effect: until it succeeds, we must not ack the source message.
+	return d.scheduleRetry(ctx, sourceTopic, cbMsg, cause)
+}
+
+// scheduleRetry bumps the retry count, computes the next NextRetryAt using
+// linear backoff, and republishes back to the source topic. The republish is
+// the durable side-effect: until it succeeds, we must not ack the source
+// message.
+//
+// Extracted from scheduleRetryOrDLQ so the oversize branch — which is
+// evaluated ahead of the permanent-failure check, and so cannot fall through
+// to the tail of that function — schedules retries through exactly the same
+// code path, with the same backoff and the same durability contract, as every
+// other retryable failure. Duplicating it there would be a standing invitation
+// for the two ladders to drift.
+func (d *DeliveryService) scheduleRetry(ctx context.Context, sourceTopic string, cbMsg *kafka.CallbackTopicMessage, cause error) error {
 	cbMsg.RetryCount++
 	backoffSec := d.cfg.Callback.BackoffBaseSec * cbMsg.RetryCount
 	cbMsg.NextRetryAt = time.Now().Add(time.Duration(backoffSec) * time.Second)
@@ -907,6 +1074,44 @@ func (d *DeliveryService) deliverCallback(ctx context.Context, msg *kafka.Callba
 		}
 	}
 
+	// Size gate. The body is finished at this point (including a cache hit),
+	// so this covers every delivery, not just freshly-built ones.
+	//
+	// The WARN is unconditional early warning; the pre-flight refusal only
+	// fires when an operator has told us the receiver's cap. Refusing here
+	// rather than POSTing saves a doomed multi-MiB upload plus a request
+	// timeout, and — far more importantly — produces a diagnosis that names
+	// the block hash, subtree index and exact byte count, instead of an
+	// opaque 413 from the far end that we historically threw away as
+	// "permanent". See oversizeDeliveryError for the incident.
+	if len(body) > bodyWarnBytes {
+		d.Logger.Warn(
+			"callback body is approaching the receiver's inbound size limit — "+
+				"a STUMP that crosses it is rejected with 413 and strands its block until the cap is raised",
+			logfields.CallbackURL(msg.CallbackURL),
+			"type", msg.Type,
+			logfields.BlockHash(msg.BlockHash),
+			logfields.SubtreeIndex(msg.SubtreeIndex),
+			"bodyBytes", len(body),
+			"warnThresholdBytes", bodyWarnBytes,
+			"configuredMaxBodyBytes", d.cfg.Callback.MaxBodyBytes,
+		)
+	}
+	if limit := d.cfg.Callback.MaxBodyBytes; limit > 0 && int64(len(body)) > limit {
+		metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeOversize).Inc()
+		// No request is issued on this path, so ObserveCallbackDelivery never
+		// runs — record the size explicitly so the largest bodies (the ones
+		// that matter most for spotting the growth trend) are not silently
+		// missing from the payload-size histogram.
+		metrics.ObserveCallbackPayloadSize(msg.CallbackURL, len(body))
+		d.logOversize(msg, len(body), limit, 0,
+			"callback body exceeds callback.maxBodyBytes — refusing to POST a body the receiver will reject with 413")
+		return errOversizeDelivery(
+			fmt.Errorf("callback body %d bytes exceeds configured callback.maxBodyBytes %d", len(body), limit),
+			len(body), limit, 0,
+		)
+	}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, msg.CallbackURL, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP request: %w", err)
@@ -978,12 +1183,25 @@ func (d *DeliveryService) deliverCallback(ctx context.Context, msg *kafka.Callba
 	} else {
 		statusErr = fmt.Errorf("callback returned non-2xx status: %d: %s", resp.StatusCode, string(snippet))
 	}
-	// 4xx other than 408 (Request Timeout) and 429 (Too Many Requests) signal
-	// a client-side problem the receiver cannot resolve by us retrying — wrong
-	// URL, missing/invalid auth token, malformed payload, gone. Route straight
-	// to DLQ so a misconfigured arcade does not pin a callback worker on
-	// every block for the full retry budget. 408/429 stay retryable because
-	// they are explicit "try again later" signals.
+	// 413 first: it is a 4xx, but it is a payload-SIZE problem, not a
+	// "this request is invalid forever" problem, and conflating the two is
+	// what stranded a whole block's transactions on 2026-08-11 (see
+	// oversizeDeliveryError). Give it its own class so it keeps its retry
+	// budget and never trips the per-URL circuit breaker.
+	if resp.StatusCode == http.StatusRequestEntityTooLarge {
+		metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomeOversize).Inc()
+		d.logOversize(msg, len(body), d.cfg.Callback.MaxBodyBytes, resp.StatusCode,
+			"callback REJECTED as too large by the receiver (413) — raise the receiver's inbound body cap "+
+				"(arcade: callback.max_body_bytes / ARCADE_CALLBACK_MAX_BODY_BYTES); until it is raised, "+
+				"this block cannot be finalized and its transactions cannot reach MINED")
+		return errOversizeDelivery(statusErr, len(body), d.cfg.Callback.MaxBodyBytes, resp.StatusCode)
+	}
+	// 4xx other than 408 (Request Timeout), 413 (handled above) and 429 (Too
+	// Many Requests) signal a client-side problem the receiver cannot resolve
+	// by us retrying — wrong URL, missing/invalid auth token, malformed
+	// payload, gone. Route straight to DLQ so a misconfigured arcade does not
+	// pin a callback worker on every block for the full retry budget. 408/429
+	// stay retryable because they are explicit "try again later" signals.
 	if isNonRetryable4xx(resp.StatusCode) {
 		metrics.CallbackMessagesTotal.WithLabelValues(metrics.OutcomePermanent4xx).Inc()
 		return errPermanentDelivery(statusErr)
@@ -991,15 +1209,48 @@ func (d *DeliveryService) deliverCallback(ctx context.Context, msg *kafka.Callba
 	return statusErr
 }
 
+// logOversize emits the single operator-facing ERROR for an oversize
+// callback. It deliberately names the block hash, subtree index and exact
+// body size: those three facts are what turn "some callback failed" into
+// "block <hash> subtree <n> is stranded because its body is <n> bytes and the
+// receiver's cap is lower than that", which is diagnosable at a glance.
+//
+// limit is 0 when we only learned about the cap from a 413 and the operator
+// has not mirrored the receiver's value into callback.maxBodyBytes; status is
+// 0 when our own pre-flight check refused the POST.
+func (d *DeliveryService) logOversize(msg *kafka.CallbackTopicMessage, bodyBytes int, limit int64, status int, headline string) {
+	d.Logger.Error(
+		headline,
+		logfields.CallbackURL(msg.CallbackURL),
+		logfields.TxID(msg.TxID),
+		"type", msg.Type,
+		logfields.BlockHash(msg.BlockHash),
+		logfields.SubtreeIndex(msg.SubtreeIndex),
+		"bodyBytes", bodyBytes,
+		"limitBytes", limit,
+		"status", status,
+		"stumpRef", msg.StumpRef,
+		"retryCount", msg.RetryCount,
+	)
+}
+
 // isNonRetryable4xx reports whether code is a 4xx response that we should
 // treat as permanent. 408 (Request Timeout) and 429 (Too Many Requests) are
 // the standard "try again later" 4xx codes and stay on the retry path.
+//
+// 413 (Request Entity Too Large) is likewise NOT permanent, but for a
+// different reason: it is curable by an operator raising the receiver's cap,
+// so it gets its own oversize class with its own routing rather than sharing
+// the generic retry path — see oversizeDeliveryError and the caller above,
+// which peels 413 off before consulting this function. It is listed here too
+// so that any future caller of isNonRetryable4xx cannot silently reintroduce
+// the "413 == permanent == DLQ == stranded block" bug.
 func isNonRetryable4xx(code int) bool {
 	if code < 400 || code >= 500 {
 		return false
 	}
 	switch code {
-	case http.StatusRequestTimeout, http.StatusTooManyRequests:
+	case http.StatusRequestTimeout, http.StatusRequestEntityTooLarge, http.StatusTooManyRequests:
 		return false
 	}
 	return true

--- a/internal/callback/delivery.go
+++ b/internal/callback/delivery.go
@@ -211,17 +211,40 @@ type DeliveryService struct {
 	// re-hex-encoded (~half MB), and re-JSON-marshaled (~half MB) once per
 	// subscriber: at 100 subscribers, 100x redundant work and two ~half-MB
 	// allocations per delivery on the hot path. Entries are evicted FIFO at
-	// bodyCacheMaxEntries.
+	// bodyCacheMaxEntries OR bodyCacheMaxBytes, whichever binds first.
 	bodyMu    sync.Mutex
 	bodyCache map[string][]byte
 	bodyOrder []string
+	// bodyBytes is the running sum of len(v) over bodyCache, maintained
+	// incrementally so the byte budget costs no iteration on the hot path.
+	bodyBytes int
 }
 
-// bodyCacheMaxEntries bounds the STUMP body cache. Bodies are ~545 KB
-// (~271 KB stump, hex-doubled, plus small JSON fields), so 64 entries caps
-// the cache at ~35 MB while comfortably covering the distinct subtrees in
-// flight during one block's delivery fan-out.
+// bodyCacheMaxEntries bounds the STUMP body cache by entry count. Bodies are
+// ~545 KB (~271 KB stump, hex-doubled, plus small JSON fields) in the steady
+// state, and 64 entries comfortably covers the distinct subtrees in flight
+// during one block's delivery fan-out.
 const bodyCacheMaxEntries = 64
+
+// bodyCacheMaxBytes bounds the same cache by total resident bytes, and is the
+// bound that actually protects the process.
+//
+// An entry count alone is only safe while entries are a predictable size, and
+// the 2026-08-11 dev-ovh-1 incident is the proof that they are not: a single
+// STUMP body crossed 16 MiB, and arcade's cap has since been raised to 128 MiB
+// (teranode-argocd-deployments#211) precisely so bodies that large can be
+// delivered. At that ceiling a purely count-bounded cache would hold
+// 64 x 128 MiB ~= 8 GiB — an OOM-kill of the callback-delivery pod, converting
+// "one block's STUMPs are oversized" into "the delivery service is dead".
+//
+// 64 MiB keeps the steady state fully cached (64 x ~545 KB ~= 35 MB fits with
+// room to spare, so nothing about normal operation changes) while capping the
+// pathological case at a survivable number. Exceeding it evicts oldest-first;
+// in the degenerate case where one body alone exceeds the budget it is still
+// cached — evicting it immediately would just restore the redundant
+// fetch/hex/marshal work per subscriber that the cache exists to remove — but
+// it will be the only resident entry.
+const bodyCacheMaxBytes = 64 << 20
 
 // bodyWarnBytes is the built-body size above which a delivery logs a WARN
 // naming the block, subtree and exact byte count — even when the POST then
@@ -276,10 +299,11 @@ func (d *DeliveryService) cachedBody(key string) []byte {
 	return d.bodyCache[key]
 }
 
-// storeBody memoizes body under key with FIFO eviction. The build happens
-// outside the lock (half-MB hex+marshal work must not serialize the
-// per-partition delivery workers); a concurrent duplicate build is harmless —
-// first writer wins.
+// storeBody memoizes body under key with FIFO eviction, bounded by BOTH
+// bodyCacheMaxEntries and bodyCacheMaxBytes. The build happens outside the
+// lock (half-MB hex+marshal work must not serialize the per-partition
+// delivery workers); a concurrent duplicate build is harmless — first writer
+// wins.
 func (d *DeliveryService) storeBody(key string, body []byte) {
 	d.bodyMu.Lock()
 	defer d.bodyMu.Unlock()
@@ -287,14 +311,23 @@ func (d *DeliveryService) storeBody(key string, body []byte) {
 		// Lazy init: tests construct DeliveryService via struct literal.
 		d.bodyCache = make(map[string][]byte, bodyCacheMaxEntries)
 	}
-	if _, ok := d.bodyCache[key]; !ok {
-		if len(d.bodyOrder) >= bodyCacheMaxEntries {
-			oldest := d.bodyOrder[0]
-			d.bodyOrder = d.bodyOrder[1:]
-			delete(d.bodyCache, oldest)
-		}
-		d.bodyCache[key] = body
-		d.bodyOrder = append(d.bodyOrder, key)
+	if _, ok := d.bodyCache[key]; ok {
+		return
+	}
+	d.bodyCache[key] = body
+	d.bodyOrder = append(d.bodyOrder, key)
+	d.bodyBytes += len(body)
+	// Evict oldest-first until BOTH bounds hold. The byte budget is checked
+	// with len(d.bodyOrder) > 1 so the newly-stored entry is never evicted by
+	// its own size: a body larger than the whole budget still gets cached
+	// (alone), because evicting it on insert would restore exactly the
+	// per-subscriber fetch/hex/marshal duplication the cache exists to remove.
+	for len(d.bodyOrder) > bodyCacheMaxEntries ||
+		(d.bodyBytes > bodyCacheMaxBytes && len(d.bodyOrder) > 1) {
+		oldest := d.bodyOrder[0]
+		d.bodyOrder = d.bodyOrder[1:]
+		d.bodyBytes -= len(d.bodyCache[oldest])
+		delete(d.bodyCache, oldest)
 	}
 }
 

--- a/internal/callback/delivery_oversize_test.go
+++ b/internal/callback/delivery_oversize_test.go
@@ -1,0 +1,518 @@
+package callback
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/bsv-blockchain/merkle-service/internal/kafka"
+	"github.com/bsv-blockchain/merkle-service/internal/logfields"
+	"github.com/bsv-blockchain/merkle-service/internal/metrics"
+	"github.com/bsv-blockchain/merkle-service/internal/store"
+)
+
+// These tests pin the semantics introduced after the 2026-08-11 dev-ovh-1
+// incident (1000 TPS): a subtree's STUMP, hex-encoded, exceeded arcade's
+// then-default 16 MiB `callback.max_body_bytes`; arcade answered
+// 413 Request Entity Too Large; merkle classified the 4xx as permanent and
+// published the callback to `callback-dlq` after ZERO retries. arcade's
+// bump-builder then logged, forever,
+//
+//	"BLOCK_PROCESSED is missing expected STUMPs — deferring finalization"
+//	expected_stumps:1 received_stumps:0 missing_subtree_indices:[0]
+//
+// so the block never got a BUMP and every transaction in it never reached
+// MINED.
+//
+// The pinned semantics are:
+//  1. 413 is NOT permanent — it keeps its retry budget, so an operator
+//     raising the receiver's cap heals the block automatically.
+//  2. 413 never trips the per-URL circuit breaker, because disabling
+//     arcade's callback URL would strand every transaction, not just the
+//     oversize block's.
+//  3. The condition is loudly observable: a dedicated metric outcome plus an
+//     ERROR naming the block hash, subtree index and exact body size.
+//  4. A configured `callback.maxBodyBytes` refuses the POST up front instead
+//     of uploading a body the receiver is certain to reject.
+
+// recordingURLRegistry captures RecordFailure calls so a test can assert the
+// per-URL circuit breaker was (or was not) advanced.
+type recordingURLRegistry struct {
+	failures atomic.Int32
+}
+
+func (r *recordingURLRegistry) Add(_, _ string) error { return nil }
+
+func (r *recordingURLRegistry) GetAll() ([]store.CallbackEntry, error) { return nil, nil }
+
+func (r *recordingURLRegistry) RecordFailure(_ string, _ int) (bool, error) {
+	r.failures.Add(1)
+	return false, nil
+}
+
+var _ store.CallbackURLRegistry = (*recordingURLRegistry)(nil)
+
+// newOversizeTestServer returns an httptest server that always answers 413,
+// mimicking arcade's http.MaxBytesReader → StatusRequestEntityTooLarge
+// mapping, plus a counter of how many requests actually arrived.
+func newOversizeTestServer(t *testing.T) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+		_, _ = w.Write([]byte(`{"error":"request body too large"}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+// TestDeliverCallback_413IsNotPermanent is the narrowest statement of the
+// bug: deliverCallback must classify a 413 as an oversize failure, not a
+// permanent one. isPermanentDeliveryError deciding "true" here is precisely
+// what routed the incident's STUMP to the DLQ with no retries.
+func TestDeliverCallback_413IsNotPermanent(t *testing.T) {
+	server, hits := newOversizeTestServer(t)
+
+	cfg := defaultTestConfig()
+	ds, _, _ := newTestDeliveryService(t, cfg, server.Client())
+
+	msg := &kafka.CallbackTopicMessage{
+		CallbackURL:  server.URL + "/callback",
+		Type:         kafka.CallbackStump,
+		BlockHash:    testBlockHash,
+		SubtreeIndex: 4,
+	}
+
+	err := ds.deliverCallback(context.Background(), msg)
+	if err == nil {
+		t.Fatal("expected an error for a 413 response, got nil")
+	}
+	if isPermanentDeliveryError(err) {
+		t.Fatal("413 must NOT be classified as permanent — that is what strands the block")
+	}
+	o := asOversizeDeliveryError(err)
+	if o == nil {
+		t.Fatalf("expected an oversizeDeliveryError, got %T: %v", err, err)
+	}
+	if o.statusCode != http.StatusRequestEntityTooLarge {
+		t.Errorf("statusCode: expected 413, got %d", o.statusCode)
+	}
+	if o.bodyBytes <= 0 {
+		t.Errorf("bodyBytes: expected the sent body size to be recorded, got %d", o.bodyBytes)
+	}
+	if hits.Load() != 1 {
+		t.Errorf("expected exactly 1 request to reach the receiver, got %d", hits.Load())
+	}
+}
+
+// TestIsNonRetryable4xx_413IsExcluded guards the classifier itself. Even if a
+// future caller stops peeling 413 off ahead of this function, it must not
+// re-acquire "permanent" semantics through this path.
+func TestIsNonRetryable4xx_413IsExcluded(t *testing.T) {
+	if isNonRetryable4xx(http.StatusRequestEntityTooLarge) {
+		t.Error("413 must not be reported as a non-retryable 4xx")
+	}
+	// The genuinely-permanent codes must be unchanged by this fix.
+	for _, code := range []int{
+		http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden,
+		http.StatusNotFound, http.StatusMethodNotAllowed, http.StatusGone,
+		http.StatusUnsupportedMediaType, http.StatusUnprocessableEntity,
+	} {
+		if !isNonRetryable4xx(code) {
+			t.Errorf("status %d should still be a non-retryable 4xx", code)
+		}
+	}
+	// And the pre-existing retryable ones too.
+	for _, code := range []int{http.StatusRequestTimeout, http.StatusTooManyRequests} {
+		if isNonRetryable4xx(code) {
+			t.Errorf("status %d must stay retryable", code)
+		}
+	}
+}
+
+// TestProcessDelivery_413DoesNotGoStraightToDLQ is the regression test for
+// the incident. Before the fix this produced exactly one DLQ message and zero
+// retries; it must now produce exactly one retry republish and zero DLQ
+// messages.
+func TestProcessDelivery_413DoesNotGoStraightToDLQ(t *testing.T) {
+	server, _ := newOversizeTestServer(t)
+
+	cfg := defaultTestConfig()
+	ds, retryMock, dlqMock := newTestDeliveryService(t, cfg, server.Client())
+	registry := &recordingURLRegistry{}
+	ds.urlRegistry = registry
+	cfg.Callback.BreakerThreshold = 1 // trip on the very first failure, if it were reachable
+
+	msg := &kafka.CallbackTopicMessage{
+		CallbackURL:  server.URL + "/callback",
+		Type:         kafka.CallbackStump,
+		BlockHash:    "blockhash-oversize",
+		SubtreeIndex: 0,
+		RetryCount:   0,
+	}
+
+	beforeOversize := callbackCount(metrics.OutcomeOversize)
+	beforeDLQ := callbackCount(metrics.OutcomeDLQ)
+
+	if err := ds.processDelivery(context.Background(), "", msg); err != nil {
+		t.Fatalf("processDelivery returned error: %v", err)
+	}
+
+	if got := len(dlqMock.getMessages()); got != 0 {
+		t.Fatalf("a 413 must not be DLQ'd on the first attempt; got %d DLQ message(s)", got)
+	}
+	retries := retryMock.getMessages()
+	if len(retries) != 1 {
+		t.Fatalf("expected exactly 1 retry republish, got %d", len(retries))
+	}
+	retried := decodePublishedCallbackMessage(t, retries[0])
+	if retried.RetryCount != 1 {
+		t.Errorf("retryCount: expected 1, got %d", retried.RetryCount)
+	}
+	if retried.NextRetryAt.IsZero() {
+		t.Error("expected the retry to carry a nextRetryAt backoff stamp")
+	}
+	if retried.BlockHash != "blockhash-oversize" {
+		t.Errorf("blockHash lost on retry: %q", retried.BlockHash)
+	}
+
+	if delta := callbackCount(metrics.OutcomeOversize) - beforeOversize; delta != 1 {
+		t.Errorf("expected oversize counter delta=1, got %d", delta)
+	}
+	if delta := callbackCount(metrics.OutcomeDLQ) - beforeDLQ; delta != 0 {
+		t.Errorf("expected DLQ counter delta=0, got %d", delta)
+	}
+	if registry.failures.Load() != 0 {
+		t.Errorf("the per-URL circuit breaker must not advance on an oversize retry, got %d failures", registry.failures.Load())
+	}
+}
+
+// TestProcessDelivery_413ExhaustedRetriesStrandsLoudlyWithoutTrippingBreaker
+// pins the terminal case. Once the retry budget is spent the message does go
+// to the DLQ — but under its own `oversize_stranded` outcome (the metric an
+// operator pages on) and WITHOUT advancing the per-URL circuit breaker.
+//
+// The breaker exclusion is the important half: arcade registers one callback
+// URL for the whole deployment, so a block whose subtrees all produce
+// oversize STUMPs would cross the default threshold of 20 in a single block
+// and auto-disable that URL — killing SEEN and BLOCK_PROCESSED delivery for
+// every transaction in flight, not just the stranded block's.
+func TestProcessDelivery_413ExhaustedRetriesStrandsLoudlyWithoutTrippingBreaker(t *testing.T) {
+	server, _ := newOversizeTestServer(t)
+
+	cfg := defaultTestConfig()
+	cfg.Callback.MaxRetries = 3
+	cfg.Callback.BreakerThreshold = 1
+	ds, retryMock, dlqMock := newTestDeliveryService(t, cfg, server.Client())
+	registry := &recordingURLRegistry{}
+	ds.urlRegistry = registry
+
+	var buf bytes.Buffer
+	ds.Logger = slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	msg := &kafka.CallbackTopicMessage{
+		CallbackURL:  server.URL + "/callback",
+		Type:         kafka.CallbackStump,
+		BlockHash:    "blockhash-stranded",
+		SubtreeIndex: 11,
+		RetryCount:   3, // budget already spent
+	}
+
+	beforeStranded := callbackCount(metrics.OutcomeOversizeStranded)
+
+	if err := ds.processDelivery(context.Background(), "", msg); err != nil {
+		t.Fatalf("processDelivery returned error: %v", err)
+	}
+
+	if got := len(retryMock.getMessages()); got != 0 {
+		t.Errorf("expected no further retries once the budget is spent, got %d", got)
+	}
+	if got := len(dlqMock.getMessages()); got != 1 {
+		t.Fatalf("expected exactly 1 DLQ message, got %d", got)
+	}
+	if delta := callbackCount(metrics.OutcomeOversizeStranded) - beforeStranded; delta != 1 {
+		t.Errorf("expected oversize_stranded counter delta=1, got %d", delta)
+	}
+	if registry.failures.Load() != 0 {
+		t.Errorf("the per-URL circuit breaker must never advance on oversize, got %d failures", registry.failures.Load())
+	}
+
+	entry := findLogEntry(t, buf.Bytes(), func(e map[string]any) bool {
+		return e["reason"] == "oversize"
+	})
+	if entry["level"] != "ERROR" {
+		t.Errorf("expected the strand notice at ERROR, got %v", entry["level"])
+	}
+	if entry[logfields.KeyBlockHash] != "blockhash-stranded" {
+		t.Errorf("strand notice must name the block hash; got %v", entry[logfields.KeyBlockHash])
+	}
+	if entry[logfields.KeySubtreeIndex] != float64(11) {
+		t.Errorf("strand notice must name the subtree index; got %v", entry[logfields.KeySubtreeIndex])
+	}
+	if v, ok := entry["bodyBytes"].(float64); !ok || v <= 0 {
+		t.Errorf("strand notice must name the body size; got %v", entry["bodyBytes"])
+	}
+	if v, ok := entry["status"].(float64); !ok || int(v) != http.StatusRequestEntityTooLarge {
+		t.Errorf("strand notice must name the status; got %v", entry["status"])
+	}
+}
+
+// TestDeliverCallback_413LogsBlockIdentityAndSize pins requirement 4 of the
+// fix at the point of detection: the ERROR must carry block hash, subtree
+// index and the exact body size, so an operator can tell instantly which
+// block is stuck and by how much the payload overshot.
+func TestDeliverCallback_413LogsBlockIdentityAndSize(t *testing.T) {
+	server, _ := newOversizeTestServer(t)
+
+	cfg := defaultTestConfig()
+	cfg.Callback.MaxBodyBytes = 0 // learn the limit from the 413, not locally
+	ds, _, _ := newTestDeliveryService(t, cfg, server.Client())
+
+	var buf bytes.Buffer
+	ds.Logger = slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	msg := &kafka.CallbackTopicMessage{
+		CallbackURL:  server.URL + "/callback",
+		Type:         kafka.CallbackStump,
+		BlockHash:    "blockhash-413-log",
+		SubtreeIndex: 7,
+		TxID:         "tx-413",
+	}
+
+	if err := ds.deliverCallback(context.Background(), msg); err == nil {
+		t.Fatal("expected an error for a 413 response")
+	}
+
+	entry := findLogEntry(t, buf.Bytes(), func(e map[string]any) bool {
+		v, ok := e["status"].(float64)
+		return ok && int(v) == http.StatusRequestEntityTooLarge
+	})
+	if entry[logfields.KeyBlockHash] != "blockhash-413-log" {
+		t.Errorf("missing/wrong %s: %v", logfields.KeyBlockHash, entry[logfields.KeyBlockHash])
+	}
+	if entry[logfields.KeySubtreeIndex] != float64(7) {
+		t.Errorf("missing/wrong %s: %v", logfields.KeySubtreeIndex, entry[logfields.KeySubtreeIndex])
+	}
+	if entry[logfields.KeyCallbackURL] != msg.CallbackURL {
+		t.Errorf("missing/wrong %s: %v", logfields.KeyCallbackURL, entry[logfields.KeyCallbackURL])
+	}
+	if v, ok := entry["bodyBytes"].(float64); !ok || v <= 0 {
+		t.Errorf("missing/wrong bodyBytes: %v", entry["bodyBytes"])
+	}
+	if entry["type"] != "STUMP" {
+		t.Errorf("missing/wrong type: %v", entry["type"])
+	}
+}
+
+// TestDeliverCallback_PreflightMaxBodyBytesRefusesThePost pins the pre-flight
+// check: with callback.maxBodyBytes configured, an over-limit body is never
+// uploaded. The receiver must see zero requests — the point is to turn a
+// doomed multi-MiB POST plus a request timeout into an immediate, fully
+// contextualized local diagnosis.
+func TestDeliverCallback_PreflightMaxBodyBytesRefusesThePost(t *testing.T) {
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := defaultTestConfig()
+	cfg.Callback.MaxBodyBytes = 32 // smaller than any real payload
+	ds, _, _ := newTestDeliveryService(t, cfg, server.Client())
+
+	var buf bytes.Buffer
+	ds.Logger = slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	msg := &kafka.CallbackTopicMessage{
+		CallbackURL:  server.URL + "/callback",
+		Type:         kafka.CallbackStump,
+		BlockHash:    "blockhash-preflight",
+		SubtreeIndex: 2,
+	}
+
+	beforeOversize := callbackCount(metrics.OutcomeOversize)
+
+	err := ds.deliverCallback(context.Background(), msg)
+	if err == nil {
+		t.Fatal("expected an oversize error from the pre-flight check")
+	}
+	if hits.Load() != 0 {
+		t.Errorf("pre-flight must not send the request; receiver saw %d hit(s)", hits.Load())
+	}
+	o := asOversizeDeliveryError(err)
+	if o == nil {
+		t.Fatalf("expected an oversizeDeliveryError, got %T: %v", err, err)
+	}
+	if isPermanentDeliveryError(err) {
+		t.Error("a pre-flight oversize refusal must not be permanent")
+	}
+	if o.statusCode != 0 {
+		t.Errorf("statusCode: expected 0 (never sent), got %d", o.statusCode)
+	}
+	if o.limitBytes != 32 {
+		t.Errorf("limitBytes: expected 32, got %d", o.limitBytes)
+	}
+	if delta := callbackCount(metrics.OutcomeOversize) - beforeOversize; delta != 1 {
+		t.Errorf("expected oversize counter delta=1, got %d", delta)
+	}
+
+	entry := findLogEntry(t, buf.Bytes(), func(e map[string]any) bool {
+		return e[logfields.KeyBlockHash] == "blockhash-preflight"
+	})
+	if v, ok := entry["limitBytes"].(float64); !ok || int64(v) != 32 {
+		t.Errorf("pre-flight log must name the configured limit; got %v", entry["limitBytes"])
+	}
+	if v, ok := entry["bodyBytes"].(float64); !ok || v <= 32 {
+		t.Errorf("pre-flight log must name the over-limit body size; got %v", entry["bodyBytes"])
+	}
+}
+
+// TestDeliverCallback_PreflightDisabledByDefault guards the non-breaking
+// default: maxBodyBytes=0 means "trust the receiver". merkle cannot know a
+// third-party receiver's cap, so a non-zero default here would start refusing
+// bodies the receiver would happily have accepted.
+func TestDeliverCallback_PreflightDisabledByDefault(t *testing.T) {
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := defaultTestConfig()
+	if cfg.Callback.MaxBodyBytes != 0 {
+		t.Fatalf("test precondition: expected MaxBodyBytes 0, got %d", cfg.Callback.MaxBodyBytes)
+	}
+	ds, _, _ := newTestDeliveryService(t, cfg, server.Client())
+
+	msg := &kafka.CallbackTopicMessage{
+		CallbackURL:  server.URL + "/callback",
+		Type:         kafka.CallbackStump,
+		BlockHash:    testBlockHash,
+		SubtreeIndex: 1,
+	}
+	if err := ds.deliverCallback(context.Background(), msg); err != nil {
+		t.Fatalf("delivery should succeed with the pre-flight check disabled: %v", err)
+	}
+	if hits.Load() != 1 {
+		t.Errorf("expected the request to be sent, receiver saw %d hit(s)", hits.Load())
+	}
+}
+
+// TestHandleMessage_413RepublishesBeforeAck ties the new class back to the
+// durability contract: handleMessage may only return nil once the retry
+// republish has been acknowledged by Kafka. If the republish fails, the
+// offset must stay uncommitted so the oversize callback is reconsidered —
+// never silently dropped.
+func TestHandleMessage_413RepublishesBeforeAck(t *testing.T) {
+	server, _ := newOversizeTestServer(t)
+
+	cfg := defaultTestConfig()
+	ds, retryMock, dlqMock := newTestDeliveryService(t, cfg, server.Client())
+
+	msg := &kafka.CallbackTopicMessage{
+		CallbackURL:  server.URL + "/callback",
+		Type:         kafka.CallbackStump,
+		BlockHash:    "blockhash-durable",
+		SubtreeIndex: 5,
+	}
+
+	// Happy path: republished, then ack'd.
+	if err := ds.handleMessage(context.Background(), encodeConsumerMessage(t, msg)); err != nil {
+		t.Fatalf("handleMessage returned error: %v", err)
+	}
+	if len(retryMock.getMessages()) != 1 {
+		t.Fatalf("expected 1 retry republish, got %d", len(retryMock.getMessages()))
+	}
+	if len(dlqMock.getMessages()) != 0 {
+		t.Fatalf("expected 0 DLQ messages, got %d", len(dlqMock.getMessages()))
+	}
+
+	// Republish fails: must NOT ack.
+	retryMock.failNext = 1
+	fresh := &kafka.CallbackTopicMessage{
+		CallbackURL:  server.URL + "/callback",
+		Type:         kafka.CallbackStump,
+		BlockHash:    "blockhash-durable-2",
+		SubtreeIndex: 6,
+	}
+	if err := ds.handleMessage(context.Background(), encodeConsumerMessage(t, fresh)); err == nil {
+		t.Fatal("expected a non-nil error so the Kafka offset stays uncommitted")
+	}
+}
+
+// TestDeliverCallback_BodyWarnThresholdLogs pins the early-warning signal:
+// a body over bodyWarnBytes logs a WARN naming the block, subtree and size
+// even when the POST succeeds, so growth is visible BEFORE it becomes an
+// outage. The body is inflated via a real STUMP blob so the warning is
+// exercised through the same hex-encode path that doubled the payload in the
+// incident.
+func TestDeliverCallback_BodyWarnThresholdLogs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := defaultTestConfig()
+	ds, _, _, stumpStore := newTestDeliveryServiceWithStumps(t, cfg, server.Client())
+
+	var buf bytes.Buffer
+	ds.Logger = slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	// Just over half the warn threshold in raw bytes; hex doubles it, which
+	// is exactly the inflation that made a "small enough" STUMP too large.
+	raw := bytes.Repeat([]byte{0xab}, (bodyWarnBytes/2)+1024)
+	ref, err := stumpStore.Put(raw, 0)
+	if err != nil {
+		t.Fatalf("storing stump blob: %v", err)
+	}
+
+	msg := &kafka.CallbackTopicMessage{
+		CallbackURL:  server.URL + "/callback",
+		Type:         kafka.CallbackStump,
+		BlockHash:    "blockhash-warn",
+		SubtreeIndex: 3,
+		StumpRef:     ref,
+	}
+	if err := ds.deliverCallback(context.Background(), msg); err != nil {
+		t.Fatalf("delivery should still succeed: %v", err)
+	}
+
+	entry := findLogEntry(t, buf.Bytes(), func(e map[string]any) bool {
+		return e["level"] == "WARN" && e[logfields.KeyBlockHash] == "blockhash-warn"
+	})
+	if v, ok := entry["bodyBytes"].(float64); !ok || int(v) <= bodyWarnBytes {
+		t.Errorf("warn must name a body size above the threshold; got %v", entry["bodyBytes"])
+	}
+	if entry[logfields.KeySubtreeIndex] != float64(3) {
+		t.Errorf("warn must name the subtree index; got %v", entry[logfields.KeySubtreeIndex])
+	}
+}
+
+// findLogEntry decodes the JSON-lines log buffer and returns the first entry
+// matching pred, failing the test when none does. Delivery emits several
+// lines per attempt, so tests must select rather than assume a single entry.
+func findLogEntry(t *testing.T, raw []byte, pred func(map[string]any) bool) map[string]any {
+	t.Helper()
+	for _, line := range bytes.Split(bytes.TrimSpace(raw), []byte("\n")) {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal(line, &entry); err != nil {
+			t.Fatalf("decode log entry: %v\nraw: %s", err, line)
+		}
+		if pred(entry) {
+			return entry
+		}
+	}
+	t.Fatalf("no matching log entry found in:\n%s", raw)
+	return nil
+}

--- a/internal/callback/delivery_oversize_test.go
+++ b/internal/callback/delivery_oversize_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"sync/atomic"
 	"testing"
 
@@ -144,10 +145,10 @@ func TestProcessDelivery_413DoesNotGoStraightToDLQ(t *testing.T) {
 	server, _ := newOversizeTestServer(t)
 
 	cfg := defaultTestConfig()
+	cfg.Callback.BreakerThreshold = 1 // trip on the very first failure, if it were reachable
 	ds, retryMock, dlqMock := newTestDeliveryService(t, cfg, server.Client())
 	registry := &recordingURLRegistry{}
 	ds.urlRegistry = registry
-	cfg.Callback.BreakerThreshold = 1 // trip on the very first failure, if it were reachable
 
 	msg := &kafka.CallbackTopicMessage{
 		CallbackURL:  server.URL + "/callback",
@@ -515,4 +516,99 @@ func findLogEntry(t *testing.T, raw []byte, pred func(map[string]any) bool) map[
 	}
 	t.Fatalf("no matching log entry found in:\n%s", raw)
 	return nil
+}
+
+// TestStoreBody_ByteBudgetEvicts pins the memory bound that makes the STUMP
+// body cache safe now that bodies can legitimately be huge.
+//
+// bodyCacheMaxEntries alone is only a safe bound while entries are a
+// predictable size. The 2026-08-11 incident proved they are not — and arcade's
+// cap has since been raised to 128 MiB so that bodies that large CAN be
+// delivered. Count-bounded, the cache would then hold 64 x 128 MiB ~= 8 GiB
+// and OOM-kill the delivery pod, escalating "one block's STUMPs are oversized"
+// into "callback delivery is dead".
+func TestStoreBody_ByteBudgetEvicts(t *testing.T) {
+	ds := &DeliveryService{}
+
+	// Entries far below the count limit, but together far above the byte
+	// budget: the byte bound must be the one that binds.
+	const chunk = bodyCacheMaxBytes / 4
+	for i := range 8 {
+		ds.storeBody(strconv.Itoa(i), make([]byte, chunk))
+	}
+
+	if ds.bodyBytes > bodyCacheMaxBytes {
+		t.Errorf("resident bytes %d exceed budget %d", ds.bodyBytes, bodyCacheMaxBytes)
+	}
+	if len(ds.bodyCache) != len(ds.bodyOrder) {
+		t.Errorf("cache/order desync: %d entries vs %d order slots", len(ds.bodyCache), len(ds.bodyOrder))
+	}
+	// bodyBytes must stay an exact running sum, or the budget silently drifts.
+	var sum int
+	for _, v := range ds.bodyCache {
+		sum += len(v)
+	}
+	if sum != ds.bodyBytes {
+		t.Errorf("bodyBytes drifted: tracked %d, actual %d", ds.bodyBytes, sum)
+	}
+	// FIFO: the newest entry survives, the oldest does not.
+	if ds.cachedBody("7") == nil {
+		t.Error("most recently stored entry was evicted")
+	}
+	if ds.cachedBody("0") != nil {
+		t.Error("oldest entry should have been evicted by the byte budget")
+	}
+}
+
+// TestStoreBody_EntryBudgetStillEvicts guards the original count bound: small
+// bodies must still be capped at bodyCacheMaxEntries, since the byte budget
+// would never bind for them.
+func TestStoreBody_EntryBudgetStillEvicts(t *testing.T) {
+	ds := &DeliveryService{}
+	for i := range bodyCacheMaxEntries + 10 {
+		ds.storeBody(strconv.Itoa(i), []byte("small"))
+	}
+	if len(ds.bodyCache) != bodyCacheMaxEntries {
+		t.Errorf("expected %d entries, got %d", bodyCacheMaxEntries, len(ds.bodyCache))
+	}
+	if ds.cachedBody("0") != nil {
+		t.Error("oldest entry should have been evicted by the count budget")
+	}
+}
+
+// TestStoreBody_OversizedSingleBodyIsStillCached pins the degenerate case: a
+// single body larger than the whole budget is cached anyway, alone. Refusing
+// it would restore precisely the per-subscriber re-fetch/re-hex/re-marshal
+// duplication the cache exists to eliminate — and that duplication is at its
+// most expensive exactly when the body is at its largest.
+func TestStoreBody_OversizedSingleBodyIsStillCached(t *testing.T) {
+	ds := &DeliveryService{}
+	ds.storeBody("small", []byte("x"))
+	huge := make([]byte, bodyCacheMaxBytes+1)
+	ds.storeBody("huge", huge)
+
+	if ds.cachedBody("huge") == nil {
+		t.Fatal("an over-budget body must still be cached, so the fan-out does not rebuild it per subscriber")
+	}
+	if len(ds.bodyCache) != 1 {
+		t.Errorf("expected the over-budget body to be the only resident entry, got %d", len(ds.bodyCache))
+	}
+}
+
+// TestStoreBody_DuplicateKeyDoesNotDoubleCount guards the running sum against
+// the classic incremental-accounting bug: re-storing an existing key must not
+// add its size again, or bodyBytes drifts upward until the cache evicts
+// everything on every insert.
+func TestStoreBody_DuplicateKeyDoesNotDoubleCount(t *testing.T) {
+	ds := &DeliveryService{}
+	body := make([]byte, 1024)
+	ds.storeBody("k", body)
+	ds.storeBody("k", body)
+
+	if ds.bodyBytes != 1024 {
+		t.Errorf("bodyBytes: expected 1024 after a duplicate store, got %d", ds.bodyBytes)
+	}
+	if len(ds.bodyOrder) != 1 {
+		t.Errorf("order: expected 1 entry after a duplicate store, got %d", len(ds.bodyOrder))
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -601,6 +601,30 @@ type CallbackConfig struct {
 	// registry and BLOCK_PROCESSED / STUMP fan-out stops targeting it (a fresh
 	// /watch re-enables it). Default 20; set <= 0 to disable the breaker.
 	BreakerThreshold int `yaml:"breakerThreshold" mapstructure:"breakerthreshold"`
+	// MaxBodyBytes mirrors, on OUR side, the inbound body cap the receiver
+	// enforces on its callback endpoint (arcade: `callback.max_body_bytes`,
+	// which wraps the request in http.MaxBytesReader and answers 413 on
+	// overflow). When > 0, a built callback body larger than this is never
+	// POSTed: delivery fails fast with an oversize error that logs the block
+	// hash, subtree index and exact body size, instead of burning a request
+	// timeout uploading a body that is guaranteed to be rejected.
+	//
+	// Default 0 = disabled, i.e. "trust the receiver and discover the limit
+	// from its 413". That is deliberate: merkle cannot know a third-party
+	// receiver's cap, and a wrong non-zero default here would start refusing
+	// bodies the receiver would happily have accepted. Operators who know
+	// their receiver's cap SHOULD set this to the same number so the failure
+	// is diagnosed here, with full block/subtree context, rather than as an
+	// opaque 413 from the far end.
+	//
+	// Incident 2026-08-11 (dev-ovh-1, 1000 TPS): a single subtree's STUMP,
+	// hex-encoded (2x inflation), exceeded arcade's then-default 16 MiB cap.
+	// arcade answered 413, merkle classified the 4xx as permanent and DLQ'd
+	// the callback with zero retries, and arcade's bump-builder then logged
+	// `expected_stumps:1, received_stumps:0` forever — every transaction in
+	// that block never reached MINED. See CallbackConfig usage in
+	// internal/callback/delivery.go.
+	MaxBodyBytes int64 `yaml:"maxBodyBytes" mapstructure:"maxbodybytes"`
 	// AllowPrivateIPs disables the SSRF guard that normally rejects
 	// callback URLs (or dial addresses) pointing at loopback,
 	// link-local, or RFC1918 destinations. Default false. Operators
@@ -836,6 +860,10 @@ func registerDefaults(v *viper.Viper) {
 	v.SetDefault("callback.dedupttlsec", 86400)
 	v.SetDefault("callback.maxconnsperhost", 32)
 	v.SetDefault("callback.maxidleconnsperhost", 16)
+	// 0 = disabled: no local pre-flight cap, discover the receiver's limit
+	// from its 413. See CallbackConfig.MaxBodyBytes for why there is no
+	// non-zero default.
+	v.SetDefault("callback.maxbodybytes", 0)
 	v.SetDefault("callback.allowprivateips", false)
 
 	// BlobStore
@@ -1012,6 +1040,7 @@ func bindEnvVars(v *viper.Viper) {
 		"callback.dedupttlsec":         "CALLBACK_DEDUP_TTL_SEC",
 		"callback.maxconnsperhost":     "CALLBACK_MAX_CONNS_PER_HOST",
 		"callback.maxidleconnsperhost": "CALLBACK_MAX_IDLE_CONNS_PER_HOST",
+		"callback.maxbodybytes":        "CALLBACK_MAX_BODY_BYTES",
 		"callback.allowprivateips":     "CALLBACK_ALLOW_PRIVATE_IPS",
 
 		// BlobStore

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -45,6 +45,7 @@ func clearConfigEnv(t *testing.T) {
 		"BLOCK_EMIT_EXPECTED_STUMP_SET",
 		"CALLBACK_MAX_RETRIES", "CALLBACK_BACKOFF_BASE_SEC",
 		"CALLBACK_TIMEOUT_SEC", "CALLBACK_SEEN_THRESHOLD",
+		"CALLBACK_MAX_BODY_BYTES",
 		"BLOB_STORE_URL", "BLOB_STORE_SWEEP_INTERVAL_SEC", "BLOB_STORE_SWEEP_MAX_AGE_SEC",
 		envTelemetryEnabled, "TELEMETRY_ENDPOINT", envTelemetryProtocol,
 		"TELEMETRY_INSECURE", "TELEMETRY_SERVICE_NAME", "TELEMETRY_NAMESPACE",
@@ -870,5 +871,48 @@ func TestBlockConfig_EmitExpectedStumpSetEnabled_ZeroValue(t *testing.T) {
 	var cfg BlockConfig
 	if !cfg.EmitExpectedStumpSetEnabled() {
 		t.Error("zero-valued BlockConfig: EmitExpectedStumpSetEnabled() expected true (nil means enabled), got false")
+	}
+}
+
+// TestLoad_CallbackMaxBodyBytesDefaultsToDisabled pins the non-breaking
+// default for the pre-flight body cap introduced after the 2026-08-11
+// dev-ovh-1 STUMP-413 incident. 0 means "no local cap; discover the
+// receiver's limit from its 413".
+//
+// The default MUST stay 0. merkle cannot know a third-party receiver's
+// inbound cap, so any non-zero default here would start refusing bodies the
+// receiver would happily have accepted — trading a rare, now-recoverable
+// failure for a guaranteed one.
+func TestLoad_CallbackMaxBodyBytesDefaultsToDisabled(t *testing.T) {
+	clearConfigEnv(t)
+	_ = os.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")
+	defer clearConfigEnv(t)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	if cfg.Callback.MaxBodyBytes != 0 {
+		t.Errorf("Callback.MaxBodyBytes: expected 0 (disabled) by default, got %d", cfg.Callback.MaxBodyBytes)
+	}
+}
+
+// TestLoad_CallbackMaxBodyBytesEnvOverride covers the knob operators reach
+// for: mirror the receiver's cap (arcade's callback.max_body_bytes, raised to
+// 128 MiB on dev-ovh-1 in teranode-argocd-deployments#211) so an oversize
+// body is diagnosed here, with block/subtree context, instead of as an opaque
+// 413 from the far end.
+func TestLoad_CallbackMaxBodyBytesEnvOverride(t *testing.T) {
+	clearConfigEnv(t)
+	_ = os.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")
+	_ = os.Setenv("CALLBACK_MAX_BODY_BYTES", "134217728")
+	defer clearConfigEnv(t)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	if cfg.Callback.MaxBodyBytes != 134217728 {
+		t.Errorf("Callback.MaxBodyBytes: expected 134217728, got %d", cfg.Callback.MaxBodyBytes)
 	}
 }

--- a/internal/metrics/callback.go
+++ b/internal/metrics/callback.go
@@ -89,9 +89,24 @@ func ObserveCallbackDelivery(callbackURL string, statusCode, payloadSize int, d 
 	host := HostLabel(callbackURL)
 	statusClass := StatusClass(statusCode, err)
 	callbackDeliveryDuration.WithLabelValues(host, statusClass).Observe(d.Seconds())
-	if payloadSize > 0 {
-		callbackPayloadSize.WithLabelValues(host).Observe(float64(payloadSize))
+	ObserveCallbackPayloadSize(callbackURL, payloadSize)
+}
+
+// ObserveCallbackPayloadSize records the size of a body built for a callback,
+// independently of whether it was actually sent.
+//
+// Split out of ObserveCallbackDelivery so the pre-flight oversize refusal
+// (callback.maxBodyBytes) still lands in the size histogram. That path never
+// issues an HTTP request, so it has no status and no duration to report — but
+// it is precisely the case where knowing the payload size matters most, and
+// silently dropping the largest bodies from the histogram would hide the
+// growth trend that leads to the 413 in the first place. Non-positive sizes
+// are ignored.
+func ObserveCallbackPayloadSize(callbackURL string, payloadSize int) {
+	if payloadSize <= 0 {
+		return
 	}
+	callbackPayloadSize.WithLabelValues(HostLabel(callbackURL)).Observe(float64(payloadSize))
 }
 
 // ObserveCallbackRetryAttempt records the RetryCount distribution at the

--- a/internal/metrics/labels.go
+++ b/internal/metrics/labels.go
@@ -27,6 +27,20 @@ const (
 	OutcomeRetryScheduled   = "retry_scheduled"
 	OutcomeStumpNotFound    = "stump_not_found"
 	OutcomePermanent4xx     = "permanent_4xx"
+	// OutcomeOversize counts callback deliveries whose request body was too
+	// large for the receiver — either it answered 413, or our own pre-flight
+	// callback.maxBodyBytes check refused to send it. Counted once per
+	// attempt, so a non-zero rate here means bodies are already being
+	// rejected and a block's finalization is being delayed.
+	OutcomeOversize = "oversize"
+	// OutcomeOversizeStranded counts oversize deliveries that exhausted their
+	// retry budget and went to the DLQ. Deliberately separate from
+	// OutcomeDLQ: this is the "a block cannot be finalized and its
+	// transactions cannot reach MINED" signal (the 2026-08-11 dev-ovh-1
+	// incident), and it is the one an operator should page on. Non-zero here
+	// means the receiver's inbound body cap must be raised and the affected
+	// block re-driven via POST /reprocess.
+	OutcomeOversizeStranded = "oversize_stranded"
 	OutcomeHit              = "hit"
 	OutcomeMiss             = "miss"
 	OutcomeEmpty            = "empty"

--- a/openspec/changes/oversize-callback-recovery/design.md
+++ b/openspec/changes/oversize-callback-recovery/design.md
@@ -1,0 +1,152 @@
+# Design: oversize-callback-recovery
+
+## The decision that matters: what class is a 413?
+
+`scheduleRetryOrDLQ` had exactly two terminal shapes for a failed delivery:
+
+| Class | Routing | Rationale |
+|---|---|---|
+| permanent (`errPermanentDelivery`) | DLQ immediately, 0 retries, trip breaker | retrying provably cannot help — blob expired, endpoint gone |
+| everything else | retry ladder, DLQ on exhaustion, trip breaker | might be transient |
+
+413 was filed under "permanent" only because `isNonRetryable4xx` swept up
+every 4xx that is not 408/429. But the *reason* a 413 cannot be cured by
+retrying is not a property of the message — it is a property of the
+receiver's **current configuration**. Change one number on the receiver and
+the identical request succeeds. That is the definition of an operational
+condition, and operational conditions belong on the retry path, not in a
+dead-letter queue.
+
+The repo already has this distinction elsewhere: `OutcomeParkedDiskFull`
+exists precisely because "the disk is full" is an operational condition that
+retention-protected Kafka should ride out rather than DLQ. Oversize is the
+same shape.
+
+### Why not simply park it in Kafka forever?
+
+Parking (return an error, never ack, let the offset stall) is the strongest
+possible "never lose it" guarantee, and it is what `parked_disk_full` does on
+the subtree topic. It is the wrong answer here because
+`kafka.callbackTopic` **is pinned at 1 partition** — that is a hard
+requirement so single-partition ordering keeps `BLOCK_PROCESSED` behind its
+`STUMP`s (`docs/block-processed-completeness.md`). A stalled offset on a
+1-partition topic halts callback delivery for every other block in the
+system. Trading "one block stranded" for "all blocks stalled" is a strictly
+worse outage.
+
+The retry ladder is the right middle: the message is durably parked *in
+Kafka* between attempts (republished, not held), so it costs the partition
+one short visit per backoff cycle rather than the whole lane.
+
+### Why is the normal retry budget enough?
+
+It isn't, on its own — 5 attempts × 30 s linear ≈ 7.5 minutes. It is enough
+because merkle is not the only recovery mechanism:
+
+- arcade's completeness gate (`services/bump_builder/builder.go`,
+  `resolveStumps`) deliberately does **not** stamp `processed_at` when
+  expected STUMPs are missing, and returns `done` rather than an error —
+  because "a Kafka requeue would just replay against the same gap".
+- `processed_at IS NULL` is the durable recovery signal:
+  `ListStaleBlockProcessingStatus` surfaces the block and the watchdog
+  re-drives `POST /reprocess` against merkle, which re-emits the missing
+  STUMPs and BLOCK_PROCESSED.
+
+So the block stays recoverable indefinitely (up to the watchdog's
+`MaxReprocessAttempts` / `MaxStaleAge` parking). merkle's retry budget buys
+the *automatic* window; arcade's watchdog buys the *unbounded* one. What was
+missing was neither of those — it was that merkle refused to try at all, and
+said so in a log line indistinguishable from a bad auth token.
+
+### Why exclude oversize from the circuit breaker?
+
+`recordCallbackURLFailure` trips a per-URL breaker at
+`callback.breakerThreshold` (default **20**) DLQ'd deliveries, after which
+the URL is disabled and all fan-out to it stops until a fresh `/watch`.
+
+arcade registers **one** callback URL for the entire deployment. A block
+whose subtrees produce oversize STUMPs generates one DLQ per subtree per
+subscriber — 20 is reachable inside a single block. Tripping the breaker
+would then stop SEEN, STUMP and BLOCK_PROCESSED delivery for *every*
+transaction in flight, not just the stranded block's. The breaker exists to
+protect against a dead endpoint; a receiver that answers 413 with a JSON body
+is demonstrably alive.
+
+## The pre-flight cap, and why its default is 0
+
+`callback.maxBodyBytes` is a mirror of the *receiver's* limit, not a limit of
+our own. Two consequences:
+
+- **Default 0 (disabled).** merkle delivers to arbitrary registered URLs and
+  cannot know their caps. Any non-zero default would refuse bodies some
+  receiver would have accepted — converting a rare, now-recoverable failure
+  into a guaranteed one. Set it to match your receiver
+  (`ARCADE_CALLBACK_MAX_BODY_BYTES`; arcade's own default is 16 MiB, dev-ovh-1
+  runs 128 MiB since `teranode-argocd-deployments#211`).
+- **It changes diagnosis, not outcome.** With it set, the failure is
+  identical in routing to a 413 — same class, same retries, same metric — but
+  it is diagnosed locally, before a doomed multi-MiB upload and a request
+  timeout, and the log names the configured limit as well as the body size.
+
+The unconditional 8 MiB WARN (`bodyWarnBytes`) is deliberately a constant, not
+config. Its job is "tell me payloads are growing", which needs no tuning; the
+*enforcing* knob is configurable because only the operator knows the real cap.
+8 MiB is half arcade's original 16 MiB default, i.e. the point at which the
+deployment is one subtree-growth step from the incident.
+
+The warning is emitted per *delivery*, not per built body — it sits after the
+`bodyCache` lookup, so a subtree fanned out to N subscribers logs N lines.
+That is deliberate: the body is memoized but the risk is per-request, and each
+of those N deliveries can independently be the one that 413s. Bodies above
+8 MiB are exceptional by construction (a normal STUMP body is ~545 KB), so the
+volume is bounded by how close the deployment already is to an outage — which
+is exactly when an operator wants to be told loudly.
+
+## Follow-up: the claim-check path (needs a coordinated arcade change)
+
+Investigated and explicitly deferred. Findings:
+
+- merkle already claim-checks STUMPs **internally**: `CallbackTopicMessage`
+  carries `StumpRef` and the delivery service resolves it through
+  `store.StumpStore` (blob store, `blobStore.url`) rather than putting the
+  blob on the Kafka topic. That ref never leaves merkle.
+- arcade has **no** counterpart: no `stumpRef` / `stump_url` / `ref` field on
+  `models.CallbackMessage`, and no code anywhere that fetches a STUMP. Its
+  only STUMP ingress is the inline hex `stump` field, which
+  `handleStump` writes synchronously to its own store.
+- The `CALLBACK_STUMP_CACHE_MODE` / `CALLBACK_STUMP_CACHE_LRU_SIZE` /
+  `CALLBACK_STUMP_CACHE_TTL_SEC` env vars present in `deploy/k8s/*.yaml` and
+  `deploy/k8s/README.md` are **dead configuration** — nothing under
+  `internal/` or `cmd/` reads them. They are residue from the
+  `k8s-distributed-stump-cache` change; the shipped claim check is the blob
+  store, not an Aerospike stump cache. Setting
+  `CALLBACK_STUMP_CACHE_MODE=aerospike` has no effect on anything today.
+
+A real claim-check delivery would need, in order:
+
+1. merkle: an authenticated `GET /api/stump/{ref}` on the API server, bounded
+   and rate-limited, serving `store.StumpStore.Get`. Must respect the STUMP
+   blob's DAH so a ref cannot outlive its blob.
+2. merkle: an additive `stumpUrl` field on the callback body, emitted only
+   when a new `callback.stumpDeliveryMode` is set to `ref`.
+3. arcade: `models.CallbackMessage.StumpURL`, a fetch path in `handleStump`
+   with its own timeout/retry/SSRF guard, and a decision about what a fetch
+   failure means for the 200-means-durable contract (today a 200 on the
+   callback IS the durability guarantee that the bump-builder relies on).
+4. Rollout: merkle must keep sending inline until every arcade is upgraded,
+   so the field is negotiated, not switched.
+
+That is a multi-repo change with real failure-mode surface. It is the right
+long-term answer to unbounded payload growth; it is not the right thing to
+bundle with an incident fix whose whole point is that the current failure
+mode is unrecoverable.
+
+## Alternatives rejected
+
+| Option | Why not |
+|---|---|
+| base64 instead of hex (2x → 1.33x) | arcade decodes `stump` with `hex.DecodeString` via `models.HexBytes.UnmarshalJSON`. base64 gives `400`, or silently wrong bytes for an even-length all-hex string. Breaking wire change. |
+| gzip the body | arcade has no gzip middleware; Go does not auto-decompress request bodies → opaque `400`. And a BRC-74 path of 32-byte hashes is near incompressible; gzip would only undo the hex overhead. |
+| Give oversize an unbounded retry budget | Each not-yet-due retry costs a 2 s in-process wait on a 1-partition topic (`futureRetryWaitCap`). An immortal message would consume a large fraction of the single delivery lane forever. |
+| Split a STUMP across multiple callbacks | Changes the wire contract and arcade's `(blockHash, subtreeIndex)` STUMP key, and reintroduces a partial-delivery completeness problem one layer down. |
+| Just raise arcade's cap | Already done as the interim mitigation (`teranode-argocd-deployments#211`). It does not make the failure recoverable or observable when the next threshold is crossed. |

--- a/openspec/changes/oversize-callback-recovery/proposal.md
+++ b/openspec/changes/oversize-callback-recovery/proposal.md
@@ -116,7 +116,13 @@ the Kafka message schema, the dedup keys and the DLQ topic are all unchanged.)_
   `CallbackConfig.MaxBodyBytes`, viper default 0, env binding
   `CALLBACK_MAX_BODY_BYTES`.
 - **`internal/metrics/labels.go`**: `OutcomeOversize`,
-  `OutcomeOversizeStranded`.
+  `OutcomeOversizeStranded`. **`internal/metrics/callback.go`**:
+  `ObserveCallbackPayloadSize` split out of `ObserveCallbackDelivery` so the
+  pre-flight refusal — which issues no request, and so has no status or
+  duration — still lands in the size histogram.
+- **`internal/callback/delivery.go`** (body cache): `bodyCacheMaxBytes`
+  (64 MiB) and an incrementally-maintained `bodyBytes` running sum, so the
+  STUMP body cache is bounded by total resident bytes as well as entry count.
 - **No changes** to the HTTP body, the encoding, the Kafka message format,
   dedup keys, the DLQ topic, or arcade.
 

--- a/openspec/changes/oversize-callback-recovery/proposal.md
+++ b/openspec/changes/oversize-callback-recovery/proposal.md
@@ -1,0 +1,143 @@
+# Stop stranding blocks when a STUMP callback is rejected as too large
+
+## Why
+
+Live on dev-ovh-1, 2026-08-11, at 1000 TPS: **a block's entire transaction set
+was permanently stranded short of `MINED`** because one oversized STUMP
+callback was dropped instead of retried.
+
+The chain:
+
+1. `callback.DeliveryService` builds a STUMP body — fetch the blob via
+   `stumpStore.Get(msg.StumpRef)`, **hex-encode it (2x inflation)**, JSON-marshal
+   it inline (`internal/callback/delivery.go`, `deliverCallback`).
+2. arcade's api-server wraps the inbound body in `http.MaxBytesReader` at
+   `callback.max_body_bytes`, **default 16 MiB**
+   (`arcade config.DefaultCallbackMaxBodyBytes`), and maps overflow to
+   `413 Request Entity Too Large`.
+3. At 1000 TPS one subtree's STUMP crossed that cap after hex inflation.
+   arcade returned **413**.
+4. merkle classified the 4xx as **permanent** (`isNonRetryable4xx` →
+   `errPermanentDelivery`) and logged, with **zero retry attempts**:
+
+   ```
+   callback permanently failed, publishing to DLQ  type:"STUMP" reason:"permanent"
+   ```
+
+   → published to `callback-dlq`.
+5. arcade's bump-builder was then stuck forever:
+
+   ```
+   BLOCK_PROCESSED is missing expected STUMPs — deferring finalization
+   expected_stumps:1  received_stumps:0  missing_subtree_indices:[0]
+   ```
+
+   No BUMP was ever built, so **every transaction in that block never reached
+   `MINED`**.
+6. `/reprocess` could not recover it: the regenerated STUMP is byte-identical
+   in size and 413s again. Deterministic, not transient.
+
+The classification is the bug. Every other non-retryable 4xx
+(400/401/403/404/405/410/415/422) means "this request is wrong and always will
+be" — bad URL, bad token, unparseable payload. **413 means something
+categorically different: "too big *for my current configuration*"** — an
+operational condition curable without changing anything about the message, by
+raising the receiver's cap. Collapsing the two threw away the only window in
+which the block could heal itself.
+
+Operators mitigated by raising arcade's cap to 128 MiB
+(`teranode-argocd-deployments#211`), but that is a band-aid: the payload grows
+with subtree size, so the cap will be hit again.
+
+## What Changes
+
+- **413 becomes its own delivery-failure class** (`oversizeDeliveryError`),
+  distinct from both `permanentDeliveryError` and the generic retryable
+  failure. It keeps the normal retry budget — 5 attempts on a 30 s linear
+  backoff, ≈7.5 minutes of durable, Kafka-parked retrying — so an operator
+  raising the receiver's cap heals the block with no further action. 413 is
+  also removed from `isNonRetryable4xx` so no future caller can silently
+  reintroduce "413 == permanent == DLQ == stranded block".
+- **An oversize failure never trips the per-URL circuit breaker.** The
+  breaker's premise is "this endpoint is dead"; a receiver rejecting one
+  oversize STUMP is emphatically alive. arcade registers ONE callback URL for
+  the whole deployment, so a block whose subtrees all produce oversize STUMPs
+  would cross the default threshold of 20 within a single block and
+  auto-disable that URL — killing SEEN and BLOCK_PROCESSED delivery for every
+  transaction in flight. That is a strictly worse outage than the one being
+  fixed.
+- **New pre-flight cap `callback.maxBodyBytes`** (env
+  `CALLBACK_MAX_BODY_BYTES`), a mirror of the RECEIVER's limit. When > 0 an
+  over-limit body is never POSTed; delivery fails immediately with the block
+  hash, subtree index and exact byte count. **Default 0 = disabled**, so the
+  change is inert until configured: merkle cannot know a third-party
+  receiver's cap, and a non-zero default would start refusing bodies the
+  receiver would happily have accepted.
+- **Observability.** Two new outcome labels on
+  `merkle_callback_messages_total`: `oversize` (per rejected attempt) and
+  `oversize_stranded` (retries exhausted → DLQ; the page-worthy "a block
+  cannot be finalized" signal). An ERROR at detection and a `BLOCK STRANDED:`
+  ERROR at give-up, both naming block hash, subtree index, body size, limit
+  and status. Plus an unconditional WARN above a fixed 8 MiB (`bodyWarnBytes`,
+  half arcade's original default) so payload growth is visible *before* it
+  becomes an outage.
+
+## Capabilities
+
+### New Capabilities
+
+_(none — no new service, topic, message field or wire format. The HTTP body,
+the Kafka message schema, the dedup keys and the DLQ topic are all unchanged.)_
+
+### Modified Capabilities
+
+- `unified-callback-topic`: the delivery-failure classification gains a third
+  class between "retryable" and "permanent". The DLQ requirement is qualified:
+  an oversize body is not a permanent failure and must exhaust its retry
+  budget first.
+
+## Impact
+
+- **`internal/callback/delivery.go`**: `oversizeDeliveryError` +
+  `errOversizeDelivery` / `asOversizeDeliveryError`; `bodyWarnBytes`;
+  size gate and 413 branch in `deliverCallback`; `logOversize`; oversize
+  branch in `scheduleRetryOrDLQ`; retry tail extracted to `scheduleRetry` so
+  both paths share one backoff ladder; 413 removed from `isNonRetryable4xx`;
+  init log gains `maxBodyBytes` / `bodyWarnBytes`.
+- **`internal/config/config.go` / `config.yaml`**:
+  `CallbackConfig.MaxBodyBytes`, viper default 0, env binding
+  `CALLBACK_MAX_BODY_BYTES`.
+- **`internal/metrics/labels.go`**: `OutcomeOversize`,
+  `OutcomeOversizeStranded`.
+- **No changes** to the HTTP body, the encoding, the Kafka message format,
+  dedup keys, the DLQ topic, or arcade.
+
+## Deliberately NOT changed (and why)
+
+- **Encoding stays hex.** base64 would cut the body from 2x to 1.33x of the
+  blob, but arcade's `stump` field is `models.HexBytes` with a custom
+  `UnmarshalJSON` that calls `hex.DecodeString` — base64 would be rejected as
+  `400 invalid request body`, or (for a string that happens to be even-length
+  all-hex) silently decode to the WRONG bytes. This is a coordinated
+  arcade-side change, not a merkle-side one.
+- **No gzip.** arcade has no gzip middleware and Go's `net/http` does not
+  transparently decompress request bodies, so a `Content-Encoding: gzip` body
+  reaches `json.Decoder` as raw gzip and yields an opaque `400`. Independently,
+  a STUMP is a BRC-74 path made almost entirely of 32-byte hashes — near
+  incompressible — so gzip would only recover the ~2x hex overhead, which
+  base64 does more cheaply.
+- **No claim-check delivery to arcade.** `StumpRef` is a merkle-INTERNAL
+  claim check (Kafka message → `store.StumpStore` → blob store); it is never
+  on the wire to arcade, and arcade has no `stumpRef`/`stump_url` field and no
+  code path that fetches a STUMP from anywhere. Wiring it would mean a new
+  authenticated `GET /api/stump/{ref}` on merkle plus a new fetch path,
+  SSRF guard and failure semantics in arcade — a coordinated cross-repo
+  change with no consumer today. Ship the recovery + observability fix first;
+  see `design.md` for the follow-up sketch.
+- **Oversize still reaches the DLQ once the retry budget is spent.** Parking
+  it in Kafka indefinitely would head-of-line-block `kafka.callbackTopic`,
+  which is pinned at 1 partition, halting callbacks for every OTHER block.
+  Stranding one block is bad; stalling all of them is worse. The block stays
+  recoverable regardless: arcade's completeness gate leaves `processed_at`
+  NULL and its watchdog keeps re-driving `/reprocess`, which re-emits the
+  STUMP — so once the cap is raised, the block heals.

--- a/openspec/changes/oversize-callback-recovery/proposal.md
+++ b/openspec/changes/oversize-callback-recovery/proposal.md
@@ -81,6 +81,14 @@ with subtree size, so the cap will be hit again.
   and status. Plus an unconditional WARN above a fixed 8 MiB (`bodyWarnBytes`,
   half arcade's original default) so payload growth is visible *before* it
   becomes an outage.
+- **The STUMP body cache gains a byte budget** (`bodyCacheMaxBytes`, 64 MiB)
+  alongside its existing 64-entry bound. The entry count was sized against
+  ~545 KB bodies; now that arcade's cap is 128 MiB precisely so bodies that
+  large can be delivered, a count-only bound admits 64 × 128 MiB ≈ 8 GiB
+  resident — an OOM-kill that would escalate "one block's STUMPs are
+  oversized" into "callback delivery is dead". An over-budget single body is
+  still cached (alone), since refusing it would restore the per-subscriber
+  re-fetch/re-hex/re-marshal work the cache exists to remove.
 
 ## Capabilities
 

--- a/openspec/changes/oversize-callback-recovery/specs/unified-callback-topic/spec.md
+++ b/openspec/changes/oversize-callback-recovery/specs/unified-callback-topic/spec.md
@@ -1,0 +1,162 @@
+# unified-callback-topic (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Unified callback Kafka topic
+
+Callback events SHALL by default be published to a single `callback` Kafka
+topic (configurable via `kafka.callbackTopic`). The `stumps` topic SHALL no
+longer be used for callback delivery.
+
+The system SHALL support an OPTIONAL split in which `SEEN_ON_NETWORK` and
+`SEEN_MULTIPLE_NODES` are published to a dedicated topic
+(`kafka.callbackSeenTopic`, env `KAFKA_CALLBACK_SEEN_TOPIC`) and consumed by a
+second, independent consumer group (`<consumerGroup>-callback-seen`). When
+`kafka.callbackSeenTopic` is empty the system SHALL behave exactly as the
+unified-topic case. The split exists because `callback` is a single serial
+delivery lane: ~545 KB `STUMP` deliveries, fanned out per subscriber per
+subtree, otherwise head-of-line-block the small latency-sensitive SEEN
+callbacks queued behind them.
+
+`STUMP` and `BLOCK_PROCESSED` SHALL always remain together on
+`kafka.callbackTopic`, which SHALL remain at 1 partition, so single-partition
+ordering keeps `BLOCK_PROCESSED` behind its `STUMP`s (see
+`docs/block-processed-completeness.md`).
+
+Producers and consumers SHALL resolve the SEEN topic through a single shared
+accessor (`KafkaConfig.SeenCallbackTopic()`) so the two sides cannot disagree —
+a disagreement would publish SEEN callbacks to a topic nobody consumes, with no
+error surfaced anywhere.
+
+#### Scenario: Callback topic configured, no SEEN split
+
+- **WHEN** the service starts with `kafka.callbackTopic` set to `callback` and
+  `kafka.callbackSeenTopic` empty
+- **THEN** all producers SHALL publish callback messages to the `callback`
+  topic AND all consumers SHALL consume from the `callback` topic
+
+#### Scenario: SEEN split enabled
+
+- **WHEN** the service starts with `kafka.callbackSeenTopic` set to
+  `callback-seen`
+- **THEN** the subtree-fetcher SHALL publish `SEEN_ON_NETWORK` and
+  `SEEN_MULTIPLE_NODES` to `callback-seen` AND the block services SHALL
+  continue publishing `STUMP` and `BLOCK_PROCESSED` to `callback` AND the
+  delivery service SHALL run one consumer per topic
+
+#### Scenario: Shared callback topic is never widened
+
+- **WHEN** the partition map used to create and grow topics is computed, with
+  or without `kafka.callbackSeenTopic` configured
+- **THEN** `kafka.callbackTopic` SHALL be absent from that map (created at 1
+  partition) AND `kafka.callbackSeenTopic` SHALL appear in it ONLY when it is
+  explicitly configured
+
+#### Scenario: Dead-letter queue topic
+
+- **WHEN** a callback message exceeds max retry attempts
+- **THEN** the message SHALL be published to the `callback-dlq` topic
+  (configurable via `kafka.callbackDlqTopic`), regardless of which callback
+  topic it was consumed from
+
+#### Scenario: A rejected-as-too-large callback is not dead-lettered on the first attempt
+
+- **WHEN** a callback delivery is rejected because its request body exceeded
+  the receiver's inbound size limit
+- **THEN** the message SHALL be republished for retry while its retry budget
+  allows, and SHALL NOT be published to `callback-dlq` before that budget is
+  exhausted
+
+## ADDED Requirements
+
+### Requirement: Oversize callback bodies are a distinct, recoverable failure class
+
+A callback delivery rejected because the request body exceeded the receiver's
+inbound size limit SHALL be classified as an **oversize** failure — a class
+distinct from both a retryable transport failure and a permanent failure.
+
+The system SHALL treat `413 Request Entity Too Large` as oversize and SHALL
+NOT treat it as a non-retryable 4xx. Every other non-retryable 4xx
+(400, 401, 403, 404, 405, 410, 415, 422) asserts that the request is invalid
+and always will be; 413 asserts only that the request is too large for the
+receiver's CURRENT configuration, which an operator can change without
+altering the message. Conflating the two sent a `STUMP` callback to
+`callback-dlq` with zero retry attempts on 2026-08-11 (dev-ovh-1, 1000 TPS),
+after which the receiver could never complete the block's expected-STUMP set
+and every transaction in that block failed to reach `MINED`.
+
+An oversize failure SHALL take the ordinary retry ladder, so that raising the
+receiver's limit heals the affected block with no further operator action. It
+SHALL NOT count toward the per-callback-URL circuit breaker: a receiver that
+rejects an oversize body is demonstrably reachable, and disabling a
+deployment's single registered callback URL would stop delivery of every
+callback type for every transaction, not only the oversize one.
+
+Where a receiver's limit is known, the system SHALL support a configured
+pre-flight limit (`callback.maxBodyBytes`, env `CALLBACK_MAX_BODY_BYTES`) and
+SHALL NOT send a body exceeding it. The default SHALL be 0 (disabled), because
+the sender cannot know an arbitrary receiver's limit and a non-zero default
+would refuse bodies the receiver would have accepted.
+
+#### Scenario: Receiver rejects a STUMP body as too large
+
+- **WHEN** a `STUMP` callback delivery receives `413 Request Entity Too Large`
+  and retry attempts remain
+- **THEN** the message SHALL be republished to its source topic with an
+  incremented retry count AND SHALL NOT be published to `callback-dlq` AND the
+  per-callback-URL circuit breaker SHALL NOT be advanced
+
+#### Scenario: Oversize retries are exhausted
+
+- **WHEN** an oversize callback exhausts its retry budget
+- **THEN** it SHALL be published to `callback-dlq` AND the per-callback-URL
+  circuit breaker SHALL still NOT be advanced AND the event SHALL be recorded
+  under an outcome distinct from an ordinary dead-lettered callback
+
+#### Scenario: Pre-flight limit configured
+
+- **WHEN** `callback.maxBodyBytes` is greater than zero and a built callback
+  body exceeds it
+- **THEN** the request SHALL NOT be sent AND the delivery SHALL fail as an
+  oversize failure
+
+#### Scenario: Pre-flight limit unset
+
+- **WHEN** `callback.maxBodyBytes` is zero
+- **THEN** no local size limit SHALL be applied and the body SHALL be sent,
+  leaving the receiver to enforce its own limit
+
+### Requirement: Oversize callback failures are observable
+
+An oversize callback failure SHALL be reported at ERROR level naming, at
+minimum, the block hash, the subtree index and the size in bytes of the body
+that was rejected or refused — the three facts required to identify which
+block cannot be finalized and by how much its payload overshot.
+
+The system SHALL expose a metric outcome for oversize rejections, and a
+SEPARATE metric outcome for an oversize failure that has exhausted its retry
+budget, so that "payloads are approaching the limit" and "a block cannot be
+finalized" can be alerted on independently.
+
+The system SHALL additionally warn when a built callback body exceeds a fixed
+early-warning threshold, even when that delivery succeeds, so that payload
+growth is visible before it becomes a delivery failure.
+
+#### Scenario: Oversize rejection is logged and counted
+
+- **WHEN** a callback delivery fails as oversize
+- **THEN** an ERROR SHALL be emitted carrying the block hash, subtree index
+  and body size AND the oversize metric outcome SHALL be incremented
+
+#### Scenario: A stranded block is distinguishable
+
+- **WHEN** an oversize callback exhausts its retry budget
+- **THEN** a distinct ERROR SHALL state that the block cannot be finalized
+  AND a distinct metric outcome SHALL be incremented
+
+#### Scenario: Body size approaching the limit
+
+- **WHEN** a callback body exceeds the early-warning threshold but the
+  delivery succeeds
+- **THEN** a WARN SHALL be emitted naming the block hash, subtree index and
+  body size

--- a/openspec/changes/oversize-callback-recovery/tasks.md
+++ b/openspec/changes/oversize-callback-recovery/tasks.md
@@ -37,6 +37,14 @@
       blob and that dev-ovh-1 runs 128 MiB since
       teranode-argocd-deployments#211
 - [x] 3.5 Surface `maxBodyBytes` / `bodyWarnBytes` in the delivery init log
+- [x] 3.6 Bound the STUMP body cache by total bytes (`bodyCacheMaxBytes`,
+      64 MiB) as well as entry count. The existing 64-entry bound assumed
+      ~545 KB bodies; with arcade's cap now 128 MiB a count-only bound admits
+      64 x 128 MiB ~= 8 GiB resident and OOM-kills the delivery pod, escalating
+      "one block's STUMPs are oversized" into "callback delivery is dead". An
+      over-budget single body is still cached (alone), since refusing it would
+      restore the per-subscriber re-fetch/re-hex/re-marshal work the cache
+      exists to remove
 
 ## 4. Observability
 
@@ -59,7 +67,11 @@
       `TestDeliverCallback_PreflightMaxBodyBytesRefusesThePost`,
       `TestDeliverCallback_PreflightDisabledByDefault`,
       `TestHandleMessage_413RepublishesBeforeAck`,
-      `TestDeliverCallback_BodyWarnThresholdLogs`
+      `TestDeliverCallback_BodyWarnThresholdLogs`,
+      `TestStoreBody_ByteBudgetEvicts`,
+      `TestStoreBody_EntryBudgetStillEvicts`,
+      `TestStoreBody_OversizedSingleBodyIsStillCached`,
+      `TestStoreBody_DuplicateKeyDoesNotDoubleCount`
 - [x] 5.2 `internal/config/config_test.go`:
       `TestLoad_CallbackMaxBodyBytesDefaultsToDisabled`,
       `TestLoad_CallbackMaxBodyBytesEnvOverride`; add

--- a/openspec/changes/oversize-callback-recovery/tasks.md
+++ b/openspec/changes/oversize-callback-recovery/tasks.md
@@ -1,0 +1,94 @@
+# Tasks: oversize-callback-recovery
+
+## 1. Failure classification
+
+- [x] 1.1 Add `oversizeDeliveryError` (carrying `bodyBytes`, `limitBytes`,
+      `statusCode`) with `errOversizeDelivery` / `asOversizeDeliveryError`,
+      documented against the 2026-08-11 dev-ovh-1 incident
+- [x] 1.2 `deliverCallback`: map a `413 Request Entity Too Large` response to
+      the oversize class, ahead of the `isNonRetryable4xx` check
+- [x] 1.3 Remove 413 from `isNonRetryable4xx` so no future caller can
+      silently restore "413 == permanent == DLQ == stranded block"; comment
+      the hazard inline
+
+## 2. Routing
+
+- [x] 2.1 `scheduleRetryOrDLQ`: oversize branch evaluated BEFORE the
+      permanent check — retry while budget remains, DLQ with a distinct
+      `BLOCK STRANDED:` ERROR once exhausted
+- [x] 2.2 Never call `recordCallbackURLFailure` on the oversize path (a
+      single registered arcade URL would be auto-disabled inside one block,
+      killing all callback delivery)
+- [x] 2.3 Extract the retry tail into `scheduleRetry` so the oversize branch
+      and the normal fall-through share one backoff ladder and one
+      durability contract
+
+## 3. Pre-flight size gate
+
+- [x] 3.1 `CallbackConfig.MaxBodyBytes` (yaml `maxBodyBytes`, mapstructure
+      `maxbodybytes`), viper default **0 = disabled**, env
+      `CALLBACK_MAX_BODY_BYTES`
+- [x] 3.2 `deliverCallback`: after the body is finished (cache hit included),
+      refuse to POST when `MaxBodyBytes > 0` and the body exceeds it; same
+      oversize class, `statusCode` 0
+- [x] 3.3 Unconditional WARN above `bodyWarnBytes` (8 MiB const, half
+      arcade's original default) naming block, subtree and size
+- [x] 3.4 Document both in `config.yaml`, including that hex DOUBLES the
+      blob and that dev-ovh-1 runs 128 MiB since
+      teranode-argocd-deployments#211
+- [x] 3.5 Surface `maxBodyBytes` / `bodyWarnBytes` in the delivery init log
+
+## 4. Observability
+
+- [x] 4.1 `metrics.OutcomeOversize` — one per rejected attempt
+- [x] 4.2 `metrics.OutcomeOversizeStranded` — retries exhausted → DLQ; the
+      page-worthy "this block cannot be finalized" signal, deliberately
+      separate from `OutcomeDLQ`
+- [x] 4.3 `logOversize`: single ERROR naming callback URL, type, block hash,
+      subtree index, body size, limit, status, stump ref and retry count
+
+## 5. Tests
+
+- [x] 5.1 `internal/callback/delivery_oversize_test.go`:
+      `TestDeliverCallback_413IsNotPermanent`,
+      `TestIsNonRetryable4xx_413IsExcluded`,
+      `TestProcessDelivery_413DoesNotGoStraightToDLQ` (the regression test:
+      0 DLQ, 1 retry republish, retryCount incremented, breaker untouched),
+      `TestProcessDelivery_413ExhaustedRetriesStrandsLoudlyWithoutTrippingBreaker`,
+      `TestDeliverCallback_413LogsBlockIdentityAndSize`,
+      `TestDeliverCallback_PreflightMaxBodyBytesRefusesThePost`,
+      `TestDeliverCallback_PreflightDisabledByDefault`,
+      `TestHandleMessage_413RepublishesBeforeAck`,
+      `TestDeliverCallback_BodyWarnThresholdLogs`
+- [x] 5.2 `internal/config/config_test.go`:
+      `TestLoad_CallbackMaxBodyBytesDefaultsToDisabled`,
+      `TestLoad_CallbackMaxBodyBytesEnvOverride`; add
+      `CALLBACK_MAX_BODY_BYTES` to `clearConfigEnv`
+
+## 6. OpenSpec
+
+- [x] 6.1 Update `openspec/specs/unified-callback-topic/spec.md` with the
+      oversize class and the qualified DLQ requirement
+- [x] 6.2 Add this change folder (proposal / design / tasks / spec delta)
+
+## 7. Validation
+
+- [x] 7.1 `go build ./...`, `go vet ./...`, `go test ./...`
+- [x] 7.2 `make lint` (golangci-lint + lint-logfields)
+- [x] 7.3 Pre-existing `internal/store` failures (Aerospike `merkle`
+      namespace absent in the dev environment) confirmed identical on
+      `origin/main`
+
+## 8. Follow-up (NOT in this PR)
+
+- [ ] 8.1 Set `CALLBACK_MAX_BODY_BYTES` in `deploy/k8s/callback-delivery.yaml`
+      to match whatever `ARCADE_CALLBACK_MAX_BODY_BYTES` the target
+      environment runs (dev-ovh-1: `134217728`)
+- [ ] 8.2 Alert on `merkle_callback_messages_total{outcome="oversize_stranded"} > 0`
+      (page) and `{outcome="oversize"}` rate (warn)
+- [ ] 8.3 Claim-check STUMP delivery — needs a coordinated arcade change; see
+      `design.md` for the four-step sketch
+- [ ] 8.4 Remove the dead `CALLBACK_STUMP_CACHE_MODE` /
+      `CALLBACK_STUMP_CACHE_LRU_SIZE` / `CALLBACK_STUMP_CACHE_TTL_SEC` entries
+      from `deploy/k8s/*.yaml` and `deploy/k8s/README.md`, or re-wire them —
+      nothing under `internal/` or `cmd/` reads them today

--- a/openspec/specs/unified-callback-topic/spec.md
+++ b/openspec/specs/unified-callback-topic/spec.md
@@ -23,6 +23,54 @@ Producers and consumers SHALL resolve the SEEN topic through a single shared acc
 - **WHEN** a callback message exceeds max retry attempts
 - **THEN** the message SHALL be published to the `callback-dlq` topic (configurable via `kafka.callbackDlqTopic`), regardless of which callback topic it was consumed from
 
+#### Scenario: A rejected-as-too-large callback is not dead-lettered on the first attempt
+- **WHEN** a callback delivery is rejected because its request body exceeded the receiver's inbound size limit
+- **THEN** the message SHALL be republished for retry while its retry budget allows, and SHALL NOT be published to `callback-dlq` before that budget is exhausted
+
+### Requirement: Oversize callback bodies are a distinct, recoverable failure class
+A callback delivery rejected because the request body exceeded the receiver's inbound size limit SHALL be classified as an **oversize** failure — a class distinct from both a retryable transport failure and a permanent failure.
+
+The system SHALL treat `413 Request Entity Too Large` as oversize and SHALL NOT treat it as a non-retryable 4xx. Every other non-retryable 4xx (400, 401, 403, 404, 405, 410, 415, 422) asserts that the request is invalid and always will be; 413 asserts only that the request is too large for the receiver's CURRENT configuration, which an operator can change without altering the message. Conflating the two sent a `STUMP` callback to `callback-dlq` with zero retry attempts on 2026-08-11 (dev-ovh-1, 1000 TPS), after which the receiver could never complete the block's expected-STUMP set and every transaction in that block failed to reach `MINED`.
+
+An oversize failure SHALL take the ordinary retry ladder, so that raising the receiver's limit heals the affected block with no further operator action. It SHALL NOT count toward the per-callback-URL circuit breaker: a receiver that rejects an oversize body is demonstrably reachable, and disabling a deployment's single registered callback URL would stop delivery of every callback type for every transaction, not only the oversize one.
+
+Where a receiver's limit is known, the system SHALL support a configured pre-flight limit (`callback.maxBodyBytes`, env `CALLBACK_MAX_BODY_BYTES`) and SHALL NOT send a body exceeding it. The default SHALL be 0 (disabled), because the sender cannot know an arbitrary receiver's limit and a non-zero default would refuse bodies the receiver would have accepted.
+
+#### Scenario: Receiver rejects a STUMP body as too large
+- **WHEN** a `STUMP` callback delivery receives `413 Request Entity Too Large` and retry attempts remain
+- **THEN** the message SHALL be republished to its source topic with an incremented retry count AND SHALL NOT be published to `callback-dlq` AND the per-callback-URL circuit breaker SHALL NOT be advanced
+
+#### Scenario: Oversize retries are exhausted
+- **WHEN** an oversize callback exhausts its retry budget
+- **THEN** it SHALL be published to `callback-dlq` AND the per-callback-URL circuit breaker SHALL still NOT be advanced AND the event SHALL be recorded under an outcome distinct from an ordinary dead-lettered callback
+
+#### Scenario: Pre-flight limit configured
+- **WHEN** `callback.maxBodyBytes` is greater than zero and a built callback body exceeds it
+- **THEN** the request SHALL NOT be sent AND the delivery SHALL fail as an oversize failure
+
+#### Scenario: Pre-flight limit unset
+- **WHEN** `callback.maxBodyBytes` is zero
+- **THEN** no local size limit SHALL be applied and the body SHALL be sent, leaving the receiver to enforce its own limit
+
+### Requirement: Oversize callback failures are observable
+An oversize callback failure SHALL be reported at ERROR level naming, at minimum, the block hash, the subtree index and the size in bytes of the body that was rejected or refused — the three facts required to identify which block cannot be finalized and by how much its payload overshot.
+
+The system SHALL expose a metric outcome for oversize rejections, and a SEPARATE metric outcome for an oversize failure that has exhausted its retry budget, so that "payloads are approaching the limit" and "a block cannot be finalized" can be alerted on independently.
+
+The system SHALL additionally warn when a built callback body exceeds a fixed early-warning threshold, even when that delivery succeeds, so that payload growth is visible before it becomes a delivery failure.
+
+#### Scenario: Oversize rejection is logged and counted
+- **WHEN** a callback delivery fails as oversize
+- **THEN** an ERROR SHALL be emitted carrying the block hash, subtree index and body size AND the oversize metric outcome SHALL be incremented
+
+#### Scenario: A stranded block is distinguishable
+- **WHEN** an oversize callback exhausts its retry budget
+- **THEN** a distinct ERROR SHALL state that the block cannot be finalized AND a distinct metric outcome SHALL be incremented
+
+#### Scenario: Body size approaching the limit
+- **WHEN** a callback body exceeds the early-warning threshold but the delivery succeeds
+- **THEN** a WARN SHALL be emitted naming the block hash, subtree index and body size
+
 ### Requirement: Retries republish to the source topic
 A retry-eligible callback SHALL be republished to the SAME Kafka topic it was consumed from. Republishing a `SEEN_*` retry onto `kafka.callbackTopic` would place it back behind the `STUMP` / `BLOCK_PROCESSED` traffic the split exists to escape, silently reintroducing head-of-line blocking for callbacks that have already failed once.
 


### PR DESCRIPTION
## The incident

Live on **dev-ovh-1, 2026-08-11, at 1000 TPS**: a block's entire transaction set was **permanently stranded short of `MINED`** because one oversized STUMP callback was dropped instead of retried.

The chain:

1. `callback.DeliveryService` builds a STUMP body — fetch the blob via `stumpStore.Get(msg.StumpRef)`, **hex-encode it (2× inflation)**, JSON-marshal it inline (`internal/callback/delivery.go`, `deliverCallback`).
2. arcade's api-server wraps the inbound body in `http.MaxBytesReader` at `callback.max_body_bytes`, **default 16 MiB** (`arcade config.DefaultCallbackMaxBodyBytes`), and maps overflow to `413 Request Entity Too Large`.
3. At 1000 TPS a single subtree's STUMP crossed that cap after hex inflation. arcade returned **413**.
4. merkle classified the 4xx as **permanent** (`isNonRetryable4xx` → `errPermanentDelivery`) and logged, with **zero retry attempts**:

   ```
   callback permanently failed, publishing to DLQ  type:"STUMP" reason:"permanent"
   ```

   → published to `callback-dlq`.
5. arcade's bump-builder was then stuck forever:

   ```
   BLOCK_PROCESSED is missing expected STUMPs — deferring finalization
   expected_stumps:1  received_stumps:0  missing_subtree_indices:[0]
   ```

   No BUMP was ever built, so **every transaction in that block never reached `MINED`**.
6. `/reprocess` could not recover it — the regenerated STUMP is the same size and 413s again. Deterministic, not transient.

## Root cause

The **classification** is the bug, not the size.

Every other non-retryable 4xx (400/401/403/404/405/410/415/422) asserts *"this request is wrong and always will be"* — bad URL, bad token, unparseable payload. `413` asserts something categorically different: *"this request is too big **for my current configuration**"*. That is an operational condition, curable without changing one byte of the message, by raising the receiver's cap. `isNonRetryable4xx` swept 413 in with the rest, so a curable condition took the permanent path: DLQ on the first attempt, zero retries, and a log line indistinguishable from a misconfigured auth token.

That threw away the only window in which the block could heal itself. Worth noting what was *not* broken: arcade's completeness gate deliberately leaves `processed_at` NULL and its watchdog re-drives `POST /reprocess` indefinitely, so the block stays recoverable **for as long as merkle is still willing to attempt the delivery**. merkle refusing to try at all is what made it terminal.

## What changed

**1. `413` becomes its own delivery-failure class** — `oversizeDeliveryError`, distinct from both `permanentDeliveryError` and a generic retryable failure. It keeps the normal retry budget (5 attempts × 30 s linear ≈ **7.5 minutes** of durable, Kafka-parked retrying), so an operator raising the receiver's cap heals the block with no further action. 413 is also removed from `isNonRetryable4xx` itself, with the hazard commented inline, so no future caller can silently reintroduce *"413 == permanent == DLQ == stranded block"*.

**2. An oversize failure never trips the per-URL circuit breaker.** This was a second, larger bug hiding behind the first. `recordCallbackURLFailure` disables a callback URL after `callback.breakerThreshold` (default **20**) DLQ'd deliveries. arcade registers **one** callback URL for the whole deployment, and a block whose subtrees produce oversize STUMPs generates one DLQ per subtree per subscriber — 20 is reachable *inside a single block*. That would have auto-disabled arcade's callback URL entirely, killing SEEN and BLOCK_PROCESSED delivery for **every** transaction in flight, not just the stranded block's. Strictly worse than the outage being fixed.

**3. Pre-flight size gate** — new `callback.maxBodyBytes` (env `CALLBACK_MAX_BODY_BYTES`), a mirror of the *receiver's* cap. When `> 0` an over-limit body is never POSTed; the failure is diagnosed locally with block hash, subtree index, configured limit and exact byte count, instead of a doomed multi-MiB upload and an opaque 413 from the far end. **Default `0` = disabled**, so the change is inert until configured — merkle cannot know a third-party receiver's cap, and any non-zero default would start refusing bodies the receiver would happily have accepted.

**4. Observability.**
- `merkle_callback_messages_total{outcome="oversize"}` — one per rejected attempt (payloads are hitting the cap).
- `merkle_callback_messages_total{outcome="oversize_stranded"}` — retries exhausted → DLQ. **This is the page-worthy signal**, deliberately separate from the generic `dlq` outcome: it means a block cannot be finalized.
- ERROR at detection naming callback URL, type, block hash, subtree index, body size, limit, status, stump ref, retry count.
- `BLOCK STRANDED:` ERROR at give-up, in those words, with the same identity fields plus the remediation (raise the cap, then `POST /reprocess`).
- Unconditional WARN above a fixed **8 MiB** (`bodyWarnBytes`, half arcade's original default) even when the POST succeeds, so payload growth is visible *before* it becomes an outage. A normal STUMP body is ~545 KB.
- The pre-flight refusal path explicitly records `merkle_callback_payload_size_bytes` (via a new `metrics.ObserveCallbackPayloadSize`), because it never issues a request and would otherwise drop exactly the largest bodies out of the size histogram.

**5. The STUMP body cache is now bounded by bytes, not just entry count** (second commit). `bodyCacheMaxEntries = 64` was sized against ~545 KB bodies, giving the documented "~35 MB" cap. That bound is only safe while entries are a predictable size — and this PR is the proof that they are not. With arcade's cap now at 128 MiB *specifically so bodies that large can be delivered*, a count-only bound admits **64 × 128 MiB ≈ 8 GiB resident**, OOM-killing the callback-delivery pod and escalating "one block's STUMPs are oversized" into "callback delivery is dead for every block". A 64 MiB byte budget (`bodyCacheMaxBytes`) now evicts oldest-first alongside the entry count. The steady state is untouched (64 × ~545 KB ≈ 35 MB fits with room to spare). A single body larger than the whole budget is still cached, alone — evicting it on insert would restore exactly the per-subscriber re-fetch/re-hex/re-marshal duplication the cache exists to remove, which is most expensive precisely when the body is largest.

## What I deliberately did NOT change

- **Encoding stays hex.** base64 would cut the body from 2× to 1.33× of the blob, but arcade's `stump` field is `models.HexBytes` with a custom `UnmarshalJSON` that calls `hex.DecodeString`. base64 gives `400 invalid request body` — or, for a string that happens to be even-length all-hex, **silently decodes to the wrong bytes**. This is a coordinated arcade-side change, not a merkle-side one.
- **No gzip.** arcade has no gzip middleware, and Go's `net/http` does not transparently decompress request bodies, so a `Content-Encoding: gzip` body reaches `json.Decoder` as raw gzip and yields an opaque `400`. Independently, a STUMP is a BRC-74 path made almost entirely of 32-byte hashes — near incompressible — so gzip would only recover the ~2× hex overhead that base64 recovers more cheaply.
- **No claim-check delivery to arcade.** See the finding below; it needs an arcade-side change with real failure-mode surface, and the sketch is written up in `openspec/changes/oversize-callback-recovery/design.md`.
- **Oversize still reaches the DLQ once the retry budget is spent.** Parking it in Kafka indefinitely would head-of-line-block `kafka.callbackTopic`, which is pinned at **1 partition** so `BLOCK_PROCESSED` stays ordered behind its `STUMP`s. Stranding one block is bad; stalling every block's callbacks is worse. The block stays recoverable regardless via arcade's watchdog once the cap is raised.
- **`internal/datahub/client.go` has its own `isNonRetryable4xx`** — untouched. Different subsystem (outbound block fetches), where a 413 has no analogous meaning.

## Finding: the claim-check path

Investigated per the brief; reporting honestly because part of the premise turned out to be wrong.

- merkle **already** claim-checks STUMPs, but **internally only**: `CallbackTopicMessage` carries `StumpRef`, and the delivery service resolves it through `store.StumpStore` (the blob store, `blobStore.url`) rather than putting the blob on the Kafka topic. That ref never leaves merkle.
- arcade has **no counterpart at all**: no `stumpRef` / `stump_url` / `ref` field on `models.CallbackMessage`, and no code path anywhere that fetches a STUMP from anywhere. Its only STUMP ingress is the inline hex `stump` field, which `handleStump` writes synchronously to its own store — and that synchronous write is *why* a 200 on the callback is arcade's durability guarantee. Implementing claim-check there is greenfield.
- **`CALLBACK_STUMP_CACHE_MODE=aerospike` is dead configuration.** It appears in `deploy/k8s/{block-processor,callback-delivery,subtree-worker}.yaml` and `deploy/k8s/README.md`, but **nothing under `internal/` or `cmd/` reads it** (nor `CALLBACK_STUMP_CACHE_LRU_SIZE` / `CALLBACK_STUMP_CACHE_TTL_SEC`). It is residue from the `k8s-distributed-stump-cache` change; the shipped claim check is the blob store, not an Aerospike stump cache. Setting it has no effect on anything today. Flagged as follow-up task 8.4.

So "wiring/finishing an existing capability" was not available — a real claim-check needs a new authenticated `GET /api/stump/{ref}` on merkle, a negotiated additive `stumpUrl` field, and a new fetch path + SSRF guard + failure semantics in arcade. Four-step sketch in `design.md`.

## Tests

New `internal/callback/delivery_oversize_test.go` (mirrors `delivery_test.go` conventions — `mockSyncProducer`, `kafka.NewTestProducer`, struct-literal service construction, httptest servers):

| Test | Pins |
|---|---|
| `TestProcessDelivery_413DoesNotGoStraightToDLQ` | **the regression test** — 0 DLQ messages, 1 retry republish, retry count incremented, breaker untouched |
| `TestDeliverCallback_413IsNotPermanent` | classification: `!isPermanentDeliveryError`, is `oversizeDeliveryError`, carries status + size |
| `TestIsNonRetryable4xx_413IsExcluded` | 413 excluded; 400/401/403/404/405/410/415/422 still permanent; 408/429 still retryable |
| `TestProcessDelivery_413ExhaustedRetriesStrandsLoudlyWithoutTrippingBreaker` | terminal case: DLQ, `oversize_stranded` metric, breaker still untouched, `reason:"oversize"` ERROR with block/subtree/size/status |
| `TestDeliverCallback_413LogsBlockIdentityAndSize` | the observability requirement, field by field |
| `TestDeliverCallback_PreflightMaxBodyBytesRefusesThePost` | receiver sees **zero** requests; oversize class; `statusCode 0`; limit + size in the log |
| `TestDeliverCallback_PreflightDisabledByDefault` | the non-breaking default |
| `TestHandleMessage_413RepublishesBeforeAck` | durability contract: nil only after the republish is acked; republish failure → non-nil so the offset stays uncommitted |
| `TestDeliverCallback_BodyWarnThresholdLogs` | WARN above 8 MiB on a *successful* delivery, exercised through the real blob → hex path |
| `TestStoreBody_ByteBudgetEvicts` | byte budget binds before the count limit; `bodyBytes` stays an exact running sum; FIFO order |
| `TestStoreBody_EntryBudgetStillEvicts` | the original count bound still applies to small bodies |
| `TestStoreBody_OversizedSingleBodyIsStillCached` | an over-budget body is cached alone, not refused |
| `TestStoreBody_DuplicateKeyDoesNotDoubleCount` | the incremental-accounting bug guard |

Plus `TestLoad_CallbackMaxBodyBytesDefaultsToDisabled` / `TestLoad_CallbackMaxBodyBytesEnvOverride` in `internal/config/config_test.go`.

**The tests were verified to actually pin the fix, not just pass alongside it.** With the 413 classification reverted (413 restored to `isNonRetryable4xx`, oversize branch deleted), **6 of 9** fail — including the two load-bearing assertions, `"a 413 must not be DLQ'd on the first attempt; got 1 DLQ message(s)"` and `"the per-URL circuit breaker must never advance on oversize, got 1 failures"`. Reverting the pre-flight/warn gate fails the remaining two. `TestDeliverCallback_PreflightDisabledByDefault` correctly passes under both reverts — it guards the default rather than pinning new code.

Results:

- `go build ./...` — clean
- `go vet ./...` — clean
- `make lint` (golangci-lint + `lint-logfields`) — **0 issues**
- `go test -race ./internal/callback/... ./internal/config/... ./internal/metrics/...` — clean
- `go test ./...` — all green **except** `internal/store`, which fails on 11 Aerospike tests with `INVALID_NAMESPACE … Namespace not found in partition map: merkle`. **Confirmed identical on `origin/main`** in a clean worktree — the dev Aerospike here lacks the `merkle` namespace. Same 11 test names, same error, both before and after this change.

## OpenSpec

- `openspec/specs/unified-callback-topic/spec.md` — added *Oversize callback bodies are a distinct, recoverable failure class* and *Oversize callback failures are observable*; qualified the DLQ scenario so an oversize body must exhaust its retry budget first.
- `openspec/changes/oversize-callback-recovery/` — proposal / design / tasks / spec delta, mirroring `seen-callback-topic-split`.

## Operator notes

- arcade's cap was raised to **128 MiB** on dev-ovh-1 as an interim mitigation (`teranode-argocd-deployments#211`). That remains a band-aid — the payload grows with subtree size — but it is now backed by a failure mode that retries, logs loudly, and can be alerted on.
- **Recommended:** set `CALLBACK_MAX_BODY_BYTES=134217728` in `deploy/k8s/callback-delivery.yaml` to mirror it, so an overshoot is diagnosed here with full block/subtree context rather than as an opaque 413.
- **Alerts to add:** page on `merkle_callback_messages_total{outcome="oversize_stranded"} > 0`; warn on the rate of `{outcome="oversize"}`; trend `merkle_callback_payload_size_bytes` against the receiver's cap.

https://claude.ai/code/session_01QMqfayz1Uon8apbfccGa97
