### PR TITLE
fix(seen-counter): bound seen-counter growth with a re-stamped TTL

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -119,6 +119,13 @@ aerospike:
   # Env: AEROSPIKE_SEEN_SET
   seenSet: merkle_seen_counters
 
+  # TTL in seconds for per-txid seen counters, re-stamped on every increment
+  # (an inactivity window). Mine-time cleanup only deletes counters for
+  # registered txids that get mined; this TTL reclaims counters for txids
+  # that never make it into a block so the seen set cannot grow without bound.
+  # Env: AEROSPIKE_SEEN_COUNTER_TTL_SEC
+  seenCounterTTLSec: 86400
+
   # Aerospike set used for callback delivery deduplication records.
   # Env: AEROSPIKE_CALLBACK_DEDUP_SET
   callbackDedupSet: merkle_callback_dedup

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -187,11 +187,11 @@ type AerospikeConfig struct {
 	// node's connection pool becoming the bottleneck).
 	Host string `yaml:"host" mapstructure:"host"`
 	// Seeds is a list of seed node addresses. When non-empty, Host is ignored.
-	Seeds               []string `yaml:"seeds"                mapstructure:"seeds"`
-	Port                int      `yaml:"port"                 mapstructure:"port"`
-	Namespace           string   `yaml:"namespace"            mapstructure:"namespace"`
-	SetName             string   `yaml:"setName"              mapstructure:"setname"`
-	SeenSet             string   `yaml:"seenSet"              mapstructure:"seenset"`
+	Seeds     []string `yaml:"seeds"                mapstructure:"seeds"`
+	Port      int      `yaml:"port"                 mapstructure:"port"`
+	Namespace string   `yaml:"namespace"            mapstructure:"namespace"`
+	SetName   string   `yaml:"setName"              mapstructure:"setname"`
+	SeenSet   string   `yaml:"seenSet"              mapstructure:"seenset"`
 	// SeenCounterTTLSec bounds the lifetime of per-txid seen counters. The
 	// mine-time BatchDelete only removes counters for REGISTERED txids that
 	// actually get mined; counters for unregistered or never-mined txids (or
@@ -199,9 +199,9 @@ type AerospikeConfig struct {
 	// growing the seen set without bound until the namespace hit stop-writes.
 	// The TTL is re-stamped on every increment, so it is an inactivity window:
 	// a counter expires only after ttlSec without a new subtree sighting.
-	SeenCounterTTLSec   int      `yaml:"seenCounterTTLSec"    mapstructure:"seencounterttlsec"`
-	CallbackDedupSet    string   `yaml:"callbackDedupSet"     mapstructure:"callbackdedupset"`
-	CallbackURLRegistry string   `yaml:"callbackUrlRegistry"  mapstructure:"callbackurlregistry"`
+	SeenCounterTTLSec   int    `yaml:"seenCounterTTLSec"    mapstructure:"seencounterttlsec"`
+	CallbackDedupSet    string `yaml:"callbackDedupSet"     mapstructure:"callbackdedupset"`
+	CallbackURLRegistry string `yaml:"callbackUrlRegistry"  mapstructure:"callbackurlregistry"`
 	// CallbackURLRegistryTTLSec is the per-URL eviction window applied by the
 	// Aerospike callback URL registry (and the SQL sibling). URLs whose last
 	// `Add` is older than this are evicted, bounding the registry's growth so

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -192,6 +192,14 @@ type AerospikeConfig struct {
 	Namespace           string   `yaml:"namespace"            mapstructure:"namespace"`
 	SetName             string   `yaml:"setName"              mapstructure:"setname"`
 	SeenSet             string   `yaml:"seenSet"              mapstructure:"seenset"`
+	// SeenCounterTTLSec bounds the lifetime of per-txid seen counters. The
+	// mine-time BatchDelete only removes counters for REGISTERED txids that
+	// actually get mined; counters for unregistered or never-mined txids (or
+	// txids mined while block processing was down) previously lived forever,
+	// growing the seen set without bound until the namespace hit stop-writes.
+	// The TTL is re-stamped on every increment, so it is an inactivity window:
+	// a counter expires only after ttlSec without a new subtree sighting.
+	SeenCounterTTLSec   int      `yaml:"seenCounterTTLSec"    mapstructure:"seencounterttlsec"`
 	CallbackDedupSet    string   `yaml:"callbackDedupSet"     mapstructure:"callbackdedupset"`
 	CallbackURLRegistry string   `yaml:"callbackUrlRegistry"  mapstructure:"callbackurlregistry"`
 	// CallbackURLRegistryTTLSec is the per-URL eviction window applied by the
@@ -759,6 +767,11 @@ func registerDefaults(v *viper.Viper) {
 	v.SetDefault("aerospike.namespace", "merkle")
 	v.SetDefault("aerospike.setname", "merkle_registrations")
 	v.SetDefault("aerospike.seenset", "merkle_seen_counters")
+	// 24h. Seen counters track pre-mine propagation, so anything alive this
+	// long is a txid that never made it into a block (or was mined while the
+	// service couldn't process the block). Generous relative to normal mine
+	// times; re-stamped on every increment so active txids never expire.
+	v.SetDefault("aerospike.seencounterttlsec", 24*60*60)
 	v.SetDefault("aerospike.callbackdedupset", "merkle_callback_dedup")
 	v.SetDefault("aerospike.callbackurlregistry", "merkle_callback_urls")
 	v.SetDefault("aerospike.callbackurlregistryttlsec", 7*24*60*60)
@@ -959,6 +972,7 @@ func bindEnvVars(v *viper.Viper) {
 		"aerospike.namespace":                   "AEROSPIKE_NAMESPACE",
 		"aerospike.setname":                     "AEROSPIKE_SET",
 		"aerospike.seenset":                     "AEROSPIKE_SEEN_SET",
+		"aerospike.seencounterttlsec":           "AEROSPIKE_SEEN_COUNTER_TTL_SEC",
 		"aerospike.callbackdedupset":            "AEROSPIKE_CALLBACK_DEDUP_SET",
 		"aerospike.callbackurlregistry":         "AEROSPIKE_CALLBACK_URL_REGISTRY",
 		"aerospike.callbackurlregistryttlsec":   "AEROSPIKE_CALLBACK_URL_REGISTRY_TTL_SEC",
@@ -1144,6 +1158,13 @@ func Load() (*Config, error) {
 	// becomes a permanent record that the sweeper never reclaims.
 	if cfg.Aerospike.SubtreeCounterTTLSec <= 0 {
 		return nil, fmt.Errorf("invalid aerospike.subtreeCounterTTLSec %d: must be > 0", cfg.Aerospike.SubtreeCounterTTLSec)
+	}
+
+	// SeenCounterTTLSec: same rationale — 0 would fall back to the namespace
+	// default (never-expire on a default-ttl 0 namespace), silently reviving
+	// the unbounded seen-set growth this TTL exists to prevent.
+	if cfg.Aerospike.SeenCounterTTLSec <= 0 {
+		return nil, fmt.Errorf("invalid aerospike.seenCounterTTLSec %d: must be > 0", cfg.Aerospike.SeenCounterTTLSec)
 	}
 
 	// Blob-store sweeper validation. The age floor is the safety property:

--- a/internal/store/factory.go
+++ b/internal/store/factory.go
@@ -149,6 +149,7 @@ func newAerospikeRegistry(_ context.Context, cfg *config.Config, logger *slog.Lo
 		),
 		SeenCounter: NewSeenCounterStore(
 			asClient, cfg.Aerospike.SeenSet, cfg.Callback.SeenThreshold,
+			cfg.Aerospike.SeenCounterTTLSec,
 			cfg.Aerospike.MaxRetries, cfg.Aerospike.RetryBaseMs, logger,
 		),
 		SubtreeCounter: NewSubtreeCounterStore(

--- a/internal/store/seen_counter.go
+++ b/internal/store/seen_counter.go
@@ -26,6 +26,7 @@ type aerospikeSeenCounter struct {
 	client      *AerospikeClient
 	setName     string
 	threshold   int
+	ttlSec      int
 	logger      *slog.Logger
 	maxRetries  int
 	retryBaseMs int
@@ -33,11 +34,12 @@ type aerospikeSeenCounter struct {
 
 var _ SeenCounterStore = (*aerospikeSeenCounter)(nil)
 
-func NewSeenCounterStore(client *AerospikeClient, setName string, threshold, maxRetries, retryBaseMs int, logger *slog.Logger) SeenCounterStore {
+func NewSeenCounterStore(client *AerospikeClient, setName string, threshold, ttlSec, maxRetries, retryBaseMs int, logger *slog.Logger) SeenCounterStore {
 	return &aerospikeSeenCounter{
 		client:      client,
 		setName:     setName,
 		threshold:   threshold,
+		ttlSec:      ttlSec,
 		logger:      logger,
 		maxRetries:  maxRetries,
 		retryBaseMs: retryBaseMs,
@@ -113,6 +115,11 @@ func (s *aerospikeSeenCounter) Increment(txid, subtreeID string) (*IncrementResu
 		// 0->threshold transition. New records skip the generation check via
 		// CREATE_ONLY so two concurrent first-writers also resolve cleanly.
 		wp := s.client.WritePolicy(s.maxRetries, s.retryBaseMs)
+		// Re-stamp the TTL on every write so a counter expires only after
+		// ttlSec of inactivity. Mine-time BatchDelete remains the fast path;
+		// the TTL reclaims counters for txids that never get mined (which the
+		// delete never covers) instead of letting them accumulate forever.
+		wp.Expiration = uint32(s.ttlSec) //nolint:gosec // ttlSec is config-validated and fits uint32
 		if current == nil {
 			wp.RecordExistsAction = as.CREATE_ONLY
 		} else {
@@ -224,6 +231,11 @@ func (s *aerospikeSeenCounter) BatchIncrement(txids []string, subtreeID string) 
 // concurrent observer reports ThresholdReached=true.
 func (s *aerospikeSeenCounter) batchIncrementChunk(txids []string, subtreeID string, results map[string]*IncrementResult) error {
 	listPolicy := as.NewListPolicy(as.ListOrderUnordered, as.ListWriteFlagsAddUnique|as.ListWriteFlagsNoFail)
+	// Re-stamp the TTL on every append (see Increment) so counters expire
+	// after ttlSec of inactivity instead of living forever when their txid is
+	// never mined.
+	wpol := as.NewBatchWritePolicy()
+	wpol.Expiration = uint32(s.ttlSec) //nolint:gosec // ttlSec is config-validated and fits uint32
 	batchRecs := make([]as.BatchRecordIfc, len(txids))
 	for i, txid := range txids {
 		key, err := as.NewKey(s.client.Namespace(), s.setName, txid)
@@ -234,7 +246,7 @@ func (s *aerospikeSeenCounter) batchIncrementChunk(txids []string, subtreeID str
 		// unique-subtree count on seenSubtreesBin; GetBinOp reads only the fired
 		// flag (a different bin, so its result never collides with the append's).
 		batchRecs[i] = as.NewBatchWrite(
-			nil, key,
+			wpol, key,
 			as.ListAppendWithPolicyOp(listPolicy, seenSubtreesBin, subtreeID),
 			as.GetBinOp(seenThresholdFired),
 		)

--- a/internal/store/seen_counter_integration_test.go
+++ b/internal/store/seen_counter_integration_test.go
@@ -19,7 +19,7 @@ func TestSeenCounter_BatchDelete_Aerospike(t *testing.T) {
 	setName := uniqueSet(t, "seen_del")
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	s := store.NewSeenCounterStore(client, setName, 3, 2, 10, logger)
+	s := store.NewSeenCounterStore(client, setName, 3, 86400, 2, 10, logger)
 
 	for _, txid := range []string{"tx-del-a", "tx-del-b", "tx-del-keep"} {
 		for _, st := range []string{"st1", "st2"} {

--- a/internal/store/seen_counter_test.go
+++ b/internal/store/seen_counter_test.go
@@ -20,7 +20,7 @@ func newSeenCounterTestStore(t *testing.T, threshold int) SeenCounterStore {
 	t.Cleanup(func() { client.Close() })
 
 	setName := fmt.Sprintf("test_seen_%d", os.Getpid())
-	return NewSeenCounterStore(client, setName, threshold, 2, 50, logger)
+	return NewSeenCounterStore(client, setName, threshold, 86400, 2, 50, logger)
 }
 
 func TestSeenCounter_BasicIncrement(t *testing.T) {

--- a/internal/store/sql/migrations/0009_seen_counters_ttl.sql
+++ b/internal/store/sql/migrations/0009_seen_counters_ttl.sql
@@ -1,0 +1,18 @@
+-- 0009: Bound seen-counter growth with a TTL.
+--
+-- Pre-fix: seen_counters rows only ever left the table via the mine-time
+-- BatchDelete, which covers just the REGISTERED txids of blocks the service
+-- successfully processes. Counters for unregistered txids, txids that never
+-- get mined, and txids mined during a block-processing outage lived forever,
+-- growing the table without bound (the Aerospike sibling grew until the
+-- namespace hit stop-writes and took the whole write path down).
+--
+-- Add an `expires_at` column, re-stamped on every increment so it acts as an
+-- inactivity window, and swept like the other counter tables. The column is
+-- nullable so existing rows survive the migration; each row picks up an
+-- expiry on its next increment, and rows never touched again are reclaimed
+-- by operators or left to the mine-time delete as before.
+
+ALTER TABLE seen_counters ADD COLUMN expires_at ${TIMESTAMPTZ};
+
+CREATE INDEX ${IF_NOT_EXISTS_INDEX} idx_seen_counters_expires_at ON seen_counters (expires_at);

--- a/internal/store/sql/seen_counter.go
+++ b/internal/store/sql/seen_counter.go
@@ -13,12 +13,13 @@ type seenCounter struct {
 	db        *sql.DB
 	d         *dialect
 	threshold int
+	ttlSec    int
 }
 
 var _ storepkg.SeenCounterStore = (*seenCounter)(nil)
 
-func newSeenCounter(db *sql.DB, d *dialect, threshold int) *seenCounter {
-	return &seenCounter{db: db, d: d, threshold: threshold}
+func newSeenCounter(db *sql.DB, d *dialect, threshold, ttlSec int) *seenCounter {
+	return &seenCounter{db: db, d: d, threshold: threshold, ttlSec: ttlSec}
 }
 
 func (s *seenCounter) Threshold() int { return s.threshold }
@@ -66,10 +67,15 @@ func (s *seenCounter) Increment(txid, subtreeID string) (*storepkg.IncrementResu
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// Ensure the parent counter row exists (no-op if already there).
+	// Ensure the parent counter row exists and re-stamp expires_at on every
+	// increment (an inactivity window, mirroring the Aerospike backend): the
+	// mine-time BatchDelete only covers registered txids that get mined, so
+	// without a TTL, counters for never-mined txids accumulate forever. The
+	// upsert also stamps legacy pre-0009 rows (NULL expires_at) on their next
+	// sighting.
 	qIns := fmt.Sprintf( //nolint:gosec // SQL built from internal placeholder functions, no user input
-		"INSERT INTO seen_counters (txid) VALUES (%s)%s",
-		s.d.placeholder(1), s.d.onConflictDoNothing,
+		"INSERT INTO seen_counters (txid, expires_at) VALUES (%s, %s) ON CONFLICT (txid) DO UPDATE SET expires_at = EXCLUDED.expires_at",
+		s.d.placeholder(1), s.d.intervalSeconds(s.ttlSec),
 	)
 	if _, err = tx.ExecContext(ctx, qIns, txid); err != nil {
 		return nil, fmt.Errorf("insert seen_counters: %w", err)

--- a/internal/store/sql/sql.go
+++ b/internal/store/sql/sql.go
@@ -85,7 +85,7 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger) (*storepk
 		CallbackURLRegistry: newCallbackURLRegistry(db, d, urlRetention),
 		DataHubRegistry:     newDataHubRegistry(db, d, urlRetention),
 		CallbackAccumulator: newCallbackAccumulator(db, d, cfg.Aerospike.CallbackAccumulatorTTLSec),
-		SeenCounter:         newSeenCounter(db, d, cfg.Callback.SeenThreshold),
+		SeenCounter:         newSeenCounter(db, d, cfg.Callback.SeenThreshold, cfg.Aerospike.SeenCounterTTLSec),
 		SubtreeCounter:      newSubtreeCounter(db, d, cfg.Aerospike.SubtreeCounterTTLSec),
 		ExpectedStump:       newExpectedStump(db, d, cfg.Aerospike.SubtreeCounterTTLSec),
 		Blob:                blob,

--- a/internal/store/sql/sql_test.go
+++ b/internal/store/sql/sql_test.go
@@ -531,7 +531,7 @@ func TestCallbackURLRegistry_SweeperEvicts(t *testing.T) {
 
 func TestSeenCounter_ThresholdFiresOnce(t *testing.T) {
 	db, d := newTestDB(t)
-	s := newSeenCounter(db, d, 3)
+	s := newSeenCounter(db, d, 3, 86400)
 
 	var firedCount int
 	// Increment with 5 distinct subtreeIDs.
@@ -588,7 +588,7 @@ func TestSeenCounter_ConcurrentThresholdFiresOnce(t *testing.T) {
 		threshold = 5
 		workers   = 32
 	)
-	s := newSeenCounter(db, d, threshold)
+	s := newSeenCounter(db, d, threshold, 86400)
 
 	var firedCount int64
 	var wg sync.WaitGroup
@@ -970,7 +970,7 @@ func TestSQLBackend_InterfaceSatisfaction(t *testing.T) {
 		_ storepkg.CallbackDedupStore       = newCallbackDedup(db, d)
 		_ storepkg.CallbackURLRegistry      = newCallbackURLRegistry(db, d, time.Hour)
 		_ storepkg.CallbackAccumulatorStore = newCallbackAccumulator(db, d, 60)
-		_ storepkg.SeenCounterStore         = newSeenCounter(db, d, 3)
+		_ storepkg.SeenCounterStore         = newSeenCounter(db, d, 3, 86400)
 		_ storepkg.SubtreeCounterStore      = newSubtreeCounter(db, d, 60)
 	)
 }
@@ -995,7 +995,7 @@ func TestMigrations_Idempotent(t *testing.T) {
 // threshold fire across successive batches, and idempotent re-runs.
 func TestSeenCounter_BatchIncrement(t *testing.T) {
 	db, d := newTestDB(t)
-	s := newSeenCounter(db, d, 2)
+	s := newSeenCounter(db, d, 2, 86400)
 
 	txids := []string{"tx-a", "tx-b", "tx-c"}
 
@@ -1043,7 +1043,7 @@ func TestSeenCounter_BatchIncrement(t *testing.T) {
 // per-subtree child rows, so a hypothetical later increment starts fresh.
 func TestSeenCounter_BatchDelete(t *testing.T) {
 	db, d := newTestDB(t)
-	s := newSeenCounter(db, d, 3)
+	s := newSeenCounter(db, d, 3, 86400)
 
 	for _, txid := range []string{"tx-a", "tx-b", "tx-keep"} {
 		for i := 0; i < 2; i++ {
@@ -1073,5 +1073,126 @@ func TestSeenCounter_BatchDelete(t *testing.T) {
 	}
 	if res.NewCount != 3 {
 		t.Errorf("tx-keep count = %d, want 3 (2 prior + 1 new)", res.NewCount)
+	}
+}
+
+// TestSeenCounter_IncrementRestampsTTL verifies that every Increment re-stamps
+// expires_at (inactivity-window semantics, matching the Aerospike backend) —
+// including rows created before migration 0009, whose expires_at is NULL until
+// their next sighting.
+func TestSeenCounter_IncrementRestampsTTL(t *testing.T) {
+	db, d := newTestDB(t)
+	s := newSeenCounter(db, d, 3, 86400)
+
+	if _, err := s.Increment("tx-ttl", "st1"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Backdate the row's expiry firmly into the past — the state the sweeper
+	// would see for a txid with no recent sightings.
+	if _, err := db.ExecContext(
+		context.Background(),
+		fmt.Sprintf("UPDATE seen_counters SET expires_at = %s WHERE txid = %s", d.intervalSeconds(-3600), d.placeholder(1)),
+		"tx-ttl",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := s.Increment("tx-ttl", "st2"); err != nil {
+		t.Fatal(err)
+	}
+
+	var future bool
+	if err := db.QueryRowContext(
+		context.Background(),
+		fmt.Sprintf("SELECT expires_at > %s FROM seen_counters WHERE txid = %s", d.now, d.placeholder(1)),
+		"tx-ttl",
+	).Scan(&future); err != nil {
+		t.Fatal(err)
+	}
+	if !future {
+		t.Fatal("Increment did not re-stamp expires_at into the future")
+	}
+
+	// A legacy row (NULL expires_at, as left by migration 0009) picks up an
+	// expiry on its next increment.
+	if _, err := db.ExecContext(
+		context.Background(),
+		fmt.Sprintf("UPDATE seen_counters SET expires_at = NULL WHERE txid = %s", d.placeholder(1)),
+		"tx-ttl",
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Increment("tx-ttl", "st3"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRowContext(
+		context.Background(),
+		fmt.Sprintf("SELECT expires_at IS NOT NULL FROM seen_counters WHERE txid = %s", d.placeholder(1)),
+		"tx-ttl",
+	).Scan(&future); err != nil {
+		t.Fatal(err)
+	}
+	if !future {
+		t.Fatal("Increment left a legacy NULL expires_at unstamped")
+	}
+}
+
+// TestSweeper_DeletesExpiredSeenCounters verifies the sweeper reclaims expired
+// seen counters along with their child subtree rows, leaves active counters
+// alone, and never touches legacy rows whose expires_at is still NULL.
+func TestSweeper_DeletesExpiredSeenCounters(t *testing.T) {
+	db, d := newTestDB(t)
+	s := newSeenCounter(db, d, 3, 86400)
+
+	for txid, subtree := range map[string]string{
+		"tx-expired": "st1",
+		"tx-fresh":   "st2",
+		"tx-legacy":  "st3",
+	} {
+		if _, err := s.Increment(txid, subtree); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Expire one counter and strip another back to the pre-0009 NULL state.
+	if _, err := db.ExecContext(
+		context.Background(),
+		fmt.Sprintf("UPDATE seen_counters SET expires_at = %s WHERE txid = %s", d.intervalSeconds(-3600), d.placeholder(1)),
+		"tx-expired",
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(
+		context.Background(),
+		fmt.Sprintf("UPDATE seen_counters SET expires_at = NULL WHERE txid = %s", d.placeholder(1)),
+		"tx-legacy",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	sw := newSweeper(db, d, 10*time.Millisecond, time.Hour, slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})))
+	sw.sweepOnce(context.Background())
+
+	counts := func(txid string) (parents, children int) {
+		if err := db.QueryRowContext(context.Background(),
+			fmt.Sprintf("SELECT COUNT(*) FROM seen_counters WHERE txid = %s", d.placeholder(1)), txid).Scan(&parents); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.QueryRowContext(context.Background(),
+			fmt.Sprintf("SELECT COUNT(*) FROM seen_counter_subtrees WHERE txid = %s", d.placeholder(1)), txid).Scan(&children); err != nil {
+			t.Fatal(err)
+		}
+		return parents, children
+	}
+
+	if p, c := counts("tx-expired"); p != 0 || c != 0 {
+		t.Fatalf("expired counter not fully swept: parents=%d children=%d", p, c)
+	}
+	if p, c := counts("tx-fresh"); p != 1 || c != 1 {
+		t.Fatalf("fresh counter was swept: parents=%d children=%d", p, c)
+	}
+	if p, c := counts("tx-legacy"); p != 1 || c != 1 {
+		t.Fatalf("legacy NULL-expiry counter was swept: parents=%d children=%d", p, c)
 	}
 }

--- a/internal/store/sql/sweeper.go
+++ b/internal/store/sql/sweeper.go
@@ -44,6 +44,11 @@ var ttlTables = []ttlTable{
 	},
 	{parent: "callback_dedup"},
 	{parent: "subtree_counters"},
+	{
+		parent:    "seen_counters",
+		parentKey: "txid",
+		children:  []ttlChild{{table: "seen_counter_subtrees", fk: "txid"}},
+	},
 	{parent: "expected_stumps"},
 	{
 		parent:    "callback_accumulator",

--- a/internal/store/throughput_bench_integration_test.go
+++ b/internal/store/throughput_bench_integration_test.go
@@ -65,7 +65,7 @@ func benchTxids(prefix string, n int) []string {
 func BenchmarkSeenCounter(b *testing.B) {
 	client := benchAerospikeClient(b)
 	setName := fmt.Sprintf("bench_seen_%d", time.Now().UnixNano())
-	sc := store.NewSeenCounterStore(client, setName, 1_000_000, 3, 100, slog.Default())
+	sc := store.NewSeenCounterStore(client, setName, 1_000_000, 86400, 3, 100, slog.Default())
 
 	for _, size := range []int{100, 1000, 5000} {
 		b.Run(fmt.Sprintf("serial/txids=%d", size), func(b *testing.B) {
@@ -220,7 +220,7 @@ func TestBatchIncrement_ConcurrentThresholdFiresOnce(t *testing.T) {
 		threshold = 3
 	)
 	setName := fmt.Sprintf("bench_f045_%d", time.Now().UnixNano())
-	sc := store.NewSeenCounterStore(client, setName, threshold, 3, 100, slog.Default())
+	sc := store.NewSeenCounterStore(client, setName, threshold, 86400, 3, 100, slog.Default())
 	txids := benchTxids("f045", txidCount)
 
 	type fireCount struct {
@@ -294,7 +294,7 @@ func TestBatchIncrement_CountIsListSizeAndIdempotent(t *testing.T) {
 
 	const threshold = 100 // high: keep phase 2 (threshold firing) out of the picture
 	setName := fmt.Sprintf("bench_count_%d", time.Now().UnixNano())
-	sc := store.NewSeenCounterStore(client, setName, threshold, 3, 100, slog.Default())
+	sc := store.NewSeenCounterStore(client, setName, threshold, 86400, 3, 100, slog.Default())
 	txids := benchTxids("count", 50)
 
 	assertCounts := func(stage string, results map[string]*store.IncrementResult, want int) {


### PR DESCRIPTION
## Problem

Seen counters only ever leave the store via the mine-time `BatchDelete`, which covers just the **registered** txids of blocks the service processes successfully. Counters for unregistered txids, txids that never get mined, and txids mined while block processing was down accumulate forever.

On a production deployment this grew the seen set to ~745k never-expiring records (~2.3GB of a 4GB in-memory namespace). Free write-blocks fragmented until `data_avail_pct` dropped below `stop-writes-avail-pct` and Aerospike latched **stop-writes** — at which point every write returned `SERVER_MEM_ERROR`, all write-path API requests 500'd, and the block consumer wedged in a redeliver loop (`failed to init subtree counter ... rewinding partition to redeliver`).

## Fix

Add `aerospike.seenCounterTTLSec` (default 86400 = 24h, env `AEROSPIKE_SEEN_COUNTER_TTL_SEC`), stamped on **every** increment in both backends so it acts as an inactivity window — active txids never expire, and the mine-time delete remains the fast path.

- **Aerospike**: `Expiration` set on the batch append policy (`batchIncrementChunk`) and on the CAS `Increment` write policy. Validated `> 0` at startup like `subtreeCounterTTLSec` — `0` silently means namespace-default, i.e. never-expire on a `default-ttl 0` namespace, which is exactly the failure this prevents.
- **SQL**: migration 0009 adds a nullable `expires_at` to `seen_counters` (legacy rows are stamped on their next sighting and never swept while NULL); the increment upsert re-stamps it; the sweeper reclaims expired counters together with their `seen_counter_subtrees` children.

## Tests

- `TestSeenCounter_IncrementRestampsTTL` — re-stamp on increment, including legacy NULL rows picking up an expiry.
- `TestSweeper_DeletesExpiredSeenCounters` — expired parent+children swept; fresh and legacy-NULL rows untouched.
- Existing seen-counter/sweeper suites pass unchanged; full `go test ./...` green.