### PR TITLE
[Dashboard] Render merkle-root verify output via textContent

### DIFF
--- a/internal/api/dashboard.html
+++ b/internal/api/dashboard.html
@@ -729,15 +729,26 @@
                         (inputLower === reversedRoot && inputLower !== computedRoot ? ' (matched in display byte order)' : '');
                 } else {
                     resultBox.style.background = '#1c0e0e'; resultBox.style.border = '1px solid #da3633'; resultBox.style.color = '#f85149';
-                    resultBox.innerHTML = '<strong>&#10007; Invalid ' + formatName + '</strong> &mdash; Computed merkle root does not match.' +
-                        '<br>Expected: ' + rootInput +
-                        '<br>Computed: ' + computedRoot +
-                        '<br>Computed (display order): ' + reversedRoot;
+                    resultBox.textContent = '';
+                    var invalidTitle = document.createElement('strong');
+                    invalidTitle.textContent = '\u2717 Invalid ' + formatName;
+                    resultBox.appendChild(invalidTitle);
+                    resultBox.appendChild(document.createTextNode(' \u2014 Computed merkle root does not match.'));
+                    resultBox.appendChild(document.createElement('br'));
+                    resultBox.appendChild(document.createTextNode('Expected: ' + rootInput));
+                    resultBox.appendChild(document.createElement('br'));
+                    resultBox.appendChild(document.createTextNode('Computed: ' + computedRoot));
+                    resultBox.appendChild(document.createElement('br'));
+                    resultBox.appendChild(document.createTextNode('Computed (display order): ' + reversedRoot));
                 }
             } catch (e) {
                 resultBox.style.display = '';
                 resultBox.style.background = '#1c0e0e'; resultBox.style.border = '1px solid #da3633'; resultBox.style.color = '#f85149';
-                resultBox.innerHTML = '<strong>Verification error:</strong> ' + e.message;
+                resultBox.textContent = '';
+                var errTitle = document.createElement('strong');
+                errTitle.textContent = 'Verification error:';
+                resultBox.appendChild(errTitle);
+                resultBox.appendChild(document.createTextNode(' ' + e.message));
             }
         }
 

--- a/tools/debug-dashboard/templates/stump.html
+++ b/tools/debug-dashboard/templates/stump.html
@@ -650,17 +650,28 @@ async function verifyMerkleRoot(bump) {
             resultBox.style.background = '#1c0e0e';
             resultBox.style.border = '1px solid #da3633';
             resultBox.style.color = '#f85149';
-            resultBox.innerHTML = '<strong>&#10007; Invalid ' + formatName + '</strong> &mdash; Computed merkle root does not match.' +
-                '<br>Expected: ' + rootInput +
-                '<br>Computed: ' + computedRoot +
-                '<br>Computed (display order): ' + reversedRoot;
+            resultBox.textContent = '';
+            var invalidTitle = document.createElement('strong');
+            invalidTitle.textContent = '\u2717 Invalid ' + formatName;
+            resultBox.appendChild(invalidTitle);
+            resultBox.appendChild(document.createTextNode(' \u2014 Computed merkle root does not match.'));
+            resultBox.appendChild(document.createElement('br'));
+            resultBox.appendChild(document.createTextNode('Expected: ' + rootInput));
+            resultBox.appendChild(document.createElement('br'));
+            resultBox.appendChild(document.createTextNode('Computed: ' + computedRoot));
+            resultBox.appendChild(document.createElement('br'));
+            resultBox.appendChild(document.createTextNode('Computed (display order): ' + reversedRoot));
         }
     } catch (e) {
         resultBox.style.display = '';
         resultBox.style.background = '#1c0e0e';
         resultBox.style.border = '1px solid #da3633';
         resultBox.style.color = '#f85149';
-        resultBox.innerHTML = '<strong>Verification error:</strong> ' + e.message;
+        resultBox.textContent = '';
+        var errTitle = document.createElement('strong');
+        errTitle.textContent = 'Verification error:';
+        resultBox.appendChild(errTitle);
+        resultBox.appendChild(document.createTextNode(' ' + e.message));
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What Changed

* The STUMP visualizer mismatch and error paths now build the verification result with `textContent` / DOM text nodes instead of concatenating `rootInput` (and `e.message`) into `innerHTML`.
* Applied in both copies of the visualizer: `tools/debug-dashboard/templates/stump.html` and `internal/api/dashboard.html`.

## Why It Was Necessary

A pasted merkle-root value was interpolated into `innerHTML` without escaping. A malicious string in the root field could execute script in the debug dashboard page.

Fixes #66
Related: #65

## Testing Performed

* Markup-only change in the verification-failure path; other dashboard `innerHTML` usage is unchanged.
* Confirmed the mismatch path no longer concatenates `rootInput` into HTML.

## Impact / Risk

* **Breaking Change**: None
* **Risk**: Low — visual output is the same (bold title, line breaks, monospace values); only the DOM construction method changed.
* **Scope**: Limited to the invalid-root and verification-error result boxes. Success-path `innerHTML` still uses computed hex roots only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e422f8e-81b1-4fdb-8b2a-f72d36f0ad1c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e422f8e-81b1-4fdb-8b2a-f72d36f0ad1c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

