### PR TITLE
[Store] Join all registry closer errors on Close

### DIFF
--- a/internal/store/registry.go
+++ b/internal/store/registry.go
@@ -1,5 +1,7 @@
 package store
 
+import "errors"
+
 // Registry bundles every store needed by a service. Services read the fields
 // they need (typed as interfaces) so they stay backend-agnostic. Close()
 // releases any backend-owned resources (Aerospike client, SQL connection pool,
@@ -44,12 +46,12 @@ func (r *Registry) AddCloser(fn func() error) {
 // are collected and returned as a joined error so one failure doesn't hide
 // another.
 func (r *Registry) Close() error {
-	var firstErr error
+	var errs []error
 	for i := len(r.closers) - 1; i >= 0; i-- {
-		if err := r.closers[i](); err != nil && firstErr == nil {
-			firstErr = err
+		if err := r.closers[i](); err != nil {
+			errs = append(errs, err)
 		}
 	}
 	r.closers = nil
-	return firstErr
+	return errors.Join(errs...)
 }

--- a/internal/store/registry_test.go
+++ b/internal/store/registry_test.go
@@ -1,0 +1,60 @@
+package store
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestRegistry_CloseJoinsCloserErrors(t *testing.T) {
+	reg := &Registry{}
+	errA := errors.New("close a")
+	errB := errors.New("close b")
+	var order []string
+
+	reg.AddCloser(func() error {
+		order = append(order, "a")
+		return errA
+	})
+	reg.AddCloser(func() error {
+		order = append(order, "b")
+		return errB
+	})
+	reg.AddCloser(func() error {
+		order = append(order, "ok")
+		return nil
+	})
+
+	err := reg.Close()
+	if err == nil {
+		t.Fatal("expected joined closer errors, got nil")
+	}
+	if !errors.Is(err, errA) {
+		t.Errorf("joined error missing first closer: %v", err)
+	}
+	if !errors.Is(err, errB) {
+		t.Errorf("joined error missing second closer: %v", err)
+	}
+
+	wantOrder := []string{"ok", "b", "a"}
+	if len(order) != len(wantOrder) {
+		t.Fatalf("closer order %v, want %v", order, wantOrder)
+	}
+	for i := range wantOrder {
+		if order[i] != wantOrder[i] {
+			t.Fatalf("closer order %v, want %v", order, wantOrder)
+		}
+	}
+
+	if err := reg.Close(); err != nil {
+		t.Errorf("second Close after clearing closers: %v", err)
+	}
+}
+
+func TestRegistry_CloseNilWhenNoErrors(t *testing.T) {
+	reg := &Registry{}
+	reg.AddCloser(nil)
+	reg.AddCloser(func() error { return nil })
+	if err := reg.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What Changed

* `Registry.Close` now collects every closer error with `errors.Join` instead of returning only the first failure.
* Closers still run in reverse registration order; later failures no longer hide earlier ones.
* Added unit tests covering joined errors, reverse invocation order, nil closers, and a second `Close` after cleanup.

## Why It Was Necessary

The `Close` comment promised joined errors so one cleanup failure would not hide another, but the implementation kept only the first error. Shutdown diagnostics could drop secondary backend close failures.

Fixes #59

## Testing Performed

* `go test ./internal/store/ -run TestRegistry_Close` — pass (`TestRegistry_CloseJoinsCloserErrors`, `TestRegistry_CloseNilWhenNoErrors`).

## Impact / Risk

* **Breaking Change**: None for successful shutdown. Callers that type-assert a single closer error should use `errors.Is` / `errors.As` (standard for `errors.Join`).
* **Risk**: Low — same closers still run; only the returned error value changes when two or more fail.
* **Behavior**: Multiple closer failures are now all visible on the returned error.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e422f8e-81b1-4fdb-8b2a-f72d36f0ad1c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e422f8e-81b1-4fdb-8b2a-f72d36f0ad1c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

