### PR TITLE
[Store] Align ThresholdReached comment with >= semantics

### DIFF
--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -3,7 +3,7 @@ package store
 // IncrementResult is returned by SeenCounterStore.Increment.
 type IncrementResult struct {
 	NewCount         int
-	ThresholdReached bool // true only when count first equals threshold (not above)
+	ThresholdReached bool // true only when count first reaches or exceeds the threshold
 }
 
 // AccumulatedCallbackEntry holds data for one subtree's contribution to a


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What Changed

* Updated the `IncrementResult.ThresholdReached` field comment in `internal/store/types.go` so it documents `>=` / first-reaches-or-exceeds semantics instead of exact equality.

## Why It Was Necessary

Both seen-counter implementations (`internal/store/seen_counter.go` and `internal/store/sql/seen_counter.go`) fire when `count >= threshold` on the first transition, not only when `count == threshold`. The previous comment could mislead maintainers if a count ever jumps past the threshold in one operation.

Fixes #60

## Testing Performed

* Comment-only change; no behavior change.
* Confirmed implementations use `newSize >= s.threshold` / `count >= s.threshold`.
* No new tests; existing seen-counter tests already cover first-fire and subsequent-false behavior.

## Impact / Risk

* **Breaking Change**: None
* **Risk**: None — documentation only
* **Behavior**: Unchanged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e422f8e-81b1-4fdb-8b2a-f72d36f0ad1c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e422f8e-81b1-4fdb-8b2a-f72d36f0ad1c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

