### PR TITLE
[Config] Fail when an explicit CONFIG_FILE is missing

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -69,6 +69,8 @@ Configuration is loaded in this priority order (highest wins):
 2. **YAML config file** (`config.yaml` by default, override path with `CONFIG_FILE`)
 3. **Built-in defaults**
 
+If `CONFIG_FILE` is set, the file must exist; a missing explicit path is a startup error. A missing default `config.yaml` is ignored.
+
 ---
 
 ## All-in-One vs Microservice Mode
@@ -88,7 +90,7 @@ Set via `MODE` env var or the `mode` YAML key.
 
 | Variable       | Default        | Description                                       |
 |----------------|----------------|---------------------------------------------------|
-| `CONFIG_FILE`  | `config.yaml`  | Path to YAML configuration file.                  |
+| `CONFIG_FILE`  | `config.yaml`  | Path to YAML configuration file. Missing explicit paths fail startup. |
 | `MODE`         | `all-in-one`   | Operating mode: `all-in-one` or `microservice`.   |
 
 ### API

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1087,6 +1087,11 @@ func bindEnvVars(v *viper.Viper) {
 
 // Load reads configuration from defaults, YAML file, and environment variables.
 // Priority order: env vars > YAML file > defaults.
+//
+// When CONFIG_FILE is set, a missing or unreadable file is fatal so a typo or
+// missing mount cannot silently start the service on built-in defaults. When
+// CONFIG_FILE is unset, a missing default config.yaml is ignored and Load
+// continues with defaults and environment variables.
 func Load() (*Config, error) {
 	v := viper.New()
 
@@ -1098,23 +1103,20 @@ func Load() (*Config, error) {
 
 	// Configure config file path.
 	// Check CONFIG_FILE env var directly (not via Viper since it's not a config key).
-	if configFile := os.Getenv("CONFIG_FILE"); configFile != "" {
-		v.SetConfigFile(configFile)
+	explicitFile := os.Getenv("CONFIG_FILE")
+	if explicitFile != "" {
+		v.SetConfigFile(explicitFile)
 	} else {
 		v.SetConfigName("config")
 		v.SetConfigType("yaml")
 		v.AddConfigPath(".")
 	}
 
-	// Read config file (ignore file-not-found).
 	if err := v.ReadInConfig(); err != nil {
 		var notFoundErr viper.ConfigFileNotFoundError
-		if errors.As(err, &notFoundErr) {
-			// No config file found — use defaults + env vars only.
-		} else if os.IsNotExist(err) {
-			// Explicit CONFIG_FILE path doesn't exist — use defaults + env vars only.
+		if explicitFile == "" && (errors.As(err, &notFoundErr) || os.IsNotExist(err)) {
+			// No default config.yaml — use defaults + env vars only.
 		} else {
-			// File exists but is invalid (parse error).
 			return nil, fmt.Errorf("failed to read config file: %w", err)
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"log/slog"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -59,8 +60,7 @@ func clearConfigEnv(t *testing.T) {
 
 func TestLoad_Defaults(t *testing.T) {
 	clearConfigEnv(t)
-	_ = os.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")
-	defer func() { _ = os.Unsetenv("CONFIG_FILE") }()
+	isolateFromRepoConfig(t)
 
 	cfg, err := Load()
 	if err != nil {
@@ -195,8 +195,7 @@ func TestLoad_Defaults(t *testing.T) {
 
 func TestLoad_EnvOverrides(t *testing.T) {
 	clearConfigEnv(t)
-	_ = os.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")
-	defer func() { _ = os.Unsetenv("CONFIG_FILE") }()
+	isolateFromRepoConfig(t)
 
 	_ = os.Setenv("MODE", "microservice")
 	_ = os.Setenv("API_PORT", "9090")
@@ -374,7 +373,7 @@ func TestLoad_BlobStoreSweepValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			clearConfigEnv(t)
-			t.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")
+			isolateFromRepoConfig(t)
 			for k, v := range tt.env {
 				t.Setenv(k, v)
 			}
@@ -468,10 +467,32 @@ func TestLoad_InvalidYAMLReturnsError(t *testing.T) {
 	}
 }
 
+func TestLoad_MissingExplicitConfigFileIsFatal(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("CONFIG_FILE", filepath.Join(t.TempDir(), "does-not-exist.yaml"))
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error when CONFIG_FILE points at a missing file")
+	}
+}
+
+func TestLoad_MissingDefaultConfigFileUsesDefaults(t *testing.T) {
+	clearConfigEnv(t)
+	t.Chdir(t.TempDir())
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() with no config.yaml should succeed: %v", err)
+	}
+	if cfg.Mode != "all-in-one" {
+		t.Errorf("Mode: expected %q, got %q", "all-in-one", cfg.Mode)
+	}
+}
+
 func TestLoad_P2PMsgBusDefaults(t *testing.T) {
 	clearConfigEnv(t)
-	_ = os.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")
-	defer func() { _ = os.Unsetenv("CONFIG_FILE") }()
+	isolateFromRepoConfig(t)
 
 	cfg, err := Load()
 	if err != nil {
@@ -494,12 +515,9 @@ func TestLoad_P2PMsgBusDefaults(t *testing.T) {
 
 func TestLoad_P2PDHTModeEnvOverride(t *testing.T) {
 	clearConfigEnv(t)
-	_ = os.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")
+	isolateFromRepoConfig(t)
 	_ = os.Setenv("P2P_DHT_MODE", "server")
-	defer func() {
-		_ = os.Unsetenv("CONFIG_FILE")
-		_ = os.Unsetenv("P2P_DHT_MODE")
-	}()
+	defer func() { _ = os.Unsetenv("P2P_DHT_MODE") }()
 
 	cfg, err := Load()
 	if err != nil {
@@ -513,8 +531,7 @@ func TestLoad_P2PDHTModeEnvOverride(t *testing.T) {
 
 func TestLoad_LogLevelDefault(t *testing.T) {
 	clearConfigEnv(t)
-	_ = os.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")
-	defer func() { _ = os.Unsetenv("CONFIG_FILE") }()
+	isolateFromRepoConfig(t)
 
 	cfg, err := Load()
 	if err != nil {
@@ -528,12 +545,9 @@ func TestLoad_LogLevelDefault(t *testing.T) {
 
 func TestLoad_LogLevelEnvOverride(t *testing.T) {
 	clearConfigEnv(t)
-	_ = os.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")
+	isolateFromRepoConfig(t)
 	_ = os.Setenv("LOG_LEVEL", "debug")
-	defer func() {
-		_ = os.Unsetenv("CONFIG_FILE")
-		_ = os.Unsetenv("LOG_LEVEL")
-	}()
+	defer func() { _ = os.Unsetenv("LOG_LEVEL") }()
 
 	cfg, err := Load()
 	if err != nil {
@@ -552,7 +566,7 @@ func TestLoad_LogLevelEnvOverride(t *testing.T) {
 // cooldown even though the peer was fine).
 func TestLoad_DataHubPeerHealthDefaults(t *testing.T) {
 	clearConfigEnv(t)
-	t.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")
+	isolateFromRepoConfig(t)
 
 	cfg, err := Load()
 	if err != nil {
@@ -575,7 +589,7 @@ func TestLoad_DataHubPeerHealthDefaults(t *testing.T) {
 // env var ignored.
 func TestLoad_DataHubPeerHealthEnvBinding(t *testing.T) {
 	clearConfigEnv(t)
-	t.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")
+	isolateFromRepoConfig(t)
 	t.Setenv("DATAHUB_PEER_HEALTH_FAILURE_THRESHOLD", "5")
 	t.Setenv("DATAHUB_PEER_HEALTH_COOLDOWN_SEC", "120")
 	t.Setenv("DATAHUB_PEER_HEALTH_STALE404_GRACE_SEC", "900")
@@ -598,7 +612,7 @@ func TestLoad_DataHubPeerHealthEnvBinding(t *testing.T) {
 
 func TestLoad_TelemetryDefaults(t *testing.T) {
 	clearConfigEnv(t)
-	t.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")
+	isolateFromRepoConfig(t)
 
 	cfg, err := Load()
 	if err != nil {
@@ -642,7 +656,7 @@ func TestLoad_TelemetryDefaults(t *testing.T) {
 // binding entry would silently leave the env var ignored.
 func TestLoad_TelemetryEnvBinding(t *testing.T) {
 	clearConfigEnv(t)
-	t.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")
+	isolateFromRepoConfig(t)
 	t.Setenv(envTelemetryEnabled, "true")
 	t.Setenv("TELEMETRY_ENDPOINT", "collector:4317")
 	t.Setenv(envTelemetryProtocol, "http")
@@ -762,7 +776,7 @@ func TestLoad_TelemetryValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			clearConfigEnv(t)
-			t.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")
+			isolateFromRepoConfig(t)
 			for k, v := range tt.env {
 				t.Setenv(k, v)
 			}
@@ -814,8 +828,7 @@ func TestParseLogLevel(t *testing.T) {
 // flag is an emergency off-switch, not a rollout gate.
 func TestLoad_EmitExpectedStumpSet_DefaultTrue(t *testing.T) {
 	clearConfigEnv(t)
-	_ = os.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")
-	defer func() { _ = os.Unsetenv("CONFIG_FILE") }()
+	isolateFromRepoConfig(t)
 
 	cfg, err := Load()
 	if err != nil {
@@ -844,7 +857,7 @@ func TestLoad_EmitExpectedStumpSet_EnvOverride(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			clearConfigEnv(t)
-			_ = os.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")
+			isolateFromRepoConfig(t)
 			_ = os.Setenv("BLOCK_EMIT_EXPECTED_STUMP_SET", tt.envVal)
 			defer clearConfigEnv(t)
 
@@ -885,7 +898,7 @@ func TestBlockConfig_EmitExpectedStumpSetEnabled_ZeroValue(t *testing.T) {
 // failure for a guaranteed one.
 func TestLoad_CallbackMaxBodyBytesDefaultsToDisabled(t *testing.T) {
 	clearConfigEnv(t)
-	_ = os.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")
+	isolateFromRepoConfig(t)
 	defer clearConfigEnv(t)
 
 	cfg, err := Load()
@@ -904,7 +917,7 @@ func TestLoad_CallbackMaxBodyBytesDefaultsToDisabled(t *testing.T) {
 // 413 from the far end.
 func TestLoad_CallbackMaxBodyBytesEnvOverride(t *testing.T) {
 	clearConfigEnv(t)
-	_ = os.Setenv("CONFIG_FILE", "/tmp/nonexistent-config-file.yaml")
+	isolateFromRepoConfig(t)
 	_ = os.Setenv("CALLBACK_MAX_BODY_BYTES", "134217728")
 	defer clearConfigEnv(t)
 

--- a/internal/config/store_test.go
+++ b/internal/config/store_test.go
@@ -16,6 +16,15 @@ func writeTempConfig(t *testing.T, body string) string {
 	return path
 }
 
+// isolateFromRepoConfig points CONFIG_FILE at an empty temp YAML so Load
+// does not pick up the repo-root config.yaml. Tests that want defaults or
+// env-only overrides should call this after clearConfigEnv. A missing
+// explicit CONFIG_FILE is fatal, so this must be a real file.
+func isolateFromRepoConfig(t *testing.T) {
+	t.Helper()
+	t.Setenv("CONFIG_FILE", writeTempConfig(t, ""))
+}
+
 func loadWith(t *testing.T, env map[string]string, yaml string) (*Config, error) {
 	t.Helper()
 	for k, v := range env {

--- a/internal/config/topic_partitions_test.go
+++ b/internal/config/topic_partitions_test.go
@@ -136,7 +136,7 @@ func TestKafkaConfig_SeenCallbackTopic(t *testing.T) {
 // with no config file and no env var, SEEN callbacks still resolve to
 // 'callback' and the shared topic is still absent from the partition map.
 func TestLoad_CallbackSeenTopicDefaultsInert(t *testing.T) {
-	t.Setenv("CONFIG_FILE", "/nonexistent/config.yaml")
+	isolateFromRepoConfig(t)
 	cfg, err := Load()
 	if err != nil {
 		t.Fatalf("Load: %v", err)
@@ -158,7 +158,7 @@ func TestLoad_CallbackSeenTopicDefaultsInert(t *testing.T) {
 // TestLoad_CallbackSeenTopicEnvOverride verifies the env plumbing operators
 // will actually use to turn the split on.
 func TestLoad_CallbackSeenTopicEnvOverride(t *testing.T) {
-	t.Setenv("CONFIG_FILE", "/nonexistent/config.yaml")
+	isolateFromRepoConfig(t)
 	t.Setenv("KAFKA_CALLBACK_SEEN_TOPIC", topicCallbackSeen)
 	t.Setenv("KAFKA_CALLBACK_SEEN_PARTITIONS", "6")
 	cfg, err := Load()

--- a/internal/config/topic_retention_test.go
+++ b/internal/config/topic_retention_test.go
@@ -70,7 +70,7 @@ func TestKafkaConfig_TopicRetention(t *testing.T) {
 // broker default (dev-ovh-1: 15 minutes) can't silently apply to topics this
 // service creates.
 func TestLoad_TopicRetentionDefaults(t *testing.T) {
-	t.Setenv("CONFIG_FILE", "/nonexistent/config.yaml")
+	isolateFromRepoConfig(t)
 	cfg, err := Load()
 	if err != nil {
 		t.Fatalf("Load: %v", err)
@@ -85,7 +85,7 @@ func TestLoad_TopicRetentionDefaults(t *testing.T) {
 
 // TestLoad_TopicRetentionEnvOverride verifies the env var plumbing.
 func TestLoad_TopicRetentionEnvOverride(t *testing.T) {
-	t.Setenv("CONFIG_FILE", "/nonexistent/config.yaml")
+	isolateFromRepoConfig(t)
 	t.Setenv("KAFKA_TOPIC_RETENTION_MS", "3600000")
 	t.Setenv("KAFKA_DLQ_RETENTION_MS", "86400000")
 	cfg, err := Load()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What Changed

* `config.Load` now treats a missing or unreadable explicit `CONFIG_FILE` as fatal.
* File-not-found is ignored only when no path was requested (default `config.yaml` search).
* Tests that previously pointed `CONFIG_FILE` at a nonexistent path now use an empty temp file so they still isolate from the repo `config.yaml`.
* Added coverage for the fatal explicit-path case and the missing-default-file fallback.
* Documented the behavior in `docs/deployment.md`.

## Why It Was Necessary

A typo or missing mounted config could start the service on built-in defaults (local endpoints, default topics, all-in-one mode), producing confusing outages or misrouted traffic.

Fixes #38

## Testing Performed

* `go test ./internal/config/` — pass, including `TestLoad_MissingExplicitConfigFileIsFatal` and `TestLoad_MissingDefaultConfigFileUsesDefaults`.

## Impact / Risk

* **Breaking Change**: Deployments that set `CONFIG_FILE` to a path that does not exist will now fail startup instead of silently using defaults. That is the intended fix.
* **Risk**: Medium for misconfigured environments that relied on the old ignore behavior; low for correctly mounted configs.
* **Default path**: Unchanged — a missing `./config.yaml` still falls back to env vars and built-in defaults.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e422f8e-81b1-4fdb-8b2a-f72d36f0ad1c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e422f8e-81b1-4fdb-8b2a-f72d36f0ad1c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

